### PR TITLE
Standardize Gatus polling interval to 60s

### DIFF
--- a/blueprints/aws-eks-multicluster/k8s-apps/backend/gatus.yaml
+++ b/blueprints/aws-eks-multicluster/k8s-apps/backend/gatus.yaml
@@ -13,14 +13,14 @@ data:
       - name: "Prod Database"
         group: "Internal"
         url: "http://db.aws.aviatrixdemo.local"
-        interval: 5s
+        interval: 60s
         conditions:
           - "[STATUS] == 200"
           - "[RESPONSE_TIME] < 300"
       - name: "Frontend Service"
         group: "Internal"
         url: "http://frontend.aws.aviatrixdemo.local:8080"
-        interval: 5s
+        interval: 60s
         conditions:
           - "[STATUS] == 200"
           - "[RESPONSE_TIME] < 500"
@@ -62,13 +62,13 @@ data:
       - name: "GeoBlock - Iran"
         group: "Threats"
         url: "icmp://www.irna.ir"
-        interval: 30s
+        interval: 60s
         conditions: ["[CONNECTED] == true"]
 
       - name: "Threat Feed - Malicious IP"
         group: "Threats"
         url: "icmp://102.130.117.167"
-        interval: 30s
+        interval: 60s
         conditions: ["[CONNECTED] == true"]
 
     ui:

--- a/blueprints/aws-eks-multicluster/k8s-apps/frontend/gatus.yaml
+++ b/blueprints/aws-eks-multicluster/k8s-apps/frontend/gatus.yaml
@@ -13,14 +13,14 @@ data:
       - name: "Prod Database"
         group: "Internal"
         url: "http://db.aws.aviatrixdemo.local"
-        interval: 5s
+        interval: 60s
         conditions:
           - "[STATUS] == 200"
           - "[RESPONSE_TIME] < 300"
       - name: "Backend Service"
         group: "Internal"
         url: "http://backend.aws.aviatrixdemo.local:8080"
-        interval: 5s
+        interval: 60s
         conditions:
           - "[STATUS] == 200"
           - "[RESPONSE_TIME] < 500"
@@ -62,13 +62,13 @@ data:
       - name: "GeoBlock - Iran"
         group: "Threats"
         url: "icmp://www.irna.ir"
-        interval: 30s
+        interval: 60s
         conditions: ["[CONNECTED] == true"]
 
       - name: "Threat Feed - Malicious IP"
         group: "Threats"
         url: "icmp://102.130.117.167"
-        interval: 30s
+        interval: 60s
         conditions: ["[CONNECTED] == true"]
 
     ui:


### PR DESCRIPTION
## Summary
- Normalizes all Gatus endpoint check intervals to 60s in both frontend and backend configs
- Internal endpoints were at 5s and threat endpoints at 30s, which is unnecessarily aggressive for a demo environment
- Egress endpoints were already at 60s, so this brings everything in line

## Test plan
- [ ] Deploy the blueprint and verify Gatus dashboards still load
- [ ] Confirm all endpoint checks execute at the 60s interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)