### PR TITLE
Remove hardcoded Controller IAM role ARN from cluster layers

### DIFF
--- a/blueprints/aws-eks-multicluster/README.md
+++ b/blueprints/aws-eks-multicluster/README.md
@@ -122,6 +122,8 @@ terraform apply -var-file=var.tfvars
 # 2. Deploy frontend cluster (~10-15 min)
 cd ../clusters/frontend/
 terraform init
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars — set aviatrix_controller_role_arn to your Controller's IAM role ARN
 terraform apply
 
 # 3. Deploy frontend nodes (~7-10 min)
@@ -138,6 +140,8 @@ kubectl get nodes  # Should show 2 Ready nodes
 # 5. Deploy backend cluster (~10-15 min)
 cd ../backend/
 terraform init
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars — set aviatrix_controller_role_arn to your Controller's IAM role ARN
 terraform apply
 
 # 6. Deploy backend nodes (~7-10 min)
@@ -258,8 +262,18 @@ The cluster layer creates the EKS control plane, security groups, OIDC provider,
 ```bash
 cd ../clusters/frontend/
 
-# Initialize and deploy cluster (~10-15 minutes)
+# Initialize Terraform
 terraform init
+
+# Create your variable file
+cp terraform.tfvars.example terraform.tfvars
+
+# Edit terraform.tfvars:
+# - aviatrix_controller_role_arn: Your Aviatrix Controller's IAM role ARN
+#   (e.g., arn:aws:iam::123456789012:role/aviatrix-role-app)
+vim terraform.tfvars
+
+# Deploy cluster (~10-15 minutes)
 terraform apply
 ```
 
@@ -399,8 +413,18 @@ kube-system   kube-proxy-xmt8f                                1/1     Running   
 ```bash
 cd ../backend/
 
-# Initialize and deploy cluster (~10-15 minutes)
+# Initialize Terraform
 terraform init
+
+# Create your variable file
+cp terraform.tfvars.example terraform.tfvars
+
+# Edit terraform.tfvars:
+# - aviatrix_controller_role_arn: Your Aviatrix Controller's IAM role ARN
+#   (same value used for the frontend cluster)
+vim terraform.tfvars
+
+# Deploy cluster (~10-15 minutes)
 terraform apply
 ```
 

--- a/blueprints/aws-eks-multicluster/clusters/backend/terraform.tfvars.example
+++ b/blueprints/aws-eks-multicluster/clusters/backend/terraform.tfvars.example
@@ -1,0 +1,10 @@
+# Aviatrix Controller IAM Role ARN
+# This is the IAM role your Aviatrix Controller assumes to access AWS resources.
+# Replace ACCOUNT_ID with your AWS account ID and adjust the role name if different.
+aviatrix_controller_role_arn = "arn:aws:iam::ACCOUNT_ID:role/aviatrix-role-app"
+
+# AWS Configuration (defaults to us-east-2)
+# aws_region = "us-east-2"
+
+# Kubernetes version (defaults to 1.34)
+# kubernetes_version = "1.34"

--- a/blueprints/aws-eks-multicluster/clusters/backend/variables.tf
+++ b/blueprints/aws-eks-multicluster/clusters/backend/variables.tf
@@ -11,7 +11,6 @@ variable "kubernetes_version" {
 }
 
 variable "aviatrix_controller_role_arn" {
-  description = "IAM role ARN used by Aviatrix Controller to access EKS clusters"
+  description = "IAM role ARN used by Aviatrix Controller to access EKS clusters (e.g., arn:aws:iam::ACCOUNT_ID:role/aviatrix-role-app)"
   type        = string
-  default     = "arn:aws:iam::538591868388:role/aviatrix-role-app"
 }

--- a/blueprints/aws-eks-multicluster/clusters/frontend/terraform.tfvars.example
+++ b/blueprints/aws-eks-multicluster/clusters/frontend/terraform.tfvars.example
@@ -1,0 +1,10 @@
+# Aviatrix Controller IAM Role ARN
+# This is the IAM role your Aviatrix Controller assumes to access AWS resources.
+# Replace ACCOUNT_ID with your AWS account ID and adjust the role name if different.
+aviatrix_controller_role_arn = "arn:aws:iam::ACCOUNT_ID:role/aviatrix-role-app"
+
+# AWS Configuration (defaults to us-east-2)
+# aws_region = "us-east-2"
+
+# Kubernetes version (defaults to 1.34)
+# kubernetes_version = "1.34"

--- a/blueprints/aws-eks-multicluster/clusters/frontend/variables.tf
+++ b/blueprints/aws-eks-multicluster/clusters/frontend/variables.tf
@@ -11,7 +11,6 @@ variable "kubernetes_version" {
 }
 
 variable "aviatrix_controller_role_arn" {
-  description = "IAM role ARN used by Aviatrix Controller to access EKS clusters"
+  description = "IAM role ARN used by Aviatrix Controller to access EKS clusters (e.g., arn:aws:iam::ACCOUNT_ID:role/aviatrix-role-app)"
   type        = string
-  default     = "arn:aws:iam::538591868388:role/aviatrix-role-app"
 }

--- a/blueprints/aws-eks-multicluster/terraform.tfvars.example
+++ b/blueprints/aws-eks-multicluster/terraform.tfvars.example
@@ -22,3 +22,8 @@ node_group_config = {
 
 # DNS Configuration
 route53_private_zone_name = "aws.aviatrixdemo.local"
+
+# Aviatrix Controller IAM Role ARN
+# This is the IAM role your Aviatrix Controller assumes to access AWS resources.
+# Replace ACCOUNT_ID with your AWS account ID and adjust the role name if different.
+aviatrix_controller_role_arn = "arn:aws:iam::ACCOUNT_ID:role/aviatrix-role-app"


### PR DESCRIPTION
## Summary\n\n- Remove hardcoded `arn:aws:iam::538591868388:role/aviatrix-role-app` default from `aviatrix_controller_role_arn` in both `clusters/frontend/variables.tf` and `clusters/backend/variables.tf`\n- Add `terraform.tfvars.example` to both cluster directories so users can provide their own Controller IAM role ARN\n- Update README quickstart and detailed deployment guide with `terraform.tfvars` setup instructions for cluster layers\n- Add `aviatrix_controller_role_arn` to root `terraform.tfvars.example`\n\n## Motivation\n\nThe blueprint was non-portable because it hardcoded a specific AWS account's IAM role ARN as the default. Users deploying to different AWS accounts would silently use the wrong role, causing Aviatrix Controller onboarding failures.\n\n## Test plan\n\n- [ ] Verify `terraform validate` passes in both cluster directories (requires providing the variable)\n- [ ] Confirm `terraform plan` prompts for `aviatrix_controller_role_arn` when no tfvars is provided\n- [ ] Deploy with a valid Controller role ARN and confirm EKS onboarding succeeds\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.ai/code)"