### PR TITLE
Initialize repository structure and documentation

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,85 @@
+# Claude Code Configuration
+
+This directory contains configuration and skills for [Claude Code](https://claude.ai/code) to work effectively with the Aviatrix Blueprints repository.
+
+## Contents
+
+```
+.claude/
+├── README.md                   # This file
+├── settings.json               # Project-level Claude Code settings
+├── mcp-servers.example.json    # Example MCP server configuration
+└── skills/                     # Custom skills for blueprint development
+    ├── analyze-blueprint.md
+    ├── validate-blueprint.md
+    └── test-blueprint.md
+```
+
+## MCP Server Setup
+
+For the best experience developing blueprints, configure these MCP servers in your **global** Claude Code settings (`~/.claude.json` or via Claude Code settings):
+
+| Server | Purpose |
+|--------|---------|
+| **GitHub** | Access to Aviatrix provider documentation and repository management |
+| **Terraform** | Registry lookups for provider/module versions |
+| **Playwright** | Browser automation for testing against the Aviatrix Control Plane |
+| **Serena** | LSP-based code intelligence for Terraform |
+
+Copy the configuration from `mcp-servers.example.json` to your global settings.
+
+## Skills
+
+### /analyze-blueprint
+
+Analyzes a blueprint and generates:
+- Complete resource inventory
+- Prerequisites checklist
+- Cost estimates
+- Required permissions
+
+### /validate-blueprint
+
+Validates a blueprint against repository standards:
+- Terraform fmt/validate
+- README completeness
+- Naming conventions
+- Security checks
+
+### /test-blueprint
+
+Deploys and tests a blueprint end-to-end:
+- Pre-flight checks
+- Terraform apply
+- Control Plane verification (Controller and CoPilot)
+- Test scenario execution
+- Cleanup and orphan check
+
+## Usage
+
+1. Install [Claude Code](https://claude.ai/code)
+2. Configure MCP servers in your global settings (see `mcp-servers.example.json`)
+3. Open this repository in Claude Code
+4. Claude will automatically read the project's `CLAUDE.md` for context
+5. Use skills with `/analyze-blueprint`, `/validate-blueprint`, or `/test-blueprint`
+
+## Customization
+
+To add custom skills:
+1. Create a new `.md` file in the `skills/` directory
+2. Follow the format of existing skills
+3. Claude Code will automatically recognize the new skill
+
+## Environment Variables
+
+Some MCP servers require environment variables:
+
+```bash
+# GitHub MCP
+export GITHUB_TOKEN="your-github-token"
+
+# For testing (optional)
+export AVIATRIX_CONTROLLER_IP="10.0.0.1"
+export AVIATRIX_USERNAME="admin"
+export AVIATRIX_PASSWORD="your-password"
+```

--- a/.claude/mcp-servers.example.json
+++ b/.claude/mcp-servers.example.json
@@ -1,0 +1,24 @@
+{
+  "_comment": "Copy this MCP server configuration to your Claude Code settings (~/.claude/settings.json)",
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<your-github-token>"
+      }
+    },
+    "terraform": {
+      "command": "npx",
+      "args": ["-y", "@anthropics/terraform-mcp-server"]
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@anthropics/mcp-server-playwright"]
+    },
+    "serena": {
+      "command": "npx",
+      "args": ["-y", "serena-mcp-server"]
+    }
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json"
+}

--- a/.claude/skills/analyze-blueprint.md
+++ b/.claude/skills/analyze-blueprint.md
@@ -1,0 +1,117 @@
+# /analyze-blueprint
+
+Analyze a blueprint directory and generate comprehensive documentation about what it creates and requires.
+
+## Usage
+
+```
+/analyze-blueprint [blueprint-path]
+```
+
+If no path is provided, analyzes the current directory or prompts for selection.
+
+## What This Skill Does
+
+1. **Reads all Terraform files** in the blueprint directory
+2. **Extracts resources** from `resource` blocks
+3. **Identifies data sources** from `data` blocks
+4. **Parses variables** from `variables.tf`
+5. **Collects outputs** from `outputs.tf`
+6. **Checks provider requirements** from `versions.tf`
+
+## Output Generated
+
+### Resources Created Table
+
+| Resource Type | Resource Name | Description | Cloud |
+|---------------|---------------|-------------|-------|
+| aws_vpc | main | Primary VPC for workloads | AWS |
+| aviatrix_spoke_gateway | spoke | Spoke gateway attached to transit | Aviatrix |
+
+### Prerequisites Checklist
+
+- [ ] Aviatrix Control Plane v8.1+ accessible (Controller and CoPilot)
+- [ ] AWS CLI configured with appropriate permissions
+- [ ] Terraform v1.5+ installed
+- [ ] Sufficient EIP quota (X required)
+
+### Required IAM Permissions
+
+Lists the AWS/Azure/GCP permissions needed based on resources created.
+
+### Estimated Costs
+
+Provides hourly and monthly cost estimates for the resources.
+
+### Variable Reference
+
+Complete table of all input variables with types, defaults, and whether required.
+
+### Output Reference
+
+Complete table of all outputs with descriptions.
+
+## Instructions for Claude
+
+When this skill is invoked:
+
+1. Read all `.tf` files in the specified blueprint directory
+2. Parse each file to extract:
+   - `resource` blocks → Resources Created
+   - `data` blocks → Data sources (may indicate prerequisites)
+   - `variable` blocks → Variables Reference
+   - `output` blocks → Output Reference
+   - `terraform.required_providers` → Provider versions
+3. For each resource, determine:
+   - Cloud provider (AWS, Azure, GCP, Aviatrix)
+   - Approximate cost (use known pricing or estimate)
+   - Required permissions
+4. Generate a comprehensive markdown report
+5. Optionally update the blueprint's README.md with the generated content
+
+## Example
+
+```
+> /analyze-blueprint blueprints/dcf-eks
+
+Analyzing blueprint: dcf-eks
+
+## Resources Created (14 total)
+
+| Resource | Name | Description | Count |
+|----------|------|-------------|-------|
+| aws_vpc | transit | Transit VPC | 1 |
+| aws_vpc | spoke | Spoke VPCs for workloads | 2 |
+| aws_subnet | public | Public subnets | 6 |
+| aviatrix_transit_gateway | main | Primary transit gateway | 1 |
+| aviatrix_spoke_gateway | spoke | Spoke gateways | 2 |
+| aws_eks_cluster | main | EKS cluster | 1 |
+...
+
+## Prerequisites
+
+### Required Tools
+- Terraform >= 1.5.0
+- AWS CLI v2
+- kubectl
+- Aviatrix Control Plane v8.1+ (Controller and CoPilot)
+
+### Required Access
+- AWS account with VPC, EC2, EKS permissions
+- Aviatrix account onboarded to the Control Plane
+
+### Resource Quotas
+- 3 Elastic IPs
+- 1 EKS cluster
+- 3 VPCs
+
+## Estimated Cost
+
+| Resource | Hourly | Monthly |
+|----------|--------|---------|
+| Aviatrix Transit Gateway | $0.50 | $365 |
+| Aviatrix Spoke Gateways (2) | $1.00 | $730 |
+| EKS Cluster | $0.10 | $73 |
+| NAT Gateways (3) | $0.135 | $98 |
+| **Total** | **$1.735** | **~$1,266** |
+```

--- a/.claude/skills/test-blueprint.md
+++ b/.claude/skills/test-blueprint.md
@@ -1,0 +1,252 @@
+# /test-blueprint
+
+Deploy a blueprint to a real environment, verify it works, run test scenarios, and clean up.
+
+## Usage
+
+```
+/test-blueprint [blueprint-path] [--keep] [--screenshots]
+```
+
+Options:
+- `--keep`: Don't destroy resources after testing (for manual inspection)
+- `--screenshots`: Capture screenshots of the Aviatrix Control Plane for documentation
+
+## Prerequisites
+
+This skill requires:
+- **Playwright MCP server** configured and running
+- **Valid terraform.tfvars** with real credentials
+- **Aviatrix Control Plane** (Controller and CoPilot) accessible from the test environment
+- **Cloud provider credentials** configured
+
+## What This Skill Does
+
+1. **Pre-flight checks** - Validates configuration before deployment
+2. **Deploy** - Runs `terraform apply`
+3. **Verify in Controller** - Uses Playwright to check resources in UI
+4. **Run test scenarios** - Executes tests defined in README
+5. **Capture evidence** - Screenshots for documentation
+6. **Cleanup** - Runs `terraform destroy`
+7. **Verify cleanup** - Confirms no orphaned resources
+
+## Test Workflow
+
+### Phase 1: Pre-flight
+
+```
+Checking prerequisites...
+✅ terraform.tfvars exists
+✅ Controller reachable at 10.0.0.1
+✅ AWS credentials valid
+✅ Required quotas available
+```
+
+### Phase 2: Deploy
+
+```
+Deploying blueprint...
+terraform init... done
+terraform plan... 23 resources to create
+terraform apply...
+
+Creating resources:
+  aws_vpc.transit... created
+  aws_vpc.spoke_1... created
+  aviatrix_transit_gateway.main... created (3m 45s)
+  aviatrix_spoke_gateway.spoke_1... created (2m 30s)
+  ...
+
+✅ Deployment complete (8m 23s)
+```
+
+### Phase 3: Verify in Control Plane
+
+Uses Playwright to:
+1. Log into the Aviatrix Control Plane
+2. Navigate to Cloud Fabric > Gateways
+3. Verify transit gateway appears and is UP
+4. Verify spoke gateways appear and are UP
+5. Check attachments are established
+6. Navigate to CoPilot topology (if applicable)
+7. Verify architecture matches diagram
+
+```
+Verifying in Control Plane...
+✅ Transit gateway 'dcf-eks-transit' status: UP
+✅ Spoke gateway 'dcf-eks-spoke-1' status: UP
+✅ Spoke gateway 'dcf-eks-spoke-2' status: UP
+✅ Transit-spoke attachment verified
+✅ CoPilot topology shows correct architecture
+```
+
+### Phase 4: Run Test Scenarios
+
+Executes test scenarios from the blueprint README:
+
+```
+Running test scenarios...
+
+Scenario 1: East-West Connectivity
+  → SSH to spoke-1 test instance
+  → Ping spoke-2 private IP
+  ✅ Ping successful (latency: 2.3ms)
+
+Scenario 2: DCF Inspection
+  → Generate traffic between spokes
+  → Check CoPilot > Security > DCF Monitor
+  ✅ Traffic appears in DCF logs
+  ✅ Correct policy applied
+
+Scenario 3: Internet Egress
+  → SSH to spoke instance
+  → curl https://api.ipify.org
+  ✅ Egress through NAT gateway confirmed
+```
+
+### Phase 5: Capture Evidence
+
+If `--screenshots` is enabled:
+
+```
+Capturing screenshots...
+📸 controller-topology.png
+📸 copilot-flowiq.png
+📸 dcf-monitor.png
+📸 gateway-status.png
+```
+
+### Phase 6: Cleanup
+
+```
+Destroying resources...
+terraform destroy...
+
+Destroying resources:
+  aviatrix_spoke_gateway.spoke_2... destroyed
+  aviatrix_spoke_gateway.spoke_1... destroyed
+  aviatrix_transit_gateway.main... destroyed
+  aws_vpc.spoke_1... destroyed
+  ...
+
+✅ Destroy complete (5m 12s)
+```
+
+### Phase 7: Verify Cleanup
+
+```
+Verifying cleanup...
+✅ No VPCs with blueprint tag found
+✅ No gateways in Control Plane
+✅ No orphaned EIPs
+✅ Cleanup verified
+```
+
+## Instructions for Claude
+
+When this skill is invoked:
+
+### 1. Pre-flight Checks
+
+```bash
+# Verify tfvars exists
+test -f terraform.tfvars
+
+# Test Controller connectivity
+curl -k https://${CONTROLLER_IP}/v1/api
+
+# Verify cloud credentials
+aws sts get-caller-identity
+```
+
+### 2. Deploy
+
+```bash
+terraform init
+terraform plan -out=tfplan
+terraform apply tfplan
+```
+
+Monitor for errors and capture output.
+
+### 3. Verify with Playwright
+
+Use Playwright MCP to:
+- Open browser to Controller URL
+- Log in with provided credentials
+- Navigate to relevant pages
+- Verify resources exist and are healthy
+- Take screenshots if requested
+
+### 4. Run Test Scenarios
+
+Parse the README's "Test Scenarios" section and execute each one:
+- SSH commands via Bash
+- UI verifications via Playwright
+- API calls via curl
+
+### 5. Cleanup
+
+```bash
+terraform destroy -auto-approve
+```
+
+### 6. Verify Cleanup
+
+Check for orphaned resources:
+```bash
+# AWS example
+aws ec2 describe-vpcs --filters "Name=tag:Blueprint,Values=<name>"
+```
+
+Use Playwright to verify nothing remains in the Control Plane.
+
+## Output Format
+
+```
+=== Blueprint Test Report ===
+
+Blueprint: dcf-eks
+Date: 2024-01-15 14:32:00 UTC
+Duration: 18m 45s
+
+## Summary
+✅ Deployment: SUCCESS
+✅ Verification: SUCCESS
+✅ Test Scenarios: 3/3 PASSED
+✅ Cleanup: SUCCESS
+
+## Deployment Details
+- Resources created: 23
+- Deployment time: 8m 23s
+- No errors
+
+## Test Results
+
+| Scenario | Result | Duration |
+|----------|--------|----------|
+| East-West Connectivity | ✅ PASS | 45s |
+| DCF Inspection | ✅ PASS | 1m 20s |
+| Internet Egress | ✅ PASS | 30s |
+
+## Screenshots
+- controller-topology.png
+- dcf-monitor.png
+
+## Cleanup Details
+- Resources destroyed: 23
+- Destroy time: 5m 12s
+- Orphan check: CLEAN
+
+---
+Blueprint dcf-eks is **VERIFIED** ✅
+```
+
+## Error Handling
+
+If any phase fails:
+
+1. **Deployment fails**: Capture error, attempt cleanup, report failure
+2. **Verification fails**: Continue with tests, note discrepancy
+3. **Test fails**: Log failure, continue other tests, include in report
+4. **Cleanup fails**: Report orphaned resources, provide manual cleanup steps

--- a/.claude/skills/validate-blueprint.md
+++ b/.claude/skills/validate-blueprint.md
@@ -1,0 +1,170 @@
+# /validate-blueprint
+
+Run comprehensive validation checks on a blueprint to ensure it meets repository standards.
+
+## Usage
+
+```
+/validate-blueprint [blueprint-path]
+```
+
+If no path is provided, validates the current directory or prompts for selection.
+
+## What This Skill Does
+
+1. **Terraform validation** - fmt, init, validate
+2. **README completeness** - Checks for all required sections
+3. **Standards compliance** - Verifies naming conventions and patterns
+4. **Link verification** - Ensures all links in README are valid
+5. **Security checks** - Looks for hardcoded credentials or sensitive data
+
+## Validation Checks
+
+### Terraform Checks
+
+- [ ] `terraform fmt -check` passes
+- [ ] `terraform init -backend=false` succeeds
+- [ ] `terraform validate` passes
+- [ ] All variables have descriptions
+- [ ] All outputs have descriptions
+- [ ] Provider versions are pinned
+
+### Required Files
+
+- [ ] `README.md` exists
+- [ ] `main.tf` exists
+- [ ] `variables.tf` exists
+- [ ] `outputs.tf` exists
+- [ ] `versions.tf` exists
+- [ ] `terraform.tfvars.example` exists
+- [ ] Architecture diagram exists (`.png` or `.svg`)
+
+### README Sections
+
+Per `docs/blueprint-standards.md`, README must include:
+
+- [ ] Title and description
+- [ ] Architecture diagram with explanation
+- [ ] Prerequisites (linking to shared docs)
+- [ ] Resources Created table
+- [ ] Deployment instructions (step-by-step)
+- [ ] Variables reference table
+- [ ] Outputs reference table
+- [ ] Test scenarios
+- [ ] Cleanup/destroy instructions
+- [ ] Troubleshooting section
+- [ ] Version compatibility matrix
+
+### Naming Conventions
+
+- [ ] Blueprint directory is lowercase with hyphens
+- [ ] Resources use `var.name_prefix` or `local.name_prefix`
+- [ ] No hardcoded resource names
+
+### Security Checks
+
+- [ ] No hardcoded credentials
+- [ ] Sensitive variables marked `sensitive = true`
+- [ ] No AWS account IDs hardcoded
+- [ ] No IP addresses hardcoded (except examples in docs)
+- [ ] `.gitignore` includes `*.tfstate*` and `*.tfvars`
+
+### Link Verification
+
+- [ ] All relative links in README resolve
+- [ ] Links to shared prerequisites docs are valid
+- [ ] External links are accessible
+
+## Instructions for Claude
+
+When this skill is invoked:
+
+1. **Run Terraform checks**:
+   ```bash
+   cd <blueprint-path>
+   terraform fmt -check
+   terraform init -backend=false
+   terraform validate
+   ```
+
+2. **Check file existence**:
+   - Verify all required files exist
+   - Check for architecture diagram
+
+3. **Parse README.md**:
+   - Look for required section headers
+   - Verify tables are properly formatted
+   - Check for placeholder text that wasn't replaced
+
+4. **Analyze Terraform files**:
+   - Ensure variables have descriptions
+   - Ensure outputs have descriptions
+   - Check for hardcoded values
+   - Verify naming conventions
+
+5. **Verify links**:
+   - Check relative links resolve to existing files
+   - Optionally check external links
+
+6. **Generate report**:
+   - Show pass/fail for each check
+   - Provide specific feedback for failures
+   - Calculate overall compliance score
+
+## Output Format
+
+```
+Validating blueprint: dcf-eks
+
+## Terraform Validation
+✅ terraform fmt -check passed
+✅ terraform init succeeded
+✅ terraform validate passed
+✅ All 12 variables have descriptions
+✅ All 8 outputs have descriptions
+✅ Provider versions pinned
+
+## Required Files
+✅ README.md
+✅ main.tf
+✅ variables.tf
+✅ outputs.tf
+✅ versions.tf
+✅ terraform.tfvars.example
+✅ architecture.png
+
+## README Completeness
+✅ Title and description
+✅ Architecture diagram
+✅ Prerequisites section
+⚠️ Resources Created table - missing 2 resources
+✅ Deployment instructions
+✅ Variables reference
+✅ Outputs reference
+⚠️ Test scenarios - only 1 scenario (recommend 2+)
+✅ Cleanup instructions
+❌ Troubleshooting section - MISSING
+✅ Version compatibility
+
+## Standards Compliance
+✅ Directory naming (dcf-eks)
+✅ Resource naming uses name_prefix
+✅ No hardcoded credentials detected
+⚠️ AWS region hardcoded in data source (line 45)
+
+## Link Verification
+✅ 8/8 internal links valid
+✅ 3/3 external links accessible
+
+---
+
+**Overall Score: 87%** (26/30 checks passed)
+
+### Required Fixes:
+1. Add Troubleshooting section to README
+2. Update Resources Created table (missing aws_nat_gateway, aws_eip)
+
+### Recommendations:
+1. Add more test scenarios
+2. Remove hardcoded region on line 45
+```

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,67 @@
+---
+name: Bug Report
+about: Report a bug in a blueprint
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Blueprint
+
+<!-- Which blueprint is affected? -->
+
+**Blueprint name**: blueprints/
+
+## Describe the Bug
+
+<!-- A clear and concise description of what the bug is -->
+
+## Steps to Reproduce
+
+1. Configure terraform.tfvars with:
+   ```hcl
+   # relevant configuration
+   ```
+2. Run `terraform apply`
+3. See error
+
+## Expected Behavior
+
+<!-- What you expected to happen -->
+
+## Actual Behavior
+
+<!-- What actually happened -->
+
+## Error Output
+
+<!-- Paste relevant error messages -->
+
+```
+terraform output here
+```
+
+## Environment
+
+- **Controller Version**:
+- **Terraform Version**:
+- **Provider Versions**:
+  - aviatrix:
+  - aws/azure/gcp:
+- **Operating System**:
+
+## Configuration
+
+<!-- Relevant (sanitized) configuration. Remove any sensitive values! -->
+
+```hcl
+# terraform.tfvars (sanitized)
+```
+
+## Screenshots
+
+<!-- If applicable, add screenshots to help explain your problem -->
+
+## Additional Context
+
+<!-- Add any other context about the problem here -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,39 @@
+---
+name: Feature Request
+about: Suggest an enhancement to an existing blueprint
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Blueprint
+
+<!-- Which blueprint should be enhanced? Leave blank if this is a general request -->
+
+**Blueprint name**: blueprints/
+
+## Feature Description
+
+<!-- A clear and concise description of what you want to happen -->
+
+## Use Case
+
+<!-- Explain why this feature would be useful -->
+
+## Proposed Solution
+
+<!-- If you have ideas on how to implement this, describe them here -->
+
+## Alternatives Considered
+
+<!-- Have you considered any alternative solutions or workarounds? -->
+
+## Additional Context
+
+<!-- Add any other context, screenshots, or examples about the feature request here -->
+
+## Would you be willing to contribute this feature?
+
+- [ ] Yes, I'd like to implement this feature
+- [ ] I could help with testing
+- [ ] I can only provide requirements/feedback

--- a/.github/ISSUE_TEMPLATE/new_blueprint_request.md
+++ b/.github/ISSUE_TEMPLATE/new_blueprint_request.md
@@ -1,0 +1,69 @@
+---
+name: New Blueprint Request
+about: Suggest a new blueprint to be created
+title: '[NEW BLUEPRINT] '
+labels: new-blueprint
+assignees: ''
+---
+
+## Blueprint Overview
+
+**Proposed name**:
+
+**Target cloud(s)**:
+- [ ] AWS
+- [ ] Azure
+- [ ] GCP
+- [ ] Multi-cloud
+
+## Description
+
+<!-- Describe what this blueprint should deploy and demonstrate -->
+
+## Use Case
+
+<!-- What problem does this blueprint solve? Who would use it? -->
+
+## Key Aviatrix Features
+
+<!-- Which Aviatrix features should this blueprint demonstrate? -->
+
+- [ ] Transit Gateway
+- [ ] Spoke Gateway
+- [ ] Distributed Cloud Firewall (DCF)
+- [ ] Network Segmentation
+- [ ] Site-to-Cloud (S2C)
+- [ ] User VPN
+- [ ] Network Performance Monitoring
+- [ ] CoPilot Integration
+- [ ] Other:
+
+## Architecture Overview
+
+<!-- Describe the high-level architecture. A rough diagram or bullet points is fine -->
+
+## Prerequisites
+
+<!-- What would users need to have before deploying this blueprint? -->
+
+- Aviatrix Control Plane version:
+- Cloud accounts:
+- Other requirements:
+
+## Similar Resources
+
+<!-- Are there any existing blueprints, tutorials, or documentation that are similar? -->
+
+## Priority / Business Need
+
+<!-- Why is this blueprint important? Is there customer demand? -->
+
+## Would you be willing to contribute this blueprint?
+
+- [ ] Yes, I'd like to create this blueprint
+- [ ] I could help with documentation/testing
+- [ ] I can only provide requirements/feedback
+
+## Additional Context
+
+<!-- Any other information that would help in creating this blueprint -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,70 @@
+## Description
+
+<!-- Provide a brief description of the changes in this PR -->
+
+## Type of Change
+
+<!-- Mark the relevant option with an 'x' -->
+
+- [ ] New blueprint
+- [ ] Blueprint enhancement
+- [ ] Bug fix
+- [ ] Documentation update
+- [ ] CI/CD improvement
+- [ ] Other (describe):
+
+## Blueprint Checklist (for new or modified blueprints)
+
+<!-- Complete this checklist for blueprint changes -->
+
+### Documentation
+- [ ] README.md includes all required sections (see [Blueprint Standards](docs/blueprint-standards.md))
+- [ ] Architecture diagram is included and accurate
+- [ ] All variables are documented with descriptions
+- [ ] terraform.tfvars.example includes all required variables
+- [ ] Test scenarios are documented
+- [ ] Troubleshooting section covers common issues
+
+### Code Quality
+- [ ] `terraform fmt` passes
+- [ ] `terraform validate` passes
+- [ ] No hardcoded values (use variables)
+- [ ] Sensitive variables marked as `sensitive = true`
+- [ ] Resource naming uses `var.name_prefix`
+
+### Testing
+- [ ] Full deploy/destroy cycle tested
+- [ ] All test scenarios verified
+- [ ] Tested on documented Control Plane version(s)
+- [ ] Cleanup leaves no orphaned resources
+
+### Catalog Update
+- [ ] Blueprint added to catalog in root README.md (for new blueprints)
+
+## Control Plane Version Tested
+
+<!-- List the Aviatrix Control Plane version(s) tested against -->
+
+- Control Plane version:
+
+## Cloud Environment
+
+<!-- List the cloud provider(s) and any specific configurations -->
+
+- Cloud provider(s):
+- Region(s) tested:
+
+## Screenshots / Architecture
+
+<!-- Include screenshots or architecture diagrams if applicable -->
+
+## Additional Notes
+
+<!-- Any additional information reviewers should know -->
+
+---
+
+**By submitting this PR, I confirm that:**
+- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
+- [ ] This PR does not include sensitive information (credentials, keys, etc.)
+- [ ] I am willing to respond to review feedback

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,131 @@
+name: Validate Terraform
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'blueprints/**/*.tf'
+      - '.github/workflows/validate.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'blueprints/**/*.tf'
+      - '.github/workflows/validate.yml'
+
+jobs:
+  detect-changes:
+    name: Detect Changed Blueprints
+    runs-on: ubuntu-latest
+    outputs:
+      blueprints: ${{ steps.changes.outputs.blueprints }}
+      has_changes: ${{ steps.changes.outputs.has_changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed blueprints
+        id: changes
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            BASE_SHA=${{ github.event.pull_request.base.sha }}
+            HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          else
+            BASE_SHA=${{ github.event.before }}
+            HEAD_SHA=${{ github.sha }}
+          fi
+
+          # Get list of changed blueprint directories
+          CHANGED_DIRS=$(git diff --name-only $BASE_SHA $HEAD_SHA | \
+            grep '^blueprints/' | \
+            grep -v '^blueprints/_template/' | \
+            cut -d'/' -f1-2 | \
+            sort -u | \
+            jq -R -s -c 'split("\n") | map(select(length > 0))')
+
+          echo "Changed directories: $CHANGED_DIRS"
+          echo "blueprints=$CHANGED_DIRS" >> $GITHUB_OUTPUT
+
+          if [ "$CHANGED_DIRS" != "[]" ] && [ "$CHANGED_DIRS" != "" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+  terraform-fmt:
+    name: Terraform Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.0"
+
+      - name: Terraform Format Check
+        run: terraform fmt -check -recursive blueprints/
+
+  terraform-validate:
+    name: Terraform Validate
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        blueprint: ${{ fromJson(needs.detect-changes.outputs.blueprints) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.0"
+
+      - name: Terraform Init
+        working-directory: ${{ matrix.blueprint }}
+        run: terraform init -backend=false
+
+      - name: Terraform Validate
+        working-directory: ${{ matrix.blueprint }}
+        run: terraform validate
+
+  template-validate:
+    name: Validate Template
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.0"
+
+      - name: Terraform Init (Template)
+        working-directory: blueprints/_template
+        run: terraform init -backend=false
+
+      - name: Terraform Validate (Template)
+        working-directory: blueprints/_template
+        run: terraform validate
+
+  summary:
+    name: Validation Summary
+    runs-on: ubuntu-latest
+    needs: [terraform-fmt, terraform-validate, template-validate]
+    if: always()
+    steps:
+      - name: Check results
+        run: |
+          if [ "${{ needs.terraform-fmt.result }}" == "failure" ] || \
+             [ "${{ needs.terraform-validate.result }}" == "failure" ] || \
+             [ "${{ needs.template-validate.result }}" == "failure" ]; then
+            echo "One or more validation checks failed"
+            exit 1
+          fi
+          echo "All validation checks passed!"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# Terraform
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example
+.terraform/
+.terraform.lock.hcl
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc
+
+# Claude Code local settings
+.claude/settings.local.json
+.claude/*.local.json
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Temporary files
+*.tmp
+*.temp
+
+# Credentials (should never be committed)
+*.pem
+*.key
+credentials.json
+service-account*.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,201 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code when working with the Aviatrix Blueprints repository.
+
+## Repository Overview
+
+This repository contains production-ready Terraform lab environments ("blueprints") for learning, demonstrating, and testing Aviatrix cloud networking solutions. Each blueprint is a self-contained, deployable environment.
+
+## Project Structure
+
+```
+aviatrix-blueprints/
+├── blueprints/           # Deployable lab environments
+│   ├── _template/        # Template for new blueprints (copy this)
+│   └── <name>/           # Individual blueprints
+├── docs/                 # Documentation and guides
+│   └── prerequisites/    # Tool installation guides
+├── modules/              # Shared Terraform modules (future)
+└── .github/              # CI/CD and templates
+```
+
+## Key Standards
+
+### Blueprint Requirements
+
+Every blueprint MUST include:
+1. `README.md` with ALL sections from `docs/blueprint-standards.md`
+2. Architecture diagram (`architecture.png` or `.svg`)
+3. `terraform.tfvars.example` with documented variables
+4. `versions.tf` with pinned provider versions
+5. Complete "Resources Created" table
+6. Test scenarios for validation
+7. Cleanup/destroy instructions
+
+### Terraform Patterns
+
+- Use `var.name_prefix` for all resource naming
+- Never hardcode regions, account IDs, or credentials
+- Mark sensitive variables with `sensitive = true`
+- Use `locals` for computed values and common tags
+- Always include default tags for resource tracking
+
+### Provider Versions
+
+Always use the Aviatrix Terraform provider:
+- Registry: `AviatrixSystems/aviatrix`
+- Documentation: https://registry.terraform.io/providers/AviatrixSystems/aviatrix/latest/docs
+- GitHub: https://github.com/AviatrixSystems/terraform-provider-aviatrix
+
+### Naming Conventions
+
+- Blueprint directories: lowercase with hyphens (`dcf-eks`, `transit-aws`)
+- Pattern: `<feature>-<platform>` or `<use-case>-<cloud>`
+- Resources: `${var.name_prefix}-<resource-type>`
+
+## Common Tasks
+
+### Creating a New Blueprint
+
+1. Copy the template: `cp -r blueprints/_template blueprints/<new-name>`
+2. Update all files, replacing template placeholders
+3. Create architecture diagram
+4. Test full deploy/destroy cycle
+5. Update blueprint catalog in root `README.md`
+
+### Analyzing a Blueprint
+
+When asked to analyze a blueprint, provide:
+1. **Resources Created**: Complete table of all cloud resources
+2. **Prerequisites**: All required tools, access, and quotas
+3. **Cost Estimate**: Approximate hourly/monthly cost
+4. **Dependencies**: External services or configurations needed
+5. **Security Considerations**: IAM roles, security groups, exposed endpoints
+
+### Validating a Blueprint
+
+Run these checks:
+```bash
+cd blueprints/<name>
+terraform fmt -check
+terraform init -backend=false
+terraform validate
+```
+
+### Testing with Playwright
+
+When Playwright MCP is available, Claude can:
+1. Deploy the blueprint to a test environment
+2. Navigate to the Aviatrix Control Plane (Controller for API validation, CoPilot for UI verification)
+3. Verify resources appear correctly
+4. Run connectivity tests
+5. Capture screenshots for documentation
+6. Clean up resources
+
+## MCP Server Integration
+
+### GitHub MCP
+
+Use for:
+- Looking up Aviatrix provider resource documentation
+- Checking module versions and examples
+- Creating issues and PRs
+
+Key repositories:
+- `AviatrixSystems/terraform-provider-aviatrix` - Provider source
+- `AviatrixSystems/terraform-aviatrix-aws-transit` - Transit module
+- `AviatrixSystems/terraform-aviatrix-mc-spoke` - Multi-cloud spoke module
+
+### Terraform MCP
+
+Use for:
+- Looking up latest provider versions
+- Getting resource documentation
+- Finding module examples
+
+### Playwright MCP
+
+Use for:
+- Automated deployment testing
+- Control Plane UI verification (CoPilot for visualization, Controller for configuration)
+- Screenshot capture for documentation
+- End-to-end validation
+
+### Serena MCP
+
+Use for:
+- Semantic code analysis
+- Cross-file refactoring
+- Symbol lookups and references
+
+## Skills (Future)
+
+The following skills will be available for blueprint development:
+
+### /analyze-blueprint
+Analyze a blueprint directory and generate:
+- Complete resources created table
+- Prerequisites checklist
+- Cost estimate
+- Dependency graph
+
+### /validate-blueprint
+Run comprehensive validation:
+- Terraform fmt/validate
+- README completeness check
+- Standards compliance
+- Link verification
+
+### /test-blueprint
+Deploy and test a blueprint:
+- Initialize and apply
+- Verify in the Aviatrix Control Plane (Controller and CoPilot)
+- Run test scenarios
+- Capture evidence
+- Destroy and verify cleanup
+
+## Important Notes
+
+- Blueprints use LOCAL STATE only - never add remote backend configuration
+- Always test destroy before considering a blueprint complete
+- Include troubleshooting for common failure scenarios
+- Link prerequisites to shared docs in `docs/prerequisites/`
+- Version format: `v<MAJOR>.<MINOR>.<PATCH>+avx<CONTROLLER_VERSION>`
+
+## Aviatrix-Specific Knowledge
+
+### Cloud Type Codes
+
+When using the Aviatrix provider, cloud types are:
+- `1` = AWS
+- `2` = GCP
+- `4` = Azure
+- `8` = OCI
+- `256` = AWS GovCloud
+- `512` = Azure Gov
+- `1024` = AWS China
+- `2048` = Azure China
+
+### Common Resource Types
+
+- `aviatrix_transit_gateway` - Transit hub gateway
+- `aviatrix_spoke_gateway` - Spoke gateway attached to transit
+- `aviatrix_transit_gateway_peering` - Transit-to-transit peering
+- `aviatrix_distributed_firewalling_config` - DCF configuration
+- `aviatrix_smart_group` - Smart groups for segmentation
+- `aviatrix_web_group` - Web groups for URL filtering
+- `aviatrix_distributed_firewalling_policy_list` - DCF policies
+
+### Aviatrix Control Plane
+
+The Aviatrix Control Plane consists of:
+- **Controller** - Management plane for Terraform and API operations
+- **CoPilot** - GUI for visualization, monitoring, and day-2 operations
+
+Alternatively, users may have an **Aviatrix Cloud Fabric** subscription (fully managed control plane).
+
+Most blueprints should include CoPilot verification steps:
+- Topology view showing deployed architecture
+- FlowIQ for traffic analysis
+- Security > DCF for firewall rules (if applicable)
+- Performance > Diagnostics for connectivity tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,9 +228,51 @@ terraform {
 
 Users deploying for longer-term use can add their own backend configuration.
 
-## Pull Request Process
+## Branching and Pull Request Workflow
 
-### 1. Before Submitting
+The `main` branch is protected. All changes must be submitted via pull request.
+
+### Branch Naming
+
+Use descriptive branch names with a prefix:
+
+| Prefix | Use Case | Example |
+|--------|----------|---------|
+| `feature/` | New blueprints or features | `feature/dcf-eks-blueprint` |
+| `fix/` | Bug fixes | `fix/transit-aws-timeout` |
+| `docs/` | Documentation updates | `docs/improve-prerequisites` |
+| `chore/` | Maintenance tasks | `chore/update-provider-versions` |
+
+### Workflow
+
+```bash
+# 1. Clone the repository (first time only)
+git clone https://github.com/AviatrixSystems/aviatrix-blueprints.git
+cd aviatrix-blueprints
+
+# 2. Create a feature branch from main
+git checkout main
+git pull origin main
+git checkout -b feature/your-blueprint-name
+
+# 3. Make your changes
+cp -r blueprints/_template blueprints/your-blueprint-name
+# ... develop and test ...
+
+# 4. Commit your changes
+git add .
+git commit -m "Add your-blueprint-name blueprint"
+
+# 5. Push your branch
+git push -u origin feature/your-blueprint-name
+
+# 6. Create a Pull Request on GitHub
+# Visit: https://github.com/AviatrixSystems/aviatrix-blueprints/pulls
+```
+
+### Pull Request Requirements
+
+#### Before Submitting
 
 - [ ] Run `terraform fmt -recursive` on your blueprint
 - [ ] Run `terraform validate` successfully
@@ -238,25 +280,30 @@ Users deploying for longer-term use can add their own backend configuration.
 - [ ] Verify all links in README work
 - [ ] Update the blueprint catalog in root README.md
 
-### 2. PR Requirements
+#### PR Description Must Include
 
-Your PR must include:
 - Clear description of what the blueprint does
 - Screenshots or diagram of the deployed architecture
 - Confirmation that you've tested deploy and destroy
 - List of any prerequisites beyond standard requirements
 
-### 3. Review Process
+### Review Process
 
 1. **Automated checks**: CI runs `terraform fmt` and `terraform validate`
 2. **Maintainer review**: Code and documentation review
-3. **SE validation** (required for merging all PRs): Full deployment test by Aviatrix SE
+3. **Approval required**: At least 1 approving review from a team member with write access
+4. **SE validation** (required for merging): Full deployment test by Aviatrix SE
 
-### 4. After Merge
+### Merging
+
+Once approved, PRs are merged using **squash merge** to keep the main branch history clean. The PR title becomes the commit message.
+
+### After Merge
 
 - Blueprint appears in catalog as "Community" tier
 - Aviatrix team may promote to "Verified" after QA validation
 - Version tags are created for releases
+- Delete your feature branch (GitHub offers this option after merge)
 
 ## Improving Existing Blueprints
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,294 @@
+# Contributing to Aviatrix Blueprints
+
+Thank you for your interest in contributing to Aviatrix Blueprints! This document provides guidelines and standards for contributions.
+
+## Code of Conduct
+
+Please be respectful and constructive in all interactions. We're building a community resource for cloud networking professionals.
+
+## Recommended Development Environment
+
+We strongly recommend using **[Claude Code](https://claude.ai/code)** for blueprint development. Claude Code understands Terraform, Aviatrix patterns, and can help ensure your blueprints meet repository standards.
+
+### Required MCP Servers
+
+Configure Claude Code with the following MCP servers for the best development experience:
+
+| MCP Server | Purpose | Configuration |
+|------------|---------|---------------|
+| **GitHub** | Access to Aviatrix Terraform provider docs, modules, and repository management | Point to [AviatrixSystems/terraform-provider-aviatrix](https://github.com/AviatrixSystems/terraform-provider-aviatrix) |
+| **Terraform** | Registry lookups for provider/module versions and documentation | Default configuration |
+| **Playwright** | Automated browser testing for validating deployments against a real Aviatrix Control Plane | Required for self-testing blueprints |
+| **Serena** | LSP-based code intelligence for semantic understanding of Terraform configurations | Enables accurate refactoring and analysis |
+
+### Why Use Claude Code?
+
+- **Standards Compliance**: Claude Code reads the repository's `CLAUDE.md` and automatically follows blueprint standards
+- **Self-Testing**: With Playwright MCP, Claude can deploy blueprints and verify they work against a real Aviatrix environment
+- **Accurate Documentation**: Automatically generates comprehensive resource lists and prerequisites
+- **Provider Awareness**: Direct access to Aviatrix Terraform provider documentation ensures correct resource usage
+
+### Setting Up Claude Code
+
+1. Install [Claude Code CLI](https://claude.ai/code)
+2. Configure MCP servers in your global Claude Code settings (`~/.claude.json`):
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<your-token>"
+      }
+    },
+    "terraform": {
+      "command": "npx",
+      "args": ["-y", "@anthropics/terraform-mcp-server"]
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@anthropics/mcp-server-playwright"]
+    },
+    "serena": {
+      "command": "npx",
+      "args": ["-y", "serena-mcp-server"]
+    }
+  }
+}
+```
+
+   See [.claude/mcp-servers.example.json](.claude/mcp-servers.example.json) for a copy-paste ready configuration.
+
+3. Clone this repository and open it in Claude Code
+4. Claude will automatically read `CLAUDE.md` for project-specific instructions
+
+## Ways to Contribute
+
+- **New Blueprints**: Add new lab environments demonstrating Aviatrix capabilities
+- **Improvements**: Enhance existing blueprints with better documentation, additional scenarios, or bug fixes
+- **Documentation**: Improve guides, fix typos, or add clarifications
+- **Bug Reports**: Report issues you encounter when deploying blueprints
+- **Feature Requests**: Suggest new blueprints or enhancements
+
+## Contributing a New Blueprint
+
+### 1. Start from the Template
+
+```bash
+# Copy the template
+cp -r blueprints/_template blueprints/your-blueprint-name
+
+# Follow naming conventions (see below)
+```
+
+### 2. Blueprint Requirements Checklist
+
+Every blueprint **must** include:
+
+- [ ] **README.md** with all required sections (see [Blueprint Standards](docs/blueprint-standards.md))
+- [ ] **Architecture diagram** (PNG or SVG in the blueprint directory)
+- [ ] **terraform.tfvars.example** with documented variables
+- [ ] **versions.tf** with required provider versions
+- [ ] **Complete prerequisites list** linking to shared docs
+- [ ] **Resources Created table** listing all cloud resources
+- [ ] **Test scenarios** for validating the deployment
+- [ ] **Cleanup instructions** including any manual steps
+
+### 3. Naming Conventions
+
+#### Blueprint Directory Names
+
+Use lowercase with hyphens:
+```
+blueprints/dcf-eks/           # Good
+blueprints/DCF_EKS/           # Bad
+blueprints/distributed-cloud-firewall-eks/  # Too verbose
+```
+
+Pattern: `<feature>-<platform>` or `<use-case>-<cloud>`
+
+Examples:
+- `dcf-eks` - Distributed Cloud Firewall with EKS
+- `transit-aws` - Transit architecture in AWS
+- `multicloud-hub` - Multi-cloud hub and spoke
+
+#### Terraform Resource Naming
+
+Use consistent prefixes within your blueprint:
+```hcl
+# Use a variable for the prefix
+variable "name_prefix" {
+  default = "dcf-eks"
+}
+
+# Apply consistently
+resource "aws_vpc" "main" {
+  tags = {
+    Name = "${var.name_prefix}-vpc"
+  }
+}
+```
+
+### 4. Terraform Standards
+
+#### File Structure
+
+```
+blueprints/your-blueprint/
+├── README.md
+├── main.tf              # Primary resources
+├── variables.tf         # Input variables
+├── outputs.tf           # Output values
+├── versions.tf          # Provider versions
+├── terraform.tfvars.example
+├── architecture.png     # Architecture diagram
+└── modules/             # Local modules (if needed)
+```
+
+#### Required versions.tf
+
+```hcl
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = ">= 3.1.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+}
+```
+
+#### Variable Documentation
+
+All variables must have descriptions:
+```hcl
+variable "controller_ip" {
+  description = "IP address or hostname of the Aviatrix Controller"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region for deployment"
+  type        = string
+  default     = "us-east-1"
+}
+```
+
+#### Output Documentation
+
+Outputs should help users interact with the deployment:
+```hcl
+output "controller_url" {
+  description = "URL to access the Aviatrix Controller"
+  value       = "https://${var.controller_ip}"
+}
+
+output "test_instance_ip" {
+  description = "IP address of the test instance for connectivity validation"
+  value       = aws_instance.test.public_ip
+}
+```
+
+### 5. Versioning
+
+Blueprints use semantic versioning with controller compatibility:
+
+```
+v<MAJOR>.<MINOR>.<PATCH>+avx<CONTROLLER_VERSION>
+```
+
+- **MAJOR**: Breaking changes (restructured inputs/outputs)
+- **MINOR**: New features, backward compatible
+- **PATCH**: Bug fixes, documentation updates
+- **avx**: Tested Aviatrix Control Plane version
+
+Examples:
+- `v1.0.0+avx8.1` - Initial release for Control Plane 8.1.x
+- `v1.1.0+avx8.2` - Added feature, tested on 8.2.x
+- `v2.0.0+avx9.0` - Breaking changes for Control Plane 9.0
+
+### 6. State Management
+
+Blueprints use **local state only**. Do not add remote state configuration:
+
+```hcl
+# Do NOT include this in blueprints
+terraform {
+  backend "s3" { ... }
+}
+```
+
+Users deploying for longer-term use can add their own backend configuration.
+
+## Pull Request Process
+
+### 1. Before Submitting
+
+- [ ] Run `terraform fmt -recursive` on your blueprint
+- [ ] Run `terraform validate` successfully
+- [ ] Test full deployment and destroy cycle
+- [ ] Verify all links in README work
+- [ ] Update the blueprint catalog in root README.md
+
+### 2. PR Requirements
+
+Your PR must include:
+- Clear description of what the blueprint does
+- Screenshots or diagram of the deployed architecture
+- Confirmation that you've tested deploy and destroy
+- List of any prerequisites beyond standard requirements
+
+### 3. Review Process
+
+1. **Automated checks**: CI runs `terraform fmt` and `terraform validate`
+2. **Maintainer review**: Code and documentation review
+3. **SE validation** (required for merging all PRs): Full deployment test by Aviatrix SE
+
+### 4. After Merge
+
+- Blueprint appears in catalog as "Community" tier
+- Aviatrix team may promote to "Verified" after QA validation
+- Version tags are created for releases
+
+## Improving Existing Blueprints
+
+### Bug Fixes
+
+1. Create an issue describing the bug
+2. Reference the issue in your PR
+3. Include steps to reproduce and verify the fix
+
+### Enhancements
+
+1. Create an issue or discussion for feedback
+2. Ensure backward compatibility when possible
+3. Update documentation to reflect changes
+
+### Documentation Improvements
+
+- Fix typos and clarify confusing sections
+- Add missing information discovered during use
+- Improve examples and test scenarios
+
+## Getting Help
+
+- **Questions**: Open a [Discussion](https://github.com/aviatrix/aviatrix-blueprints/discussions)
+- **Bugs**: Open an [Issue](https://github.com/aviatrix/aviatrix-blueprints/issues)
+- **Feature ideas**: Open an [Issue](https://github.com/aviatrix/aviatrix-blueprints/issues) with the "enhancement" label
+
+## Recognition
+
+Contributors are recognized in:
+- PR merge comments
+- Release notes
+- The blueprint's README (for significant contributions)
+
+Thank you for helping build the Aviatrix Blueprints community!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024 Aviatrix Systems, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,133 @@
-# aviatrix-blueprints
-Aviatrix blueprints
+# Aviatrix Blueprints
+
+Production-ready Terraform lab environments for learning, demonstrating, and testing Aviatrix cloud networking solutions.
+
+![Aviatrix Blueprints](aviatrix_blueprints_logo.png)
+
+## What are Blueprints?
+
+Blueprints are **complete, deployable lab environments** that demonstrate Aviatrix capabilities in real-world scenarios. Unlike reusable Terraform modules, blueprints are designed to be:
+
+- **Self-contained**: Everything needed to deploy a working environment
+- **Educational**: Clear documentation explaining what's being built and why
+- **Demonstrable**: Built-in test scenarios for showcasing functionality
+- **Ephemeral**: Designed for temporary use with easy cleanup
+
+## Blueprint Tiers
+
+| Tier | Description | Requirements |
+|------|-------------|--------------|
+| **Verified** | Validated by Aviatrix QA team, tested against specific controller versions | Full QA and SE review, version compatibility matrix |
+| **Community** | Contributed by the community, functional but not officially validated | Validated by the Aviatrix SE and Professional Services |
+
+## Blueprint Catalog
+
+| Blueprint | Description | Cloud(s) | Tier | Status |
+|-----------|-------------|----------|------|--------|
+| [dcf-eks](blueprints/dcf-eks/) | Distributed Cloud Firewall with EKS | AWS | Community | 🚧 In Progress |
+
+## Quick Start
+
+### 1. Prerequisites
+
+Before deploying any blueprint, ensure you have:
+
+- An [Aviatrix Enterprise or Aviatrix Cloud Control Plane](docs/prerequisites/aviatrix-controller.md) deployed and accessible
+- [Terraform](docs/prerequisites/terraform.md) installed (v1.5+)
+- Cloud provider CLI configured for your target cloud:
+  - [AWS CLI](docs/prerequisites/aws-cli.md)
+  - [Azure CLI](docs/prerequisites/azure-cli.md)
+  - [Google Cloud CLI](docs/prerequisites/gcloud-cli.md)
+- Additional tools as required by specific blueprints (e.g., [kubectl](docs/prerequisites/kubectl.md))
+
+See the [Prerequisites Overview](docs/prerequisites/README.md) for detailed setup instructions.
+
+### 2. Deploy a Blueprint
+
+```bash
+# Clone the repository
+git clone https://github.com/aviatrix/aviatrix-blueprints.git
+cd aviatrix-blueprints
+
+# Navigate to your chosen blueprint
+cd blueprints/dcf-eks
+
+# Review the README for specific requirements
+cat README.md
+
+# Copy and configure variables
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your values
+
+# Deploy
+terraform init
+terraform plan
+terraform apply
+```
+
+### 3. Explore and Learn
+
+Each blueprint includes:
+- Architecture diagrams
+- Step-by-step deployment instructions
+- Test scenarios to validate functionality
+- Demo walkthroughs for presentations
+
+### 4. Clean Up
+
+```bash
+# Destroy all resources when done
+terraform destroy
+```
+
+## Repository Structure
+
+```
+aviatrix-blueprints/
+├── docs/                    # Documentation and guides
+│   ├── prerequisites/       # Setup guides for required tools
+│   ├── getting-started.md   # Quick start guide
+│   └── blueprint-standards.md
+├── modules/                 # Shared Terraform modules (future)
+├── blueprints/              # Deployable lab environments
+│   ├── _template/           # Template for new blueprints
+│   └── dcf-eks/             # Individual blueprints...
+└── .github/                 # CI/CD and templates
+```
+
+## Documentation
+
+- [Getting Started Guide](docs/getting-started.md)
+- [Blueprint Standards](docs/blueprint-standards.md)
+- [Contributing Guide](CONTRIBUTING.md)
+- [Prerequisites](docs/prerequisites/README.md)
+
+## Contributing
+
+We welcome contributions! Whether you're fixing a bug, improving documentation, or adding a new blueprint, please see our [Contributing Guide](CONTRIBUTING.md).
+
+### Adding a New Blueprint
+
+1. Copy the [blueprint template](blueprints/_template/)
+2. Follow the [Blueprint Standards](docs/blueprint-standards.md)
+3. Submit a PR for review
+
+## Versioning
+
+Blueprints follow semantic versioning with controller compatibility:
+
+```
+v<MAJOR>.<MINOR>.<PATCH>+avx<CONTROLLER_VERSION>
+```
+
+Example: `v1.2.0+avx8.1` indicates version 1.2.0 tested with Aviatrix Control Plane 8.1.x
+
+## Support
+
+- **Issues**: [GitHub Issues](https://github.com/aviatrix/aviatrix-blueprints/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/aviatrix/aviatrix-blueprints/discussions)
+- **Aviatrix Documentation**: [docs.aviatrix.com](https://docs.aviatrix.com)
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.

--- a/blueprints/_template/README.md
+++ b/blueprints/_template/README.md
@@ -1,0 +1,230 @@
+# Blueprint Name
+
+<!--
+TEMPLATE: Replace this section with a brief description of your blueprint.
+1-3 sentences covering what this blueprint deploys, the use case, and key Aviatrix features demonstrated.
+-->
+
+Brief description of what this blueprint deploys and demonstrates.
+
+## Architecture
+
+<!--
+TEMPLATE: Include an architecture diagram showing:
+- Cloud resources (VPCs, subnets, instances)
+- Aviatrix components (gateways, transit, firewalls)
+- Network connectivity and data flows
+- Regions/availability zones
+
+Save the diagram as architecture.png in this directory.
+-->
+
+![Architecture Diagram](architecture.png)
+
+Brief explanation of the architecture and key data flows.
+
+## Prerequisites
+
+### Required Tools
+
+<!-- TEMPLATE: Link to shared prerequisite docs. Add or remove as needed. -->
+
+- [Aviatrix Control Plane](../../docs/prerequisites/aviatrix-controller.md) (v7.1+) - Controller and CoPilot
+- [Terraform](../../docs/prerequisites/terraform.md) (v1.5+)
+- [AWS CLI](../../docs/prerequisites/aws-cli.md)
+<!-- - [Azure CLI](../../docs/prerequisites/azure-cli.md) -->
+<!-- - [Google Cloud CLI](../../docs/prerequisites/gcloud-cli.md) -->
+<!-- - [kubectl](../../docs/prerequisites/kubectl.md) -->
+
+### Required Access
+
+<!-- TEMPLATE: List cloud permissions and Aviatrix requirements -->
+
+- AWS account with permissions to create VPCs, EC2 instances, etc.
+- Aviatrix Control Plane with AWS account onboarded
+
+### Blueprint-Specific Requirements
+
+<!-- TEMPLATE: List any requirements unique to this blueprint -->
+
+- At least 2 available Elastic IPs in the target region
+- Service quota for X (if applicable)
+
+## Resources Created
+
+<!-- TEMPLATE: List ALL resources this blueprint creates -->
+
+| Resource | Description | Quantity |
+|----------|-------------|----------|
+| AWS VPC | Main VPC for workloads | 1 |
+| Aviatrix Transit Gateway | Primary transit gateway | 1 |
+| Aviatrix Spoke Gateway | Spoke gateway for workloads | 1 |
+| EC2 Instance | Test instance for connectivity | 1 |
+
+**Estimated Cost**: ~$X/hour when running
+
+<!-- Optional: Include cost breakdown for major components -->
+
+## Deployment
+
+### Step 1: Clone and Navigate
+
+```bash
+git clone https://github.com/aviatrix/aviatrix-blueprints.git
+cd aviatrix-blueprints/blueprints/<blueprint-name>
+```
+
+### Step 2: Configure Variables
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars` with your values. See [Variables](#variables) section for details.
+
+### Step 3: Deploy
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+Type `yes` when prompted to confirm.
+
+<!-- TEMPLATE: Note approximate deployment time -->
+Deployment takes approximately X minutes.
+
+### Step 4: Verify Deployment
+
+<!-- TEMPLATE: Add verification steps specific to your blueprint -->
+
+After deployment completes:
+
+1. Check Terraform outputs: `terraform output`
+2. Verify in Aviatrix CoPilot: Navigate to Topology to view deployed resources
+3. Verify in cloud console: Check that VPCs/instances are created
+
+## Variables
+
+<!-- TEMPLATE: Document ALL input variables -->
+
+| Variable | Description | Type | Default | Required |
+|----------|-------------|------|---------|----------|
+| `controller_ip` | Aviatrix Control Plane (Controller) IP address | `string` | - | yes |
+| `controller_username` | Controller admin username | `string` | `"admin"` | no |
+| `controller_password` | Controller admin password | `string` | - | yes |
+| `aws_region` | AWS region for deployment | `string` | `"us-east-1"` | no |
+| `name_prefix` | Prefix for resource names | `string` | `"blueprint"` | no |
+
+## Outputs
+
+<!-- TEMPLATE: Document ALL outputs -->
+
+| Output | Description |
+|--------|-------------|
+| `transit_gateway_id` | ID of the Aviatrix Transit Gateway |
+| `spoke_vpc_id` | ID of the spoke VPC |
+| `test_instance_ip` | Public IP of the test instance |
+
+## Test Scenarios
+
+<!-- TEMPLATE: Provide specific, repeatable test scenarios -->
+
+### Scenario 1: Basic Connectivity
+
+Verify basic connectivity between components:
+
+```bash
+# SSH to test instance
+ssh -i <key.pem> ec2-user@<test_instance_ip>
+
+# Ping another resource
+ping <target-ip>
+```
+
+**Expected result**: Ping succeeds, traffic flows through Aviatrix gateway.
+
+### Scenario 2: [Specific Feature Test]
+
+<!-- TEMPLATE: Add scenarios for each key feature the blueprint demonstrates -->
+
+1. Navigate to CoPilot > [relevant section]
+2. Perform action
+3. Verify expected behavior
+
+**Expected result**: [describe expected outcome]
+
+## Demo Walkthrough
+
+<!-- TEMPLATE: Optional section for presentation/demo purposes -->
+
+Use this section to guide a demonstration:
+
+1. **Show the architecture**: Open CoPilot topology view
+2. **Demonstrate feature X**: Walk through the configuration
+3. **Generate traffic**: Run connectivity test
+4. **Show visibility**: View in CoPilot monitoring
+
+## Cleanup
+
+### Standard Destroy
+
+```bash
+terraform destroy
+```
+
+Type `yes` when prompted to confirm.
+
+### Manual Cleanup (if destroy fails)
+
+<!-- TEMPLATE: List resources that might need manual cleanup -->
+
+If Terraform destroy fails, manually delete:
+
+1. Any load balancers created by applications
+2. Any manually created resources
+
+### Verify Cleanup
+
+Confirm no resources remain:
+
+```bash
+# Check for remaining resources (adjust filter as needed)
+aws ec2 describe-vpcs --filters "Name=tag:Name,Values=*<name_prefix>*"
+```
+
+## Troubleshooting
+
+<!-- TEMPLATE: Document common issues and solutions -->
+
+### Issue: Gateway creation fails
+
+**Symptom**: Aviatrix gateway times out during creation
+
+**Solution**:
+1. Verify AWS account is onboarded in the Control Plane
+2. Check security group allows Controller communication
+3. Verify sufficient EIP quota in the region
+
+### Issue: [Specific issue]
+
+**Symptom**: Description of the problem
+
+**Solution**: Steps to resolve
+
+## Version Compatibility
+
+<!-- TEMPLATE: Document tested versions -->
+
+| Blueprint Version | Controller Version | Terraform | AWS Provider |
+|-------------------|-------------------|-----------|--------------|
+| v1.0.0 | 7.1.x | >= 1.5.0 | >= 5.0.0 |
+
+## Contributing
+
+See the [Contributing Guide](../../CONTRIBUTING.md) for information on how to contribute to this blueprint.
+
+## License
+
+Apache 2.0 - See [LICENSE](../../LICENSE)

--- a/blueprints/_template/main.tf
+++ b/blueprints/_template/main.tf
@@ -1,0 +1,127 @@
+# =============================================================================
+# Blueprint: [Blueprint Name]
+# Description: [Brief description of what this blueprint deploys]
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Aviatrix Provider Configuration
+# -----------------------------------------------------------------------------
+provider "aviatrix" {
+  controller_ip           = var.controller_ip
+  username                = var.controller_username
+  password                = var.controller_password
+  skip_version_validation = false
+}
+
+# -----------------------------------------------------------------------------
+# AWS Provider Configuration
+# -----------------------------------------------------------------------------
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Blueprint   = var.name_prefix
+      Environment = "lab"
+      ManagedBy   = "terraform"
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Data Sources
+# -----------------------------------------------------------------------------
+
+# Example: Get available AZs
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+# Example: Get latest Amazon Linux 2 AMI
+data "aws_ami" "amazon_linux_2" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Local Values
+# -----------------------------------------------------------------------------
+locals {
+  # Common naming
+  name_prefix = var.name_prefix
+
+  # Availability zones (use first 2)
+  azs = slice(data.aws_availability_zones.available.names, 0, 2)
+
+  # Common tags (in addition to default_tags)
+  common_tags = {
+    Blueprint = var.name_prefix
+  }
+}
+
+# -----------------------------------------------------------------------------
+# VPC Resources
+# -----------------------------------------------------------------------------
+
+# Example VPC
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${local.name_prefix}-vpc"
+  }
+}
+
+# Example Subnet
+resource "aws_subnet" "public" {
+  count = length(local.azs)
+
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index)
+  availability_zone       = local.azs[count.index]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${local.name_prefix}-public-${count.index + 1}"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Aviatrix Resources
+# -----------------------------------------------------------------------------
+
+# Example: Aviatrix Spoke Gateway
+# resource "aviatrix_spoke_gateway" "example" {
+#   cloud_type         = 1  # AWS
+#   account_name       = var.aviatrix_account_name
+#   gw_name            = "${local.name_prefix}-spoke"
+#   vpc_id             = aws_vpc.main.id
+#   vpc_reg            = var.aws_region
+#   gw_size            = var.gateway_size
+#   subnet             = aws_subnet.public[0].cidr_block
+#   single_ip_snat     = false
+#   manage_transit_gateway_attachment = false
+# }
+
+# -----------------------------------------------------------------------------
+# Test Resources
+# -----------------------------------------------------------------------------
+
+# Example: Test EC2 instance
+# resource "aws_instance" "test" {
+#   ami                    = data.aws_ami.amazon_linux_2.id
+#   instance_type          = "t3.micro"
+#   subnet_id              = aws_subnet.public[0].id
+#   vpc_security_group_ids = [aws_security_group.test.id]
+#
+#   tags = {
+#     Name = "${local.name_prefix}-test"
+#   }
+# }

--- a/blueprints/_template/outputs.tf
+++ b/blueprints/_template/outputs.tf
@@ -1,0 +1,78 @@
+# =============================================================================
+# Outputs
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# VPC Outputs
+# -----------------------------------------------------------------------------
+
+output "vpc_id" {
+  description = "ID of the created VPC"
+  value       = aws_vpc.main.id
+}
+
+output "vpc_cidr" {
+  description = "CIDR block of the VPC"
+  value       = aws_vpc.main.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = aws_subnet.public[*].id
+}
+
+# -----------------------------------------------------------------------------
+# Aviatrix Outputs
+# -----------------------------------------------------------------------------
+
+# output "spoke_gateway_name" {
+#   description = "Name of the Aviatrix Spoke Gateway"
+#   value       = aviatrix_spoke_gateway.example.gw_name
+# }
+
+# output "spoke_gateway_public_ip" {
+#   description = "Public IP of the Aviatrix Spoke Gateway"
+#   value       = aviatrix_spoke_gateway.example.eip
+# }
+
+# -----------------------------------------------------------------------------
+# Test Instance Outputs
+# -----------------------------------------------------------------------------
+
+# output "test_instance_id" {
+#   description = "ID of the test EC2 instance"
+#   value       = aws_instance.test.id
+# }
+
+# output "test_instance_public_ip" {
+#   description = "Public IP of the test EC2 instance"
+#   value       = aws_instance.test.public_ip
+# }
+
+# output "test_instance_private_ip" {
+#   description = "Private IP of the test EC2 instance"
+#   value       = aws_instance.test.private_ip
+# }
+
+# -----------------------------------------------------------------------------
+# Connection Information
+# -----------------------------------------------------------------------------
+
+# output "ssh_command" {
+#   description = "SSH command to connect to the test instance"
+#   value       = "ssh -i <your-key.pem> ec2-user@${aws_instance.test.public_ip}"
+# }
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+
+output "deployment_summary" {
+  description = "Summary of deployed resources"
+  value = {
+    region      = var.aws_region
+    name_prefix = var.name_prefix
+    vpc_id      = aws_vpc.main.id
+    vpc_cidr    = aws_vpc.main.cidr_block
+  }
+}

--- a/blueprints/_template/terraform.tfvars.example
+++ b/blueprints/_template/terraform.tfvars.example
@@ -1,0 +1,52 @@
+# =============================================================================
+# Aviatrix Blueprint Configuration
+# =============================================================================
+# Copy this file to terraform.tfvars and update the values.
+# Required values are marked with "REQUIRED".
+
+# -----------------------------------------------------------------------------
+# Aviatrix Control Plane Configuration
+# -----------------------------------------------------------------------------
+# The Aviatrix Control Plane consists of Controller (for Terraform/API) and
+# CoPilot (for GUI). These credentials connect to the Controller.
+
+# REQUIRED: IP address or hostname of your Aviatrix Controller
+controller_ip = "1.2.3.4"
+
+# Controller admin username (default: "admin")
+controller_username = "admin"
+
+# REQUIRED: Controller admin password
+controller_password = "CHANGE_ME"
+
+# REQUIRED: Aviatrix access account name for AWS
+# This must match an account already onboarded in your Control Plane
+aviatrix_account_name = "aws-account"
+
+# -----------------------------------------------------------------------------
+# AWS Configuration
+# -----------------------------------------------------------------------------
+
+# AWS region for deployment
+aws_region = "us-east-1"
+
+# -----------------------------------------------------------------------------
+# Blueprint Configuration
+# -----------------------------------------------------------------------------
+
+# Prefix for all resource names
+# Must start with a letter and contain only lowercase letters, numbers, and hyphens
+name_prefix = "blueprint"
+
+# CIDR block for the VPC
+vpc_cidr = "10.0.0.0/16"
+
+# Instance size for Aviatrix gateways
+gateway_size = "t3.medium"
+
+# -----------------------------------------------------------------------------
+# Optional Features
+# -----------------------------------------------------------------------------
+
+# Enable high availability for gateways
+# enable_ha = false

--- a/blueprints/_template/variables.tf
+++ b/blueprints/_template/variables.tf
@@ -1,0 +1,85 @@
+# =============================================================================
+# Input Variables
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Aviatrix Control Plane
+# -----------------------------------------------------------------------------
+
+variable "controller_ip" {
+  description = "IP address or hostname of the Aviatrix Controller"
+  type        = string
+}
+
+variable "controller_username" {
+  description = "Admin username for the Aviatrix Controller"
+  type        = string
+  default     = "admin"
+}
+
+variable "controller_password" {
+  description = "Admin password for the Aviatrix Controller"
+  type        = string
+  sensitive   = true
+}
+
+variable "aviatrix_account_name" {
+  description = "Aviatrix access account name for AWS"
+  type        = string
+}
+
+# -----------------------------------------------------------------------------
+# AWS Configuration
+# -----------------------------------------------------------------------------
+
+variable "aws_region" {
+  description = "AWS region for deployment"
+  type        = string
+  default     = "us-east-1"
+}
+
+# -----------------------------------------------------------------------------
+# Blueprint Configuration
+# -----------------------------------------------------------------------------
+
+variable "name_prefix" {
+  description = "Prefix for all resource names"
+  type        = string
+  default     = "blueprint"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*$", var.name_prefix))
+    error_message = "Name prefix must start with a letter and contain only lowercase letters, numbers, and hyphens."
+  }
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr, 0))
+    error_message = "VPC CIDR must be a valid CIDR block."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Gateway Configuration
+# -----------------------------------------------------------------------------
+
+variable "gateway_size" {
+  description = "Instance size for Aviatrix gateways"
+  type        = string
+  default     = "t3.medium"
+}
+
+# -----------------------------------------------------------------------------
+# Optional Features
+# -----------------------------------------------------------------------------
+
+# variable "enable_ha" {
+#   description = "Enable high availability for gateways"
+#   type        = bool
+#   default     = false
+# }

--- a/blueprints/_template/versions.tf
+++ b/blueprints/_template/versions.tf
@@ -1,0 +1,21 @@
+# =============================================================================
+# Terraform and Provider Versions
+# =============================================================================
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = ">= 3.1.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+
+  # Note: Blueprints use local state by design.
+  # Users can add their own backend configuration if needed.
+}

--- a/docs/blueprint-standards.md
+++ b/docs/blueprint-standards.md
@@ -1,0 +1,297 @@
+# Blueprint Standards
+
+Every Aviatrix Blueprint must meet these standards to ensure consistency, quality, and usability.
+
+## Required README Sections
+
+Each blueprint's README.md must include the following sections:
+
+### 1. Title and Description
+
+```markdown
+# Blueprint Name
+
+Brief description of what this blueprint deploys and demonstrates.
+One to three sentences covering the use case and key Aviatrix features.
+```
+
+### 2. Architecture Diagram
+
+A visual representation of the deployed infrastructure:
+
+```markdown
+## Architecture
+
+![Architecture Diagram](architecture.png)
+
+Brief explanation of the architecture and data flows.
+```
+
+Requirements:
+- PNG or SVG format
+- Clearly labeled components
+- Show network connectivity and Aviatrix components
+- Include cloud provider regions/availability zones
+
+### 3. Prerequisites
+
+Link to shared prerequisite docs plus any blueprint-specific requirements:
+
+```markdown
+## Prerequisites
+
+### Required Tools
+- [Aviatrix Control Plane](../../docs/prerequisites/aviatrix-controller.md) (v7.1+) - Controller and CoPilot
+- [Terraform](../../docs/prerequisites/terraform.md) (v1.5+)
+- [AWS CLI](../../docs/prerequisites/aws-cli.md)
+- [kubectl](../../docs/prerequisites/kubectl.md)
+
+### Required Access
+- AWS account with permissions to create VPCs, EKS, EC2, etc.
+- Aviatrix Control Plane with AWS account onboarded
+
+### Blueprint-Specific Requirements
+- At least 3 available EIPs in the target region
+- Service quota for EKS clusters
+```
+
+### 4. Resources Created
+
+A table listing all cloud resources that will be created:
+
+```markdown
+## Resources Created
+
+| Resource | Description | Quantity |
+|----------|-------------|----------|
+| AWS VPC | Transit and spoke VPCs | 3 |
+| Aviatrix Transit Gateway | Primary transit gateway | 1 |
+| Aviatrix Spoke Gateway | Spoke gateways for workloads | 2 |
+| EKS Cluster | Kubernetes cluster for app workloads | 1 |
+| EC2 Instance | Test instances for connectivity validation | 2 |
+
+**Estimated Cost**: ~$X/hour when running (see cost breakdown below)
+```
+
+### 5. Deployment Instructions
+
+Step-by-step instructions:
+
+```markdown
+## Deployment
+
+### Step 1: Clone and Navigate
+
+\`\`\`bash
+git clone https://github.com/aviatrix/aviatrix-blueprints.git
+cd aviatrix-blueprints/blueprints/<blueprint-name>
+\`\`\`
+
+### Step 2: Configure Variables
+
+\`\`\`bash
+cp terraform.tfvars.example terraform.tfvars
+\`\`\`
+
+Edit `terraform.tfvars` with your values:
+- `controller_ip`: Your Aviatrix Control Plane (Controller) IP
+- ...
+
+### Step 3: Deploy
+
+\`\`\`bash
+terraform init
+terraform plan
+terraform apply
+\`\`\`
+
+Deployment takes approximately X minutes.
+```
+
+### 6. Variables Reference
+
+Document all input variables:
+
+```markdown
+## Variables
+
+| Variable | Description | Type | Default | Required |
+|----------|-------------|------|---------|----------|
+| controller_ip | Aviatrix Control Plane (Controller) IP address | string | - | yes |
+| controller_username | Controller admin username | string | "admin" | no |
+| aws_region | AWS region for deployment | string | "us-east-1" | no |
+```
+
+### 7. Outputs Reference
+
+Document all outputs:
+
+```markdown
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| transit_gateway_id | ID of the Aviatrix Transit Gateway |
+| spoke_vpc_ids | List of spoke VPC IDs |
+| test_instance_ips | Public IPs of test instances |
+```
+
+### 8. Test Scenarios / Demo Walkthrough
+
+Provide specific scenarios to validate the deployment:
+
+```markdown
+## Test Scenarios
+
+### Scenario 1: East-West Connectivity
+
+Verify connectivity between spoke VPCs:
+
+\`\`\`bash
+# SSH to test instance in Spoke 1
+ssh -i key.pem ec2-user@<spoke1-instance-ip>
+
+# Ping test instance in Spoke 2
+ping <spoke2-private-ip>
+\`\`\`
+
+Expected result: Ping succeeds, traffic flows through Transit Gateway.
+
+### Scenario 2: Firewall Inspection
+
+Verify traffic is inspected by DCF:
+
+1. Open CoPilot > Security > Distributed Cloud Firewall
+2. Navigate to Monitor
+3. Generate traffic between spokes
+4. Verify traffic appears in logs
+```
+
+### 9. Cleanup / Destroy
+
+Instructions for complete cleanup:
+
+```markdown
+## Cleanup
+
+### Standard Destroy
+
+\`\`\`bash
+terraform destroy
+\`\`\`
+
+### Manual Cleanup (if destroy fails)
+
+If Terraform destroy fails, manually delete:
+
+1. Any Kubernetes LoadBalancer services (creates AWS ELBs)
+2. ...
+
+### Verify Cleanup
+
+Confirm no resources remain:
+
+\`\`\`bash
+aws ec2 describe-vpcs --filters "Name=tag:Blueprint,Values=<blueprint-name>"
+\`\`\`
+```
+
+### 10. Troubleshooting
+
+Common issues and solutions:
+
+```markdown
+## Troubleshooting
+
+### Gateway creation fails
+
+**Symptom**: Aviatrix gateway times out during creation
+
+**Solution**:
+1. Verify AWS account is onboarded in the Control Plane
+2. Check security group allows Controller communication
+3. Verify sufficient EIP quota
+
+### EKS nodes not joining
+
+**Symptom**: EKS nodes remain in "NotReady" state
+
+**Solution**:
+1. Check node IAM role permissions
+2. Verify VPC CNI configuration
+3. Review node security group rules
+```
+
+### 11. Version Compatibility Matrix
+
+Document tested versions:
+
+```markdown
+## Version Compatibility
+
+| Blueprint Version | Controller Version | Terraform | AWS Provider |
+|-------------------|-------------------|-----------|--------------|
+| v1.0.0 | 7.1.x | >= 1.5.0 | >= 5.0.0 |
+| v1.1.0 | 7.2.x | >= 1.5.0 | >= 5.0.0 |
+```
+
+## Required Files
+
+Every blueprint directory must contain:
+
+```
+blueprints/example-blueprint/
+├── README.md                 # Documentation (all sections above)
+├── main.tf                   # Primary Terraform configuration
+├── variables.tf              # Input variable definitions
+├── outputs.tf                # Output definitions
+├── versions.tf               # Required providers and versions
+├── terraform.tfvars.example  # Example variable values
+└── architecture.png          # Architecture diagram
+```
+
+### versions.tf Template
+
+```hcl
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = ">= 3.1.0"
+    }
+    # Add other providers as needed
+  }
+}
+```
+
+### terraform.tfvars.example Template
+
+```hcl
+# Aviatrix Control Plane Configuration
+controller_ip       = "1.2.3.4"
+controller_username = "admin"
+controller_password = "CHANGE_ME"
+
+# Cloud Provider Configuration
+aws_region = "us-east-1"
+
+# Blueprint-Specific Variables
+name_prefix = "dcf-eks"
+```
+
+## Quality Checklist
+
+Before submitting a blueprint:
+
+- [ ] All required README sections present
+- [ ] Architecture diagram is clear and accurate
+- [ ] All variables documented with descriptions
+- [ ] terraform.tfvars.example includes all required variables
+- [ ] `terraform fmt` passes
+- [ ] `terraform validate` passes
+- [ ] Full deploy/destroy cycle tested
+- [ ] Test scenarios verified
+- [ ] Troubleshooting section covers common issues
+- [ ] Version compatibility documented

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,196 @@
+# Getting Started with Aviatrix Blueprints
+
+This guide walks you through deploying your first Aviatrix Blueprint.
+
+## Overview
+
+Aviatrix Blueprints are complete, self-contained Terraform configurations that deploy working lab environments. Each blueprint includes:
+
+- All necessary Terraform code
+- Detailed documentation
+- Test scenarios for validation
+- Cleanup instructions
+
+## Prerequisites
+
+Before you begin, ensure you have:
+
+1. **Aviatrix Control Plane** - A deployed and accessible Aviatrix environment
+   - See [Aviatrix Control Plane Prerequisites](prerequisites/aviatrix-controller.md)
+   - This includes both **Controller** (for Terraform/API) and **CoPilot** (for GUI), or an **Aviatrix Cloud Fabric** subscription
+
+2. **Terraform** - Version 1.5 or later
+   - See [Terraform Installation Guide](prerequisites/terraform.md)
+
+3. **Cloud Provider CLI** - For your target cloud(s):
+   - [AWS CLI](prerequisites/aws-cli.md)
+   - [Azure CLI](prerequisites/azure-cli.md)
+   - [Google Cloud CLI](prerequisites/gcloud-cli.md)
+
+4. **Additional Tools** - As required by specific blueprints:
+   - [kubectl](prerequisites/kubectl.md) for Kubernetes-based blueprints
+
+## Step-by-Step Deployment
+
+### Step 1: Clone the Repository
+
+```bash
+git clone https://github.com/aviatrix/aviatrix-blueprints.git
+cd aviatrix-blueprints
+```
+
+### Step 2: Choose a Blueprint
+
+Browse the [Blueprint Catalog](../README.md#blueprint-catalog) and select one that matches your learning goals.
+
+```bash
+# Navigate to your chosen blueprint
+cd blueprints/dcf-eks
+```
+
+### Step 3: Review Requirements
+
+Read the blueprint's README carefully:
+
+```bash
+cat README.md
+```
+
+Pay attention to:
+- **Prerequisites**: What tools and access you need
+- **Resources Created**: What will be deployed (and the cost implications)
+- **Time Estimate**: How long deployment typically takes
+
+### Step 4: Configure Variables
+
+```bash
+# Copy the example variables file
+cp terraform.tfvars.example terraform.tfvars
+
+# Edit with your values
+# Use your preferred editor
+vi terraform.tfvars
+```
+
+Common variables you'll need to set:
+
+```hcl
+# Aviatrix Control Plane (Controller)
+controller_ip       = "1.2.3.4"
+controller_username = "admin"
+controller_password = "your-password"
+
+# Cloud Provider
+aws_region = "us-east-1"
+```
+
+### Step 5: Initialize Terraform
+
+```bash
+terraform init
+```
+
+This downloads required providers and modules.
+
+### Step 6: Review the Plan
+
+```bash
+terraform plan
+```
+
+Review the planned changes:
+- Confirm the resources match what you expect
+- Check for any errors or warnings
+- Note the number of resources to be created
+
+### Step 7: Deploy
+
+```bash
+terraform apply
+```
+
+Type `yes` when prompted to confirm.
+
+Deployment times vary by blueprint. Complex blueprints may take 15-30 minutes.
+
+### Step 8: Explore and Test
+
+Each blueprint includes test scenarios. Follow the instructions in the blueprint's README to:
+
+1. Verify connectivity between components
+2. Test Aviatrix features (firewalls, segmentation, etc.)
+3. Explore the CoPilot visualizations
+
+### Step 9: Clean Up
+
+When you're done:
+
+```bash
+terraform destroy
+```
+
+Type `yes` when prompted to confirm.
+
+**Important**: Always destroy resources when done to avoid ongoing cloud charges.
+
+## Tips for Success
+
+### Cost Management
+
+- Blueprints create real cloud resources that incur charges
+- Always run `terraform destroy` when finished
+- Consider using cloud provider cost alerts
+- Some blueprints note estimated costs in their README
+
+### Troubleshooting
+
+Common issues and solutions:
+
+**Terraform init fails**
+```bash
+# Clear cache and retry
+rm -rf .terraform .terraform.lock.hcl
+terraform init
+```
+
+**Authentication errors**
+- Verify your cloud CLI is configured: `aws sts get-caller-identity`
+- Check control plane credentials in terraform.tfvars
+- Ensure the Controller is accessible from your network
+
+**Resource creation timeout**
+- Some resources (like EKS clusters) take time
+- Check the cloud provider console for status
+- Review Controller/CoPilot logs for Aviatrix-related issues
+
+**Destroy fails with dependencies**
+- Some resources may need manual cleanup
+- Check the blueprint's troubleshooting section
+- Common: Load balancers created by Kubernetes services
+
+### State Files
+
+Blueprints use local state (`terraform.tfstate`). This file:
+
+- Contains sensitive information - don't commit to git
+- Is required for destroy - don't delete before cleanup
+- Can be recreated if needed (with caveats)
+
+### Multiple Deployments
+
+To deploy the same blueprint multiple times:
+
+```bash
+# Use workspaces
+terraform workspace new dev
+terraform workspace new prod
+
+# Or use separate directories
+cp -r blueprints/dcf-eks blueprints/dcf-eks-demo2
+```
+
+## Next Steps
+
+- [Blueprint Standards](blueprint-standards.md) - Understand what's in each blueprint
+- [Contributing](../CONTRIBUTING.md) - Create your own blueprints
+- [Aviatrix Documentation](https://docs.aviatrix.com) - Learn more about Aviatrix features

--- a/docs/prerequisites/README.md
+++ b/docs/prerequisites/README.md
@@ -1,0 +1,125 @@
+# Prerequisites Overview
+
+Before deploying Aviatrix Blueprints, you'll need to set up several tools and ensure you have the necessary access.
+
+## Aviatrix Control Plane
+
+Blueprints require access to an **Aviatrix Control Plane**, which consists of:
+
+- **Controller** - The management plane for Terraform and API operations
+- **CoPilot** - The GUI for visualization, monitoring, and day-2 operations
+
+Alternatively, you can use an **Aviatrix Cloud Fabric** subscription, which provides a fully managed control plane.
+
+See the [Aviatrix Control Plane Setup Guide](aviatrix-controller.md) for details.
+
+## Required for All Blueprints
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| [Aviatrix Control Plane](aviatrix-controller.md) | 7.1+ | Manages Aviatrix infrastructure |
+| [Terraform](terraform.md) | 1.5+ | Infrastructure as Code deployment |
+
+## Cloud Provider CLIs
+
+Install the CLI for your target cloud(s):
+
+| Cloud | Tool | Guide |
+|-------|------|-------|
+| AWS | AWS CLI | [Installation Guide](aws-cli.md) |
+| Azure | Azure CLI | [Installation Guide](azure-cli.md) |
+| GCP | gcloud CLI | [Installation Guide](gcloud-cli.md) |
+
+## Additional Tools
+
+Some blueprints require additional tools:
+
+| Tool | Required For | Guide |
+|------|--------------|-------|
+| kubectl | Kubernetes blueprints (EKS, AKS, GKE) | [Installation Guide](kubectl.md) |
+| helm | Some Kubernetes deployments | See blueprint README |
+
+## Cloud Shell Option
+
+If you prefer not to install tools locally, you can use cloud-native shells:
+
+| Provider | Shell | Notes |
+|----------|-------|-------|
+| AWS | CloudShell | Includes AWS CLI, limited to AWS |
+| Azure | Cloud Shell | Includes Azure CLI and Terraform |
+| GCP | Cloud Shell | Includes gcloud CLI and Terraform |
+
+See [Cloud Shell Guide](cloudshell.md) for setup instructions.
+
+## Verification
+
+After installation, verify your setup:
+
+```bash
+# Terraform
+terraform version
+# Expected: Terraform v1.5.x or higher
+
+# AWS CLI
+aws --version
+aws sts get-caller-identity
+# Expected: Shows your AWS account info
+
+# Azure CLI (if using Azure)
+az --version
+az account show
+# Expected: Shows your Azure subscription
+
+# GCP CLI (if using GCP)
+gcloud --version
+gcloud auth list
+# Expected: Shows your GCP account
+
+# kubectl (if needed)
+kubectl version --client
+# Expected: Shows client version
+```
+
+## Quick Install Summary
+
+### macOS (with Homebrew)
+
+```bash
+# Core tools
+brew install terraform
+
+# Cloud CLIs
+brew install awscli
+brew install azure-cli
+brew install google-cloud-sdk
+
+# Kubernetes tools
+brew install kubectl
+```
+
+### Windows (with Chocolatey)
+
+```powershell
+# Core tools
+choco install terraform
+
+# Cloud CLIs
+choco install awscli
+choco install azure-cli
+choco install gcloudsdk
+
+# Kubernetes tools
+choco install kubernetes-cli
+```
+
+### Linux
+
+See individual guides for distribution-specific instructions.
+
+## Next Steps
+
+1. Install required tools using the guides above
+2. Configure cloud provider authentication
+3. Verify your Aviatrix Control Plane access (Controller and CoPilot)
+4. Choose a [blueprint](../../README.md#blueprint-catalog) to deploy
+5. Follow the [Getting Started Guide](../getting-started.md)

--- a/docs/prerequisites/aviatrix-controller.md
+++ b/docs/prerequisites/aviatrix-controller.md
@@ -1,0 +1,154 @@
+# Aviatrix Control Plane Prerequisites
+
+The Aviatrix Control Plane is required for all blueprints. It consists of:
+
+- **Controller** - The management plane for Terraform and API operations
+- **CoPilot** - The GUI for visualization, monitoring, and day-2 operations
+
+Alternatively, you can use **Aviatrix Cloud Fabric**, a fully managed control plane subscription.
+
+## Requirements
+
+### Control Plane Access
+
+You need:
+- **Controller IP or hostname**: The public IP or DNS name of your Controller
+- **Admin credentials**: Username and password with admin privileges
+- **Network access**: Your workstation must be able to reach the Controller on port 443
+
+### Control Plane Version
+
+Blueprints specify their required Control Plane version. Check the blueprint's README:
+
+```markdown
+## Prerequisites
+- Aviatrix Control Plane v8.1 or later
+```
+
+### Cloud Account Onboarding
+
+Before deploying blueprints, your cloud accounts must be onboarded to the Controller:
+
+1. **AWS**: IAM roles configured via CloudFormation or manually
+2. **Azure**: Service principal or managed identity configured
+3. **GCP**: Service account configured
+
+## Deploying a Control Plane
+
+If you don't have a Control Plane, follow the official Aviatrix documentation:
+
+### AWS Deployment
+
+Follow the [AWS Getting Started Guide](https://docs.aviatrix.com/documentation/latest/getting-started/getting-started-guide-aws.html?expand=true) which covers:
+
+- Launching the Controller from AWS Marketplace
+- Initial Controller setup and licensing
+- Onboarding your AWS account
+- Deploying CoPilot
+
+### Azure Deployment
+
+Follow the [Azure Getting Started Guide](https://docs.aviatrix.com/documentation/latest/getting-started/getting-started-guide-azure.html?expand=true) which covers:
+
+- Launching the Controller from Azure Marketplace
+- Initial Controller setup and licensing
+- Onboarding your Azure subscription
+- Deploying CoPilot
+
+### GCP Deployment
+
+See the [Aviatrix Documentation](https://docs.aviatrix.com) for GCP-specific deployment instructions.
+
+## Verifying Control Plane Access
+
+### From Your Browser
+
+1. Navigate to `https://<controller-ip>`
+2. Log in with your credentials
+3. Verify you can access the dashboard
+4. Navigate to CoPilot and verify access
+
+### From Terraform
+
+Create a test file to verify connectivity:
+
+```hcl
+# test-controller.tf
+terraform {
+  required_providers {
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = ">= 3.1.0"
+    }
+  }
+}
+
+provider "aviatrix" {
+  controller_ip = var.controller_ip
+  username      = var.controller_username
+  password      = var.controller_password
+}
+
+variable "controller_ip" {
+  description = "Controller IP address"
+  type        = string
+}
+
+variable "controller_username" {
+  description = "Controller username"
+  type        = string
+  default     = "admin"
+}
+
+variable "controller_password" {
+  description = "Controller password"
+  type        = string
+  sensitive   = true
+}
+
+data "aviatrix_account" "test" {
+  account_name = "your-account-name"
+}
+
+output "account_info" {
+  value = data.aviatrix_account.test
+}
+```
+
+Run:
+```bash
+terraform init
+terraform plan -var="controller_ip=1.2.3.4" -var="controller_password=xxx"
+```
+
+If successful, you'll see the account information.
+
+## Troubleshooting
+
+### Cannot reach Controller
+
+1. Verify the Controller is running (check cloud provider console)
+2. Check security groups allow inbound HTTPS (port 443)
+3. Verify your IP is allowed (if IP allowlisting is enabled)
+4. Check VPN connectivity if Controller is in private network
+
+### Authentication fails
+
+1. Verify username and password
+2. Check for account lockout
+3. Verify user has admin privileges
+4. Check Controller license status
+
+### Cloud account connection fails
+
+1. Verify credentials are correct
+2. Check IAM permissions (AWS) or role assignments (Azure/GCP)
+3. Review Controller logs for detailed errors
+4. Verify network connectivity to cloud provider APIs
+
+## Resources
+
+- [Aviatrix Documentation](https://docs.aviatrix.com)
+- [AWS Getting Started Guide](https://docs.aviatrix.com/documentation/latest/getting-started/getting-started-guide-aws.html?expand=true)
+- [Azure Getting Started Guide](https://docs.aviatrix.com/documentation/latest/getting-started/getting-started-guide-azure.html?expand=true)
+- [Aviatrix Support](https://support.aviatrix.com)

--- a/docs/prerequisites/aws-cli.md
+++ b/docs/prerequisites/aws-cli.md
@@ -1,0 +1,299 @@
+# AWS CLI Installation Guide
+
+The AWS CLI is required for deploying blueprints to AWS. This guide covers installation and configuration on macOS and Windows.
+
+## Version Requirements
+
+- **Minimum version**: AWS CLI v2
+- **Recommended**: Latest stable version
+
+## Installation
+
+### macOS
+
+#### Using Homebrew (Recommended)
+
+```bash
+# Install AWS CLI
+brew install awscli
+
+# Verify installation
+aws --version
+```
+
+#### Using Official Installer
+
+```bash
+# Download the installer
+curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+
+# Install (requires admin password)
+sudo installer -pkg AWSCLIV2.pkg -target /
+
+# Verify installation
+aws --version
+
+# Clean up
+rm AWSCLIV2.pkg
+```
+
+### Windows
+
+#### Using MSI Installer (Recommended)
+
+1. Download the installer: [AWS CLI MSI Installer](https://awscli.amazonaws.com/AWSCLIV2.msi)
+2. Run the downloaded MSI installer
+3. Follow the installation wizard
+4. Open a new Command Prompt or PowerShell
+5. Verify: `aws --version`
+
+#### Using Chocolatey
+
+```powershell
+# Install AWS CLI
+choco install awscli
+
+# Verify installation
+aws --version
+```
+
+#### Using winget
+
+```powershell
+# Install AWS CLI
+winget install Amazon.AWSCLI
+
+# Verify installation
+aws --version
+```
+
+### Linux
+
+#### Ubuntu/Debian
+
+```bash
+# Download installer
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+
+# Install unzip if needed
+sudo apt install unzip
+
+# Extract and install
+unzip awscliv2.zip
+sudo ./aws/install
+
+# Verify
+aws --version
+
+# Clean up
+rm -rf aws awscliv2.zip
+```
+
+#### Amazon Linux 2 / RHEL / CentOS
+
+```bash
+# Download installer
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+
+# Install unzip if needed
+sudo yum install unzip
+
+# Extract and install
+unzip awscliv2.zip
+sudo ./aws/install
+
+# Verify
+aws --version
+```
+
+## Configuration
+
+### Quick Configuration
+
+The fastest way to configure credentials:
+
+```bash
+aws configure
+```
+
+You'll be prompted for:
+- **AWS Access Key ID**: Your access key
+- **AWS Secret Access Key**: Your secret key
+- **Default region name**: e.g., `us-east-1`
+- **Default output format**: `json` (recommended)
+
+### Configuration Files
+
+AWS CLI stores configuration in two files:
+
+**~/.aws/credentials** (Linux/macOS) or **%USERPROFILE%\.aws\credentials** (Windows)
+```ini
+[default]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+```
+
+**~/.aws/config**
+```ini
+[default]
+region = us-east-1
+output = json
+```
+
+### Multiple Profiles
+
+Configure multiple AWS accounts using profiles:
+
+```bash
+# Configure a named profile
+aws configure --profile production
+```
+
+**~/.aws/credentials**
+```ini
+[default]
+aws_access_key_id = AKIA...DEFAULT
+aws_secret_access_key = ...
+
+[production]
+aws_access_key_id = AKIA...PROD
+aws_secret_access_key = ...
+
+[development]
+aws_access_key_id = AKIA...DEV
+aws_secret_access_key = ...
+```
+
+Use profiles:
+```bash
+# Set profile for current session
+export AWS_PROFILE=production
+
+# Or specify per-command
+aws s3 ls --profile production
+```
+
+### Using IAM Identity Center (SSO)
+
+For organizations using AWS IAM Identity Center:
+
+```bash
+# Configure SSO
+aws configure sso
+
+# Login
+aws sso login --profile my-sso-profile
+
+# Use the profile
+export AWS_PROFILE=my-sso-profile
+```
+
+### Using IAM Roles (EC2/ECS)
+
+When running on AWS infrastructure with an IAM role attached, no configuration is needed. The CLI automatically uses the instance/task role.
+
+## Verification
+
+Verify your configuration works:
+
+```bash
+# Check CLI version
+aws --version
+
+# Verify credentials
+aws sts get-caller-identity
+```
+
+Expected output:
+```json
+{
+    "UserId": "AIDAIOSFODNN7EXAMPLE",
+    "Account": "123456789012",
+    "Arn": "arn:aws:iam::123456789012:user/myuser"
+}
+```
+
+## Terraform Integration
+
+Terraform uses AWS credentials from:
+1. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
+2. AWS credentials file (`~/.aws/credentials`)
+3. Instance profile (when running on EC2)
+
+### Using Profiles with Terraform
+
+```hcl
+provider "aws" {
+  region  = "us-east-1"
+  profile = "production"  # Optional: use specific profile
+}
+```
+
+Or set environment variable:
+```bash
+export AWS_PROFILE=production
+terraform apply
+```
+
+## Required Permissions
+
+For Aviatrix blueprints, you typically need permissions to create:
+- VPCs, Subnets, Route Tables
+- EC2 instances, Security Groups
+- IAM roles (for EKS, Aviatrix gateways)
+- EKS clusters (for Kubernetes blueprints)
+- Various other services depending on the blueprint
+
+See each blueprint's README for specific IAM requirements.
+
+## Troubleshooting
+
+### Credentials not found
+
+```
+Unable to locate credentials
+```
+
+Solutions:
+1. Run `aws configure` to set up credentials
+2. Verify credentials file exists: `cat ~/.aws/credentials`
+3. Check environment variables: `env | grep AWS`
+
+### Invalid credentials
+
+```
+An error occurred (InvalidClientTokenId)
+```
+
+Solutions:
+1. Verify access key is correct
+2. Check if key has been deactivated in IAM console
+3. Regenerate credentials if needed
+
+### Region not specified
+
+```
+You must specify a region
+```
+
+Solutions:
+1. Run `aws configure` and set default region
+2. Set environment variable: `export AWS_DEFAULT_REGION=us-east-1`
+3. Specify in command: `aws ec2 describe-instances --region us-east-1`
+
+### SSL certificate errors
+
+```
+SSL validation failed
+```
+
+Solutions:
+1. Update CA certificates on your system
+2. Check for proxy interference
+3. As last resort (not recommended): `aws --no-verify-ssl ...`
+
+## Resources
+
+- [AWS CLI Documentation](https://docs.aws.amazon.com/cli/latest/userguide/)
+- [AWS CLI Configuration](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+- [IAM Best Practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html)

--- a/docs/prerequisites/azure-cli.md
+++ b/docs/prerequisites/azure-cli.md
@@ -1,0 +1,324 @@
+# Azure CLI Installation Guide
+
+The Azure CLI is required for deploying blueprints to Microsoft Azure. This guide covers installation and configuration on macOS and Windows.
+
+## Version Requirements
+
+- **Minimum version**: 2.50.0
+- **Recommended**: Latest stable version
+
+## Installation
+
+### macOS
+
+#### Using Homebrew (Recommended)
+
+```bash
+# Install Azure CLI
+brew install azure-cli
+
+# Verify installation
+az --version
+```
+
+#### Using Official Script
+
+```bash
+# Install using the official script
+curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+
+# Verify installation
+az --version
+```
+
+### Windows
+
+#### Using MSI Installer (Recommended)
+
+1. Download the installer: [Azure CLI MSI](https://aka.ms/installazurecliwindows)
+2. Run the downloaded MSI installer
+3. Follow the installation wizard
+4. Open a new Command Prompt or PowerShell
+5. Verify: `az --version`
+
+#### Using Chocolatey
+
+```powershell
+# Install Azure CLI
+choco install azure-cli
+
+# Verify installation
+az --version
+```
+
+#### Using winget
+
+```powershell
+# Install Azure CLI
+winget install Microsoft.AzureCLI
+
+# Verify installation
+az --version
+```
+
+#### Using PowerShell
+
+```powershell
+# Install Azure CLI
+Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile .\AzureCLI.msi
+Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'
+Remove-Item .\AzureCLI.msi
+
+# Restart PowerShell, then verify
+az --version
+```
+
+### Linux
+
+#### Ubuntu/Debian
+
+```bash
+# Get packages needed for install
+sudo apt-get update
+sudo apt-get install ca-certificates curl apt-transport-https lsb-release gnupg
+
+# Download and install Microsoft signing key
+curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
+
+# Add Azure CLI repository
+AZ_REPO=$(lsb_release -cs)
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
+
+# Install
+sudo apt-get update
+sudo apt-get install azure-cli
+
+# Verify
+az --version
+```
+
+#### RHEL/CentOS/Fedora
+
+```bash
+# Import Microsoft repository key
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+
+# Add repository
+sudo dnf install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
+
+# Install
+sudo dnf install azure-cli
+
+# Verify
+az --version
+```
+
+## Authentication
+
+### Interactive Login (Recommended for Development)
+
+```bash
+# Login interactively - opens browser
+az login
+
+# Verify login
+az account show
+```
+
+### Service Principal (Recommended for Automation)
+
+Create a service principal for Terraform and automated deployments:
+
+```bash
+# Create service principal with Contributor role
+az ad sp create-for-rbac \
+  --name "aviatrix-blueprints-sp" \
+  --role Contributor \
+  --scopes /subscriptions/<subscription-id>
+```
+
+Output:
+```json
+{
+  "appId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "displayName": "aviatrix-blueprints-sp",
+  "password": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "tenant": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+```
+
+Save these values for Terraform configuration.
+
+### Login with Service Principal
+
+```bash
+az login --service-principal \
+  --username <appId> \
+  --password <password> \
+  --tenant <tenant>
+```
+
+## Configuration
+
+### Set Default Subscription
+
+```bash
+# List subscriptions
+az account list --output table
+
+# Set default subscription
+az account set --subscription "<subscription-name-or-id>"
+
+# Verify
+az account show
+```
+
+### Set Default Location
+
+```bash
+# Configure default location
+az config set defaults.location=eastus
+
+# Or use environment variable
+export AZURE_DEFAULTS_LOCATION=eastus
+```
+
+## Verification
+
+```bash
+# Check CLI version
+az --version
+
+# Verify authentication
+az account show
+
+# Test resource access
+az group list --output table
+```
+
+## Terraform Integration
+
+### Using Azure CLI Authentication
+
+Terraform can use your Azure CLI credentials directly:
+
+```hcl
+provider "azurerm" {
+  features {}
+  # Uses Azure CLI credentials automatically
+}
+```
+
+### Using Service Principal
+
+For automation, configure the service principal:
+
+```hcl
+provider "azurerm" {
+  features {}
+
+  subscription_id = var.subscription_id
+  client_id       = var.client_id
+  client_secret   = var.client_secret
+  tenant_id       = var.tenant_id
+}
+```
+
+Or use environment variables:
+```bash
+export ARM_SUBSCRIPTION_ID="<subscription-id>"
+export ARM_CLIENT_ID="<appId>"
+export ARM_CLIENT_SECRET="<password>"
+export ARM_TENANT_ID="<tenant>"
+```
+
+## Required Permissions
+
+For Aviatrix blueprints, the service principal typically needs:
+
+- **Contributor** role on the subscription (or specific resource groups)
+- Additional permissions may be needed for:
+  - Creating service principals (if blueprint creates them)
+  - Managing Azure AD resources
+  - Network Contributor for VNet peering
+
+See each blueprint's README for specific permission requirements.
+
+## Troubleshooting
+
+### Login fails in browser
+
+```bash
+# Use device code flow instead
+az login --use-device-code
+```
+
+### Subscription not found
+
+```bash
+# List all accessible subscriptions
+az account list --all --output table
+
+# Check if logged into correct tenant
+az account show
+```
+
+### Permission denied
+
+1. Verify service principal has required role
+2. Check role assignment scope (subscription vs resource group)
+3. Wait a few minutes - role assignments can take time to propagate
+
+### Token expired
+
+```bash
+# Clear cached tokens and re-login
+az account clear
+az login
+```
+
+### SSL/TLS errors
+
+```bash
+# Update CA certificates
+# macOS
+brew install ca-certificates
+
+# Ubuntu
+sudo apt-get update && sudo apt-get install ca-certificates
+
+# Or disable verification (not recommended)
+az config set core.disable_confirm_prompt=yes
+```
+
+## Managing Multiple Tenants
+
+```bash
+# Login to specific tenant
+az login --tenant <tenant-id>
+
+# List all tenants
+az account tenant list
+
+# Switch between subscriptions in different tenants
+az account set --subscription <subscription-id>
+```
+
+## Useful Commands
+
+| Command | Description |
+|---------|-------------|
+| `az login` | Interactive login |
+| `az logout` | Log out |
+| `az account list` | List subscriptions |
+| `az account show` | Show current subscription |
+| `az account set -s <sub>` | Set subscription |
+| `az group list` | List resource groups |
+| `az vm list` | List virtual machines |
+| `az network vnet list` | List virtual networks |
+
+## Resources
+
+- [Azure CLI Documentation](https://docs.microsoft.com/en-us/cli/azure/)
+- [Azure CLI Reference](https://docs.microsoft.com/en-us/cli/azure/reference-index)
+- [Azure Provider for Terraform](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs)

--- a/docs/prerequisites/cloudshell.md
+++ b/docs/prerequisites/cloudshell.md
@@ -1,0 +1,57 @@
+# Cloud Shell Guide
+
+> **Note**: This guide is a placeholder for future content. Cloud Shell provides browser-based command-line access with pre-installed tools.
+
+## Overview
+
+Cloud shells are browser-based terminal environments provided by cloud vendors. They come pre-configured with common tools, making them useful when you can't install tools locally.
+
+## Available Cloud Shells
+
+### AWS CloudShell
+
+- **URL**: Available from AWS Console (top navigation bar)
+- **Pre-installed**: AWS CLI, Python, Node.js, git
+- **Not included**: Terraform (must be installed manually)
+- **Storage**: 1 GB persistent storage in home directory
+- **Limitations**: Only works with AWS services
+
+### Azure Cloud Shell
+
+- **URL**: [shell.azure.com](https://shell.azure.com) or Azure Portal
+- **Pre-installed**: Azure CLI, Terraform, kubectl, Python, git
+- **Storage**: 5 GB persistent Azure Files storage
+- **Modes**: Bash or PowerShell
+
+### Google Cloud Shell
+
+- **URL**: [shell.cloud.google.com](https://shell.cloud.google.com) or GCP Console
+- **Pre-installed**: gcloud CLI, Terraform, kubectl, Python, git
+- **Storage**: 5 GB persistent home directory
+- **Features**: Web preview, code editor
+
+## Using Cloud Shell with Blueprints
+
+### Basic Workflow
+
+1. Open Cloud Shell for your target provider
+2. Clone the blueprints repository
+3. Navigate to your chosen blueprint
+4. Configure variables and deploy
+
+### Considerations
+
+- **Multi-cloud**: Cloud shells are typically limited to their own provider
+- **Session timeout**: Shells may disconnect after idle period
+- **Tool versions**: Pre-installed tools may not match required versions
+- **Terraform state**: Stored in Cloud Shell storage (ephemeral for some providers)
+
+## Detailed Setup Guides
+
+*Coming soon: Detailed guides for using each cloud shell with Aviatrix Blueprints.*
+
+## Resources
+
+- [AWS CloudShell Documentation](https://docs.aws.amazon.com/cloudshell/)
+- [Azure Cloud Shell Documentation](https://docs.microsoft.com/en-us/azure/cloud-shell/)
+- [Google Cloud Shell Documentation](https://cloud.google.com/shell/docs)

--- a/docs/prerequisites/gcloud-cli.md
+++ b/docs/prerequisites/gcloud-cli.md
@@ -1,0 +1,372 @@
+# Google Cloud CLI Installation Guide
+
+The Google Cloud CLI (gcloud) is required for deploying blueprints to Google Cloud Platform. This guide covers installation and configuration on macOS and Windows.
+
+## Version Requirements
+
+- **Minimum version**: 400.0.0
+- **Recommended**: Latest stable version
+
+## Installation
+
+### macOS
+
+#### Using Homebrew (Recommended)
+
+```bash
+# Install Google Cloud SDK
+brew install google-cloud-sdk
+
+# Verify installation
+gcloud --version
+```
+
+#### Using Official Installer
+
+```bash
+# Download the installer
+curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-darwin-arm.tar.gz
+
+# For Intel Macs:
+# curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-darwin-x86_64.tar.gz
+
+# Extract
+tar -xf google-cloud-cli-darwin-*.tar.gz
+
+# Install
+./google-cloud-sdk/install.sh
+
+# Initialize (restart terminal first)
+gcloud init
+
+# Verify
+gcloud --version
+```
+
+### Windows
+
+#### Using Official Installer (Recommended)
+
+1. Download: [Google Cloud CLI Installer](https://dl.google.com/dl/cloudsdk/channels/rapid/GoogleCloudSDKInstaller.exe)
+2. Run the installer
+3. Follow the installation wizard
+4. Check "Run gcloud init" at the end
+5. Complete the initialization in the terminal
+
+#### Using Chocolatey
+
+```powershell
+# Install Google Cloud SDK
+choco install gcloudsdk
+
+# Initialize
+gcloud init
+
+# Verify
+gcloud --version
+```
+
+### Linux
+
+#### Ubuntu/Debian
+
+```bash
+# Add Cloud SDK distribution URI as package source
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+
+# Import Google Cloud public key
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+
+# Install
+sudo apt-get update && sudo apt-get install google-cloud-cli
+
+# Initialize
+gcloud init
+
+# Verify
+gcloud --version
+```
+
+#### RHEL/CentOS/Fedora
+
+```bash
+# Add repository
+sudo tee -a /etc/yum.repos.d/google-cloud-sdk.repo << EOM
+[google-cloud-cli]
+name=Google Cloud CLI
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOM
+
+# Install
+sudo dnf install google-cloud-cli
+
+# Initialize
+gcloud init
+
+# Verify
+gcloud --version
+```
+
+## Authentication
+
+### Interactive Login (Development)
+
+```bash
+# Initialize and authenticate
+gcloud init
+
+# Or just authenticate
+gcloud auth login
+```
+
+This opens a browser for Google account authentication.
+
+### Application Default Credentials (Terraform)
+
+For local development with Terraform:
+
+```bash
+# Set up application default credentials
+gcloud auth application-default login
+```
+
+### Service Account (Automation)
+
+For automated deployments and CI/CD:
+
+1. **Create a service account** in GCP Console:
+   - Go to IAM & Admin > Service Accounts
+   - Create Service Account
+   - Grant required roles (see permissions section)
+   - Create and download JSON key
+
+2. **Activate service account**:
+```bash
+# Activate with key file
+gcloud auth activate-service-account --key-file=path/to/key.json
+
+# Or set environment variable
+export GOOGLE_APPLICATION_CREDENTIALS="path/to/key.json"
+```
+
+## Configuration
+
+### Initialize gcloud
+
+```bash
+gcloud init
+```
+
+This walks you through:
+1. Logging in
+2. Selecting a project
+3. Setting default region/zone
+
+### Set Default Project
+
+```bash
+# List projects
+gcloud projects list
+
+# Set default project
+gcloud config set project PROJECT_ID
+
+# Verify
+gcloud config get project
+```
+
+### Set Default Region/Zone
+
+```bash
+# Set default region
+gcloud config set compute/region us-central1
+
+# Set default zone
+gcloud config set compute/zone us-central1-a
+
+# View all configuration
+gcloud config list
+```
+
+### Manage Configurations
+
+Use configurations to manage multiple projects/accounts:
+
+```bash
+# Create a new configuration
+gcloud config configurations create my-project
+
+# Activate configuration
+gcloud config configurations activate my-project
+
+# List configurations
+gcloud config configurations list
+```
+
+## Verification
+
+```bash
+# Check version
+gcloud --version
+
+# Verify authentication
+gcloud auth list
+
+# Check current project
+gcloud config get project
+
+# Test access
+gcloud compute instances list
+```
+
+## Terraform Integration
+
+### Using Application Default Credentials
+
+```hcl
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  # Uses application default credentials automatically
+}
+```
+
+### Using Service Account Key
+
+```hcl
+provider "google" {
+  credentials = file("path/to/service-account-key.json")
+  project     = var.project_id
+  region      = var.region
+}
+```
+
+### Using Environment Variables
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS="path/to/key.json"
+export GOOGLE_PROJECT="my-project-id"
+export GOOGLE_REGION="us-central1"
+```
+
+```hcl
+provider "google" {
+  # Uses environment variables
+}
+```
+
+## Required Permissions
+
+For Aviatrix blueprints, the service account typically needs:
+
+- **Compute Admin** (`roles/compute.admin`) - VPCs, instances, firewalls
+- **Service Account User** (`roles/iam.serviceAccountUser`) - For using service accounts
+- **Kubernetes Engine Admin** (`roles/container.admin`) - For GKE blueprints
+
+Create a custom role or use predefined roles:
+
+```bash
+# Grant roles to service account
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="serviceAccount:SA_EMAIL" \
+  --role="roles/compute.admin"
+```
+
+## Additional Components
+
+Install additional components as needed:
+
+```bash
+# List available components
+gcloud components list
+
+# Install kubectl
+gcloud components install kubectl
+
+# Install GKE authentication plugin
+gcloud components install gke-gcloud-auth-plugin
+
+# Update all components
+gcloud components update
+```
+
+## Troubleshooting
+
+### Authentication errors
+
+```bash
+# Clear cached credentials
+gcloud auth revoke --all
+
+# Re-authenticate
+gcloud auth login
+
+# For application default credentials
+gcloud auth application-default revoke
+gcloud auth application-default login
+```
+
+### Project not set
+
+```
+ERROR: (gcloud) The project property must be set
+```
+
+```bash
+# Set project
+gcloud config set project YOUR_PROJECT_ID
+```
+
+### API not enabled
+
+```
+ERROR: API [compute.googleapis.com] not enabled
+```
+
+```bash
+# Enable required APIs
+gcloud services enable compute.googleapis.com
+gcloud services enable container.googleapis.com
+gcloud services enable cloudresourcemanager.googleapis.com
+```
+
+### Quota exceeded
+
+Check and request quota increases in the GCP Console:
+- Go to IAM & Admin > Quotas
+- Filter by the specific quota
+- Request increase
+
+### SSL certificate errors
+
+```bash
+# Update CA certificates
+# macOS
+brew install ca-certificates
+
+# Ubuntu
+sudo apt-get update && sudo apt-get install ca-certificates
+```
+
+## Useful Commands
+
+| Command | Description |
+|---------|-------------|
+| `gcloud init` | Initialize configuration |
+| `gcloud auth login` | Interactive login |
+| `gcloud auth list` | List authenticated accounts |
+| `gcloud projects list` | List accessible projects |
+| `gcloud config list` | Show current configuration |
+| `gcloud compute instances list` | List VMs |
+| `gcloud compute networks list` | List VPCs |
+| `gcloud container clusters list` | List GKE clusters |
+
+## Resources
+
+- [Google Cloud CLI Documentation](https://cloud.google.com/sdk/docs)
+- [gcloud Command Reference](https://cloud.google.com/sdk/gcloud/reference)
+- [Google Provider for Terraform](https://registry.terraform.io/providers/hashicorp/google/latest/docs)

--- a/docs/prerequisites/kubectl.md
+++ b/docs/prerequisites/kubectl.md
@@ -1,0 +1,358 @@
+# kubectl Installation Guide
+
+kubectl is the Kubernetes command-line tool required for blueprints that deploy or interact with Kubernetes clusters (EKS, AKS, GKE).
+
+## Version Requirements
+
+- **Version compatibility**: kubectl should be within one minor version of your cluster
+- **Recommended**: Latest stable version
+
+## Installation
+
+### macOS
+
+#### Using Homebrew (Recommended)
+
+```bash
+# Install kubectl
+brew install kubectl
+
+# Verify installation
+kubectl version --client
+```
+
+#### Using Official Binary
+
+```bash
+# Download latest release (Apple Silicon)
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl"
+
+# For Intel Macs:
+# curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl"
+
+# Make executable
+chmod +x ./kubectl
+
+# Move to PATH
+sudo mv ./kubectl /usr/local/bin/kubectl
+
+# Verify
+kubectl version --client
+```
+
+### Windows
+
+#### Using Chocolatey (Recommended)
+
+```powershell
+# Install kubectl
+choco install kubernetes-cli
+
+# Verify installation
+kubectl version --client
+```
+
+#### Using winget
+
+```powershell
+# Install kubectl
+winget install Kubernetes.kubectl
+
+# Verify installation
+kubectl version --client
+```
+
+#### Using Official Binary
+
+```powershell
+# Download (PowerShell)
+curl.exe -LO "https://dl.k8s.io/release/v1.29.0/bin/windows/amd64/kubectl.exe"
+
+# Move to a directory in your PATH, e.g.:
+Move-Item kubectl.exe C:\Windows\System32\kubectl.exe
+
+# Verify
+kubectl version --client
+```
+
+### Linux
+
+#### Using Package Manager
+
+**Ubuntu/Debian:**
+```bash
+# Add Kubernetes apt repository
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+# Install
+sudo apt-get update
+sudo apt-get install kubectl
+
+# Verify
+kubectl version --client
+```
+
+**RHEL/CentOS/Fedora:**
+```bash
+# Add Kubernetes yum repository
+cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.key
+EOF
+
+# Install
+sudo yum install kubectl
+
+# Verify
+kubectl version --client
+```
+
+#### Using Official Binary
+
+```bash
+# Download latest release
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+
+# Make executable
+chmod +x kubectl
+
+# Move to PATH
+sudo mv kubectl /usr/local/bin/
+
+# Verify
+kubectl version --client
+```
+
+## Cloud Provider Integration
+
+### AWS EKS
+
+Install the AWS CLI and configure EKS authentication:
+
+```bash
+# Update kubeconfig for EKS cluster
+aws eks update-kubeconfig --region <region> --name <cluster-name>
+
+# Verify connection
+kubectl get nodes
+```
+
+### Azure AKS
+
+Install the Azure CLI and configure AKS authentication:
+
+```bash
+# Get AKS credentials
+az aks get-credentials --resource-group <resource-group> --name <cluster-name>
+
+# Verify connection
+kubectl get nodes
+```
+
+### Google GKE
+
+Install gcloud CLI and configure GKE authentication:
+
+```bash
+# Install gke-gcloud-auth-plugin (required for GKE)
+gcloud components install gke-gcloud-auth-plugin
+
+# Get GKE credentials
+gcloud container clusters get-credentials <cluster-name> --region <region>
+
+# Verify connection
+kubectl get nodes
+```
+
+## Configuration
+
+### kubeconfig
+
+kubectl uses a configuration file (kubeconfig) to connect to clusters:
+
+- **Default location**: `~/.kube/config`
+- **Override with**: `KUBECONFIG` environment variable
+
+### Multiple Clusters
+
+Manage multiple clusters using contexts:
+
+```bash
+# View all contexts
+kubectl config get-contexts
+
+# Switch context
+kubectl config use-context <context-name>
+
+# View current context
+kubectl config current-context
+```
+
+### Namespace Default
+
+Set a default namespace:
+
+```bash
+kubectl config set-context --current --namespace=<namespace>
+```
+
+## Verification
+
+```bash
+# Check client version
+kubectl version --client
+
+# Check connection to cluster (requires configured kubeconfig)
+kubectl cluster-info
+
+# List nodes
+kubectl get nodes
+
+# List all pods in all namespaces
+kubectl get pods -A
+```
+
+## Shell Completion
+
+Enable tab completion for kubectl:
+
+### Bash
+
+```bash
+# Add to ~/.bashrc
+echo 'source <(kubectl completion bash)' >> ~/.bashrc
+
+# Add alias (optional)
+echo 'alias k=kubectl' >> ~/.bashrc
+echo 'complete -o default -F __start_kubectl k' >> ~/.bashrc
+
+# Reload
+source ~/.bashrc
+```
+
+### Zsh
+
+```bash
+# Add to ~/.zshrc
+echo 'source <(kubectl completion zsh)' >> ~/.zshrc
+
+# Reload
+source ~/.zshrc
+```
+
+### PowerShell
+
+```powershell
+# Add to PowerShell profile
+kubectl completion powershell | Out-String | Invoke-Expression
+```
+
+## Common Commands
+
+| Command | Description |
+|---------|-------------|
+| `kubectl get pods` | List pods |
+| `kubectl get svc` | List services |
+| `kubectl get nodes` | List nodes |
+| `kubectl describe pod <name>` | Pod details |
+| `kubectl logs <pod>` | View pod logs |
+| `kubectl exec -it <pod> -- /bin/sh` | Shell into pod |
+| `kubectl apply -f file.yaml` | Apply configuration |
+| `kubectl delete -f file.yaml` | Delete resources |
+| `kubectl port-forward svc/<name> 8080:80` | Port forward |
+
+## Troubleshooting
+
+### Connection refused
+
+```
+The connection to the server localhost:8080 was refused
+```
+
+kubeconfig is not configured:
+```bash
+# Check kubeconfig
+echo $KUBECONFIG
+cat ~/.kube/config
+
+# For EKS
+aws eks update-kubeconfig --region <region> --name <cluster-name>
+```
+
+### Certificate errors
+
+```
+Unable to connect to the server: x509: certificate
+```
+
+Solutions:
+1. Refresh kubeconfig from cloud provider
+2. Check cluster certificates haven't expired
+3. Verify time synchronization on your machine
+
+### Unauthorized
+
+```
+error: You must be logged in to the server (Unauthorized)
+```
+
+Solutions:
+1. Re-authenticate with cloud provider
+2. Check IAM/RBAC permissions
+3. Refresh credentials:
+```bash
+# AWS
+aws sts get-caller-identity
+aws eks update-kubeconfig --region <region> --name <cluster-name>
+
+# Azure
+az aks get-credentials --resource-group <rg> --name <cluster> --overwrite-existing
+
+# GCP
+gcloud container clusters get-credentials <cluster> --region <region>
+```
+
+### Context not found
+
+```bash
+# List available contexts
+kubectl config get-contexts
+
+# Check kubeconfig file
+cat ~/.kube/config
+```
+
+## Useful Plugins
+
+Consider installing these kubectl plugins via [krew](https://krew.sigs.k8s.io/):
+
+```bash
+# Install krew
+(
+  set -x; cd "$(mktemp -d)" &&
+  OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
+  ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/arm64/arm64/')" &&
+  KREW="krew-${OS}_${ARCH}" &&
+  curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
+  tar zxvf "${KREW}.tar.gz" &&
+  ./"${KREW}" install krew
+)
+
+# Install useful plugins
+kubectl krew install ctx    # Quick context switching
+kubectl krew install ns     # Quick namespace switching
+kubectl krew install neat   # Clean up YAML output
+```
+
+## Resources
+
+- [kubectl Documentation](https://kubernetes.io/docs/reference/kubectl/)
+- [kubectl Cheat Sheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/)
+- [EKS User Guide](https://docs.aws.amazon.com/eks/latest/userguide/)
+- [AKS Documentation](https://docs.microsoft.com/en-us/azure/aks/)
+- [GKE Documentation](https://cloud.google.com/kubernetes-engine/docs)

--- a/docs/prerequisites/terraform.md
+++ b/docs/prerequisites/terraform.md
@@ -1,0 +1,281 @@
+# Terraform Installation Guide
+
+Terraform is required for deploying all Aviatrix Blueprints. This guide covers installation on macOS, Windows, and Linux.
+
+## Version Requirements
+
+- **Minimum version**: 1.5.0
+- **Recommended**: Latest stable version
+
+Check blueprint README files for specific version requirements.
+
+## Installation
+
+### macOS
+
+#### Using Homebrew (Recommended)
+
+```bash
+# Install Homebrew if not already installed
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Install Terraform
+brew tap hashicorp/tap
+brew install hashicorp/tap/terraform
+
+# Verify installation
+terraform version
+```
+
+#### Manual Installation
+
+```bash
+# Download (replace VERSION with desired version)
+curl -LO https://releases.hashicorp.com/terraform/1.7.0/terraform_1.7.0_darwin_arm64.zip
+
+# For Intel Macs, use darwin_amd64 instead
+# curl -LO https://releases.hashicorp.com/terraform/1.7.0/terraform_1.7.0_darwin_amd64.zip
+
+# Extract
+unzip terraform_*.zip
+
+# Move to PATH
+sudo mv terraform /usr/local/bin/
+
+# Verify
+terraform version
+```
+
+### Windows
+
+#### Using Chocolatey (Recommended)
+
+```powershell
+# Install Chocolatey if not already installed (run as Administrator)
+Set-ExecutionPolicy Bypass -Scope Process -Force
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+# Install Terraform
+choco install terraform
+
+# Verify installation
+terraform version
+```
+
+#### Using winget
+
+```powershell
+winget install Hashicorp.Terraform
+
+# Verify installation
+terraform version
+```
+
+#### Manual Installation
+
+1. Download from [terraform.io/downloads](https://www.terraform.io/downloads)
+2. Extract the ZIP file
+3. Move `terraform.exe` to a directory in your PATH
+4. Or add the extraction directory to your PATH:
+   ```powershell
+   # Add to PATH (PowerShell, run as Administrator)
+   [Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\terraform", "Machine")
+   ```
+
+### Linux
+
+#### Ubuntu/Debian
+
+```bash
+# Add HashiCorp GPG key
+wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+
+# Add repository
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+
+# Install
+sudo apt update && sudo apt install terraform
+
+# Verify
+terraform version
+```
+
+#### RHEL/CentOS/Fedora
+
+```bash
+# Add repository
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
+
+# Install
+sudo yum -y install terraform
+
+# Verify
+terraform version
+```
+
+#### Amazon Linux 2
+
+```bash
+# Add repository
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo
+
+# Install
+sudo yum -y install terraform
+
+# Verify
+terraform version
+```
+
+## Verification
+
+After installation, verify Terraform is working:
+
+```bash
+# Check version
+terraform version
+
+# Expected output:
+# Terraform v1.7.0
+# on darwin_arm64
+
+# Check help
+terraform -help
+```
+
+## Managing Multiple Versions
+
+For managing multiple Terraform versions, consider using a version manager:
+
+### tfenv (macOS/Linux)
+
+```bash
+# Install tfenv
+brew install tfenv
+
+# List available versions
+tfenv list-remote
+
+# Install specific version
+tfenv install 1.5.7
+tfenv install 1.7.0
+
+# Switch versions
+tfenv use 1.7.0
+
+# Set default version
+tfenv use 1.7.0
+echo "1.7.0" > ~/.tfenv/version
+```
+
+### tfswitch (macOS/Linux)
+
+```bash
+# Install tfswitch
+brew install warrensbox/tap/tfswitch
+
+# Run in project directory to auto-select version
+tfswitch
+
+# Or specify version
+tfswitch 1.7.0
+```
+
+## Configuration
+
+### Enable Tab Completion (Optional)
+
+#### Bash
+
+```bash
+terraform -install-autocomplete
+# Restart shell or source ~/.bashrc
+```
+
+#### Zsh
+
+```bash
+terraform -install-autocomplete
+# Restart shell or source ~/.zshrc
+```
+
+### Provider Plugin Cache (Recommended)
+
+Speed up `terraform init` by caching providers:
+
+```bash
+# Create cache directory
+mkdir -p ~/.terraform.d/plugin-cache
+
+# Add to shell profile (~/.bashrc, ~/.zshrc, etc.)
+export TF_PLUGIN_CACHE_DIR="$HOME/.terraform.d/plugin-cache"
+```
+
+## Common Commands
+
+| Command | Description |
+|---------|-------------|
+| `terraform init` | Initialize working directory |
+| `terraform plan` | Preview changes |
+| `terraform apply` | Apply changes |
+| `terraform destroy` | Destroy resources |
+| `terraform fmt` | Format code |
+| `terraform validate` | Validate configuration |
+| `terraform output` | Show outputs |
+| `terraform state list` | List resources in state |
+
+## Troubleshooting
+
+### Command not found
+
+Ensure Terraform is in your PATH:
+
+```bash
+# Check PATH
+echo $PATH
+
+# Find terraform location
+which terraform
+
+# On Windows
+where terraform
+```
+
+### Provider download fails
+
+Check network connectivity and proxy settings:
+
+```bash
+# Set proxy if needed
+export HTTP_PROXY=http://proxy:port
+export HTTPS_PROXY=http://proxy:port
+```
+
+### Permission denied
+
+On Linux/macOS, ensure the binary is executable:
+
+```bash
+chmod +x /usr/local/bin/terraform
+```
+
+### Version conflicts
+
+If a blueprint requires a specific version:
+
+```bash
+# Check required version in versions.tf
+cat versions.tf
+
+# Use tfenv or tfswitch to install that version
+tfenv install 1.5.7
+tfenv use 1.5.7
+```
+
+## Resources
+
+- [Terraform Documentation](https://developer.hashicorp.com/terraform/docs)
+- [Terraform CLI Documentation](https://developer.hashicorp.com/terraform/cli)
+- [Aviatrix Terraform Provider](https://registry.terraform.io/providers/AviatrixSystems/aviatrix/latest/docs)


### PR DESCRIPTION
## Summary

- Initialize complete repository structure for Aviatrix Blueprints
- Add comprehensive documentation and standards
- Add Claude Code integration with MCP server recommendations
- Add blueprint template and GitHub CI/CD

## Changes

### Root Files
- `README.md` - Main overview with blueprint catalog and quick start
- `CONTRIBUTING.md` - Contribution guidelines with Claude Code + MCP setup
- `CLAUDE.md` - Project instructions for AI-assisted development
- `LICENSE` - Apache 2.0
- `.gitignore` - Excludes tfstate, local settings, credentials

### Documentation (`docs/`)
- `getting-started.md` - Step-by-step deployment guide
- `blueprint-standards.md` - Required README sections for all blueprints
- `prerequisites/` - Installation guides for:
  - Aviatrix Control Plane (with links to official docs)
  - Terraform
  - AWS/Azure/GCP CLIs
  - kubectl
  - Cloud Shell (placeholder)

### Blueprint Template (`blueprints/_template/`)
- Complete Terraform structure (main.tf, variables.tf, outputs.tf, versions.tf)
- Documented README template with all required sections
- terraform.tfvars.example with commented configuration

### Claude Code Integration (`.claude/`)
- MCP server configuration example (GitHub, Terraform, Playwright, Serena)
- Skill definitions:
  - `/analyze-blueprint` - Generate resource lists and prerequisites
  - `/validate-blueprint` - Check standards compliance
  - `/test-blueprint` - End-to-end deployment testing

### GitHub Templates (`.github/`)
- PR template with blueprint checklist
- Issue templates (bug report, feature request, new blueprint request)
- CI workflow for Terraform fmt/validate

## Test Plan

- [x] Terraform template passes `terraform fmt -check`
- [x] Terraform template passes `terraform validate`
- [x] All documentation links verified
- [ ] Review rendered markdown on GitHub

🤖 Generated with [Claude Code](https://claude.ai/code)