### PR TITLE
Add azure-aks-multicluster blueprint

### DIFF
--- a/blueprints/azure-aks-multicluster/README.md
+++ b/blueprints/azure-aks-multicluster/README.md
@@ -1,0 +1,1059 @@
+# Multi-Cluster AKS with Aviatrix Transit Architecture
+
+This blueprint deploys a multi-cluster Kubernetes environment on Azure with Aviatrix transit networking, demonstrating Distributed Cloud Firewall (DCF) for Kubernetes capabilities.
+
+> [!TIP]
+> **Optimized for Claude Code** — Run `/deploy-blueprint` for AI-guided deployment with prerequisite checks and automated orchestration, or `/analyze-blueprint` for resource and cost details. [Get Claude Code](https://claude.ai/code)
+
+---
+
+## Prerequisites
+
+Before deploying this infrastructure, ensure you have the following prerequisites in place.
+
+### Aviatrix Infrastructure
+
+| Component | Requirement | Notes |
+|-----------|-------------|-------|
+| **Aviatrix Controller** | Version compatible with provider ~> 8.2 | Must be deployed and accessible |
+| **Aviatrix CoPilot** | Recommended | Required for DCF visualization and SmartGroups UI |
+| **Azure Account Onboarded** | Account registered in Controller | Use the exact account name in `terraform.tfvars` |
+
+### Local Tools
+
+| Tool | Version | Installation | Purpose |
+|------|---------|--------------|---------|
+| **Terraform** | >= 1.5 | [Install Guide](https://developer.hashicorp.com/terraform/install) | Infrastructure provisioning |
+| **Azure CLI** | Latest | [Install Guide](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) | Azure authentication and AKS kubectl auth |
+| **kubectl** | Latest | [Install Guide](https://kubernetes.io/docs/tasks/tools/) | Kubernetes cluster interaction |
+| **Helm** | >= 3.x | [Install Guide](https://helm.sh/docs/intro/install/) | Kubernetes package management (used by Terraform Helm provider) |
+
+### Azure Service Principal Permissions
+
+The Azure service principal used must have permissions to create and manage:
+
+- **AKS**: Clusters, node pools, managed identities, OIDC issuers
+- **Virtual Network**: VNets, subnets, route tables, UDRs, network security groups
+- **Application Gateway**: Standard_v2 gateways, public IP addresses
+- **Role Assignments**: Managed identity role assignments (Network Contributor, route table permissions)
+- **Private DNS**: Private DNS zones, virtual network links, record sets
+- **Compute**: Virtual machines (DB test VM), managed disks
+
+The built-in **Contributor** role at the subscription scope is sufficient for a lab environment. For production, scope permissions to the target resource group.
+
+#### Azure Region Naming
+
+The Aviatrix provider and the Azure provider use different region name formats. Both must be specified:
+
+| Variable | Format | Example |
+|----------|--------|---------|
+| `azure_region` | azurerm lowercase | `eastus2` |
+| `aviatrix_azure_region` | Aviatrix display name | `East US 2` |
+
+---
+
+## Architecture Overview
+
+```
+Internet
+   │
+   ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  Azure Application Gateways (Standard_v2)                        │
+│  frontend-appgw (172.x.x.x:80)   backend-appgw (52.x.x.x:80)   │
+│  Layer 7 reverse proxy — terminates TCP, no asymmetric routing   │
+└─────────────────┬──────────────────────────┬─────────────────────┘
+                  │                          │
+         ┌────────▼────────┐       ┌─────────▼───────┐
+         │  Frontend VNet  │       │  Backend VNet    │
+         │  10.10.0.0/23   │       │  10.20.0.0/23   │
+         │                 │       │                  │
+         │ NGINX LB        │       │ NGINX LB         │
+         │ 10.10.0.200     │       │ 10.20.0.200      │
+         │    │            │       │    │             │
+         │ AKS frontend    │       │ AKS backend      │
+         │ (Cilium CNI)    │       │ (Cilium CNI)     │
+         │ pod: 100.64/16  │       │ pod: 100.64/16   │
+         │                 │       │                  │
+         │ Aviatrix Spoke  │       │ Aviatrix Spoke   │
+         │ Gateway         │       │ Gateway          │
+         └────────┬────────┘       └────────┬─────────┘
+                  │  Aviatrix Transit Fabric  │
+                  └──────────┬───────────────┘
+                             │
+              ┌──────────────▼──────────────┐
+              │  Aviatrix Transit Gateway    │
+              │  Transit VNet 10.2.0.0/20   │
+              └──────────────┬──────────────┘
+                             │
+              ┌──────────────▼──────────────┐
+              │  DB Spoke VNet 10.5.0.0/22  │
+              │  Linux test VM              │
+              │  db.azure.aviatrixdemo.local │
+              └─────────────────────────────┘
+```
+
+### Why Application Gateway Instead of a Public Load Balancer
+
+AKS clusters are configured with `outbound_type = "userDefinedRouting"` — all egress from node and system subnets flows through a `0.0.0.0/0 → VirtualAppliance (Aviatrix Spoke GW)` UDR. A public Azure Load Balancer (Layer 4) causes asymmetric routing: internet traffic arrives at the LB, but return traffic from pods exits through the UDR and arrives at the client from the Aviatrix GW IP — not the LB IP — so TCP drops it.
+
+Azure Application Gateway (Layer 7) terminates the TCP connection and opens a new one to the NGINX internal LB. All response traffic is VNet-internal (AppGW → NGINX → AppGW → client) and never touches the UDR. No asymmetric routing.
+
+### Traffic Flow (Internet → Gatus)
+
+```
+Internet client
+  → AppGW public IP :80
+  → NGINX internal LB (10.x.0.200) :80        [VNet-internal, no UDR]
+  → Gatus pod :8080                            [VNet-internal, no UDR]
+  ← response back to AppGW                    [VNet-internal, no UDR]
+  ← AppGW sends response to internet client
+```
+
+### Pod Networking (Cilium Overlay)
+
+Both clusters use **Azure CNI Powered by Cilium** with an RFC 6598 overlay CIDR (`100.64.0.0/16`) for pod IPs. This CIDR is the same across both clusters — overlapping by design. Aviatrix spoke gateways SNAT pod IPs to the spoke GW private IP before forwarding to transit, allowing the overlapping pod CIDRs to coexist without routing conflicts.
+
+---
+
+## Directory Structure
+
+```
+azure-aks-multicluster/
+├── network/                    # Layer 1: Network foundation
+│   ├── main.tf                 # Transit, spoke GWs, VNets, AppGWs, DB VM, DNS zone
+│   ├── variables.tf
+│   ├── outputs.tf              # VNet IDs, subnet IDs, AppGW IPs, NGINX LB IPs
+│   ├── versions.tf
+│   └── modules/
+│       ├── aks-vnet/           # VNet + subnet module (nodes, system, Aviatrix GW subnets)
+│       └── linux-vm/           # Linux test VM module (DB spoke)
+│
+├── clusters/
+│   ├── frontend/               # Layer 2: Frontend AKS control plane
+│   │   ├── main.tf             # AKS cluster, managed identities, role assignments, OIDC
+│   │   ├── data.tf             # Read network state
+│   │   ├── variables.tf
+│   │   ├── outputs.tf
+│   │   └── versions.tf
+│   │
+│   └── backend/                # Layer 2: Backend AKS control plane (parallel)
+│
+├── nodes/
+│   ├── frontend/               # Layer 3: Frontend node pool and Helm add-ons
+│   │   ├── main.tf             # Node pool configuration
+│   │   ├── helm.tf             # NGINX Ingress, ExternalDNS, Aviatrix k8s-firewall
+│   │   ├── data.tf             # Read network + cluster state
+│   │   ├── variables.tf
+│   │   ├── outputs.tf
+│   │   └── versions.tf
+│   │
+│   └── backend/                # Layer 3: Backend node pool and Helm add-ons (parallel)
+│
+├── k8s-apps/                   # Layer 4: Kubernetes application manifests (kubectl apply)
+│   ├── frontend/               # Gatus health dashboard — Frontend cluster
+│   │   └── gatus.yaml
+│   ├── backend/                # Gatus health dashboard — Backend cluster
+│   │   └── gatus.yaml
+│   └── dcf-crd/                # DCF Kubernetes CRD policy examples
+│       ├── firewallpolicy-infosec.yaml
+│       └── webgrouppolicy-dev.yaml
+│
+└── terraform.tfvars.example    # Variable reference with deployment instructions
+```
+
+### State Dependencies
+
+```
+network/terraform.tfstate
+    │
+    ├── clusters/frontend/terraform.tfstate
+    │       │
+    │       └── nodes/frontend/terraform.tfstate
+    │
+    └── clusters/backend/terraform.tfstate
+            │
+            └── nodes/backend/terraform.tfstate
+```
+
+Each layer reads the previous layer's state via `data "terraform_remote_state" "local"` data sources. All state is local — no remote backend is used.
+
+---
+
+## Complete Deployment Guide
+
+> **Note:** Complete all items in the [Prerequisites](#prerequisites) section before proceeding.
+
+### Step 1: Set Environment Variables
+
+```bash
+# Aviatrix Controller credentials
+export AVIATRIX_CONTROLLER_IP="<controller-ip>"
+export AVIATRIX_USERNAME="<username>"
+export AVIATRIX_PASSWORD="<password>"
+
+# Azure Service Principal credentials
+export ARM_SUBSCRIPTION_ID="<subscription-id>"
+export ARM_TENANT_ID="<tenant-id>"
+export ARM_CLIENT_ID="<client-id>"
+export ARM_CLIENT_SECRET="<client-secret>"
+
+# Verify Azure access
+az account show
+```
+
+### Step 2: Deploy Network Infrastructure
+
+The network layer creates the Aviatrix transit/spoke topology, VNets with subnets and UDRs, Application Gateways, Azure Private DNS zone, and the DB test VM.
+
+```bash
+cd network/
+
+# Initialize Terraform
+terraform init -upgrade
+
+# Create your variable file
+cp ../terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars — set at minimum:
+#   name_prefix                 (e.g., "aks-demo")
+#   aviatrix_azure_account_name (your Azure account name in Aviatrix Controller)
+#   azure_region                (e.g., "eastus2")
+#   aviatrix_azure_region       (e.g., "East US 2")
+vim terraform.tfvars
+
+# Deploy network infrastructure (~15-20 minutes)
+# AppGW provisioning takes ~7 minutes
+terraform apply
+```
+
+**What's created:**
+- Aviatrix Transit Gateway (transit VNet `10.2.0.0/20`, FireNet-enabled)
+- Frontend VNet (`10.10.0.0/23`) with Aviatrix spoke gateway and UDR
+- Backend VNet (`10.20.0.0/23`) with Aviatrix spoke gateway and UDR
+- DB spoke VNet (`10.5.0.0/22`) with Linux test VM (Apache)
+- Frontend Application Gateway (Standard_v2, public IP, backends to `10.10.0.200`)
+- Backend Application Gateway (Standard_v2, public IP, backends to `10.20.0.200`)
+- Azure Private DNS zone (`azure.aviatrixdemo.local`) linked to all VNets
+- Static DNS A record `db.azure.aviatrixdemo.local` → DB VM IP
+- DCF SmartGroups, WebGroups, and firewall policy ruleset
+
+> **AppGW backend health:** After the network apply, the Application Gateway backends will show as **Unhealthy** until Step 5 (nodes) configures NGINX on the static IP. This is expected.
+
+### Step 3: Deploy Frontend AKS Cluster
+
+The cluster layer creates the AKS control plane, user-assigned managed identities, Workload Identity federation for ExternalDNS, and the necessary role assignments for UDR management.
+
+```bash
+cd ../clusters/frontend/
+
+# Initialize Terraform
+terraform init
+
+# Create variable file (copy from network, same values apply)
+cp ../../terraform.tfvars.example terraform.tfvars
+# Verify or adjust:
+#   azure_region        (default: eastus2)
+#   kubernetes_version  (default: 1.32)
+#   authorized_ip_ranges (add your IP: run "curl -s ifconfig.me")
+vim terraform.tfvars
+
+# Deploy cluster (~10-15 minutes)
+terraform apply
+```
+
+**What's created:**
+- AKS cluster (Azure CNI Powered by Cilium, `outbound_type = "userDefinedRouting"`)
+- System node pool (initial sizing; replaced by managed pool in Layer 3)
+- User-assigned managed identity for AKS cluster
+- User-assigned managed identity for ExternalDNS (Workload Identity)
+- Federated credential for ExternalDNS Workload Identity
+- Role assignments: Network Contributor on frontend VNet, route table write access
+- OIDC issuer enabled for Workload Identity
+
+### Step 4: Deploy Backend AKS Cluster (Parallel with Step 3)
+
+```bash
+cd ../backend/
+
+# Initialize Terraform
+terraform init
+
+# Deploy cluster (~10-15 minutes)
+terraform apply
+```
+
+**What's created:** Same as the frontend cluster, scoped to the backend VNet.
+
+Steps 3 and 4 can run in parallel in separate terminals.
+
+### Step 5: Deploy Frontend Node Pool and Add-ons
+
+The node layer adds the managed user node pool and installs Helm charts: NGINX Ingress Controller (internal LB at static IP `10.10.0.200`), ExternalDNS (Azure Private DNS), and Aviatrix k8s-firewall (DCF CRDs).
+
+```bash
+cd ../../nodes/frontend/
+
+# Initialize Terraform
+terraform init
+
+# Deploy node pool and Helm charts (~7-10 minutes)
+terraform apply
+```
+
+**What's created:**
+- AKS user node pool (Standard_D2s_v3, autoscale min=1 max=3)
+- NGINX Ingress Controller — internal Azure LB at `10.10.0.200` in the `frontend-system` subnet
+- ExternalDNS — creates Private DNS A records for annotated Services and Ingresses
+- Aviatrix k8s-firewall — installs `FirewallPolicy` and `WebGroupPolicy` CRDs
+
+After this step, the frontend AppGW backend probe will become **Healthy** within ~60 seconds.
+
+### Step 6: Deploy Backend Node Pool and Add-ons (Parallel with Step 5)
+
+```bash
+cd ../backend/
+
+# Initialize Terraform
+terraform init
+
+# Deploy node pool and Helm charts (~7-10 minutes)
+terraform apply
+```
+
+**What's created:** Same as frontend nodes, with NGINX at `10.20.0.200` in the `backend-system` subnet.
+
+Steps 5 and 6 can run in parallel in separate terminals.
+
+### Step 7: Configure kubectl for Both Clusters
+
+```bash
+# Frontend cluster
+az aks get-credentials \
+  --resource-group <name_prefix>-frontend-rg \
+  --name <name_prefix>-frontend \
+  --context frontend \
+  --overwrite-existing
+
+# Backend cluster
+az aks get-credentials \
+  --resource-group <name_prefix>-backend-rg \
+  --name <name_prefix>-backend \
+  --context backend \
+  --overwrite-existing
+
+# Verify both clusters are reachable
+kubectl get nodes --context frontend
+kubectl get nodes --context backend
+```
+
+**Expected output:**
+```
+NAME                             STATUS   ROLES    AGE   VERSION
+aks-system-35398034-vmss000001   Ready    <none>   10m   v1.32.x
+```
+
+You can also retrieve the exact command from Terraform output:
+```bash
+cd clusters/frontend/
+terraform output kubectl_config_command
+```
+
+**Verify NGINX is on the internal LB (not a public IP):**
+```bash
+kubectl get svc -n ingress-nginx --context frontend
+# EXTERNAL-IP should be 10.10.0.200
+
+kubectl get svc -n ingress-nginx --context backend
+# EXTERNAL-IP should be 10.20.0.200
+```
+
+**Verify AppGW backend health:**
+```bash
+az network application-gateway show-backend-health \
+  --resource-group <name_prefix>-frontend-rg \
+  --name <name_prefix>-frontend-appgw \
+  --query "backendAddressPools[0].backendHttpSettingsCollection[0].servers[0].health" -o tsv
+# Expected: Healthy
+```
+
+**Verify DCF CRDs are installed:**
+```bash
+kubectl get crd firewallpolicies.networking.aviatrix.com --context frontend
+kubectl get crd webgrouppolicies.networking.aviatrix.com --context frontend
+```
+
+### Step 8: Deploy Gatus Monitoring Dashboards
+
+Gatus is deployed as a Kubernetes manifest (not Terraform-managed), applied directly with kubectl.
+
+```bash
+# Frontend cluster
+kubectl apply -f k8s-apps/frontend/gatus.yaml --context frontend
+
+# Backend cluster
+kubectl apply -f k8s-apps/backend/gatus.yaml --context backend
+
+# Verify pods are running
+kubectl get pods -n gatus --context frontend
+kubectl get pods -n gatus --context backend
+```
+
+**Expected output (both clusters):**
+```
+NAME                       READY   STATUS    RESTARTS   AGE
+frontend-776574778b-8ptph   1/1     Running   0          60s
+frontend-776574778b-x6ccv   1/1     Running   0          60s
+```
+
+**Get the Application Gateway public IPs to access Gatus:**
+```bash
+cd network/
+terraform output frontend_appgw_public_ip
+terraform output backend_appgw_public_ip
+```
+
+Open `http://<frontend_appgw_public_ip>/` and `http://<backend_appgw_public_ip>/` in a browser. Each shows a Gatus dashboard titled "Frontend Cluster" or "Backend Cluster" respectively.
+
+---
+
+## Test Scenarios
+
+### Scenario 1: Internet Access via Application Gateway
+
+Verify the AppGW → NGINX → Gatus path is working end-to-end.
+
+```bash
+# Get AppGW public IPs
+FRONTEND_IP=$(cd network/ && terraform output -raw frontend_appgw_public_ip)
+BACKEND_IP=$(cd network/ && terraform output -raw backend_appgw_public_ip)
+
+# Test HTTP response
+curl -s -o /dev/null -w "%{http_code}" http://$FRONTEND_IP/
+# Expected: 200
+
+curl -s -o /dev/null -w "%{http_code}" http://$BACKEND_IP/
+# Expected: 200
+```
+
+### Scenario 2: East-West Connectivity (Cross-Cluster via Aviatrix Transit)
+
+Gatus on each cluster monitors the other cluster's service over port 8080. Verify these endpoints show green in the Gatus dashboard.
+
+**Frontend Gatus monitors:**
+- `http://db.azure.aviatrixdemo.local` (DB VM in DB spoke)
+- `http://backend.azure.aviatrixdemo.local:8080` (Gatus in backend cluster)
+
+**Backend Gatus monitors:**
+- `http://db.azure.aviatrixdemo.local` (DB VM in DB spoke)
+- `http://frontend.azure.aviatrixdemo.local:8080` (Gatus in frontend cluster)
+
+You can also test manually:
+```bash
+# From a debug pod in the frontend cluster, reach the backend service
+kubectl run -it --rm debug --image=nicolaka/netshoot --restart=Never \
+  --context frontend -- curl -s http://backend.azure.aviatrixdemo.local:8080/health
+# Expected: HTTP 200
+```
+
+### Scenario 3: DCF Egress Policy — Allowed Domains
+
+Gatus monitors several allowed egress endpoints. Verify these show green:
+
+- `https://kubernetes.io` (kubernetes_io WebGroup)
+- `https://github.com/AviatrixSystems/terraform-provider-aviatrix` (github_aviatrix WebGroup)
+- `https://registry.npmjs.org` (npm_registry WebGroup)
+
+### Scenario 4: DCF Threat Blocking — GeoBlock and ThreatIQ
+
+Gatus monitors two threat endpoints that **should be blocked** by DCF. They appear as red/failed in the dashboard, which is the correct behavior:
+
+- `icmp://www.irna.ir` — GeoBlock (Iran)
+- `icmp://102.130.117.167` — ThreatGuard feed IP
+
+> **Note:** The threat IP `102.130.117.167` must be present in your active Aviatrix ThreatGuard feed for blocking to work. If your feed differs, verify and update the IP in `k8s-apps/frontend/gatus.yaml` and `k8s-apps/backend/gatus.yaml`.
+
+### Scenario 5: DCF CRD-Based Policies
+
+Apply example CRD policies to test Kubernetes-native policy management:
+
+```bash
+# Apply the InfoSec namespace FirewallPolicy (allows VirusTotal access for pods labeled app=infosec)
+kubectl apply -f k8s-apps/dcf-crd/firewallpolicy-infosec.yaml --context frontend
+
+# Apply the Dev namespace WebGroupPolicy (allows broader package registry access for dev pods)
+kubectl apply -f k8s-apps/dcf-crd/webgrouppolicy-dev.yaml --context frontend
+
+# Verify policies are accepted
+kubectl get firewallpolicies -n gatus --context frontend
+kubectl get webgrouppolicies -n dev --context frontend
+```
+
+### Scenario 6: Private DNS Resolution
+
+ExternalDNS creates Private DNS records for Gatus Services and Ingresses. Verify DNS resolution works across clusters:
+
+```bash
+# From a debug pod in the frontend cluster, resolve the backend DNS name
+kubectl run -it --rm debug --image=nicolaka/netshoot --restart=Never \
+  --context frontend -- nslookup backend.azure.aviatrixdemo.local
+# Expected: resolves to 10.20.x.x (backend NGINX LB IP)
+
+# Verify ExternalDNS created the records
+az network private-dns record-set list \
+  --resource-group <name_prefix>-shared-rg \
+  --zone-name azure.aviatrixdemo.local \
+  --output table
+```
+
+---
+
+## How It Works
+
+### Azure CNI Powered by Cilium
+
+Both clusters use Azure CNI Powered by Cilium with a Cilium overlay pod CIDR (`100.64.0.0/16`, RFC 6598). This is different from the AWS EKS blueprint which uses VPC CNI with ENIConfig for secondary CIDR pod networking.
+
+Key differences from standard AKS networking:
+- Pod IPs (`100.64.x.x`) are **not routable** in the Azure VNet — they exist only in the Cilium overlay
+- `outbound_type = "userDefinedRouting"` routes all egress through the Aviatrix spoke gateway UDR
+- `single_ip_snat = true` on spoke gateways SNATs all pod traffic (including `100.64.x.x`) to the spoke GW private IP before forwarding to transit
+- Azure does **not** expose a `cilium-config` ConfigMap for this managed mode — Cilium is fully Azure-managed, so no additional Cilium configuration is required in Terraform
+
+**Pod traffic flow (cross-cluster):**
+```
+Frontend Pod (100.64.x.x)
+  → frontend-system subnet
+  → UDR: 0.0.0.0/0 → Frontend Aviatrix Spoke GW
+  → Spoke GW SNATs 100.64.x.x → 10.10.0.4 (spoke GW private IP)
+  → Aviatrix Transit
+  → Backend Aviatrix Spoke GW
+  → Backend service/LB (10.20.x.x)
+  → Backend Pod (100.64.y.y)
+```
+
+**Why pod CIDR is excluded from transit advertisements:**
+The transit gateway is configured with `excluded_advertised_spoke_routes = "100.64.0.0/16"`. Since both clusters use the same pod CIDR, advertising it from both spokes would create an ambiguous route. The SNAT on each spoke GW ensures transit only sees the unique spoke GW IP as the source.
+
+### Workload Identity (vs. IRSA on EKS)
+
+Instead of AWS IRSA (IAM Roles for Service Accounts), Azure uses Workload Identity with OIDC federation. Terraform creates:
+1. A user-assigned managed identity for ExternalDNS
+2. A federated credential linking the identity to the AKS OIDC issuer and the `external-dns` Kubernetes ServiceAccount
+3. A role assignment granting the identity Private DNS Zone Contributor on the DNS zone
+
+No credentials are stored in the cluster. The `azure.json` file mounted by ExternalDNS uses `useWorkloadIdentityExtension: true`.
+
+### Application Gateway + NGINX Internal LB Pattern
+
+The blueprint avoids asymmetric routing caused by the Aviatrix UDR through a two-tier ingress architecture:
+
+| Component | Type | IP | Purpose |
+|-----------|------|----|---------|
+| Application Gateway | Internet-facing, Layer 7 | Public (dynamic) | Terminates internet TCP connections |
+| NGINX Ingress Controller | Internal, Layer 7 | Private, static (`10.x.0.200`) | Kubernetes ingress routing |
+
+The AppGW subnet (`10.x.0.64/26`) intentionally has **no UDR associated**. AppGW management traffic (GatewayManager service tag, ports 65200–65535) must reach the Azure platform directly. Attaching the Aviatrix UDR to the AppGW subnet breaks AppGW provisioning.
+
+### Aviatrix Distributed Cloud Firewall (DCF)
+
+The network layer provisions a complete DCF policy ruleset. Policies are enforced at the spoke gateways — DCF inspects the original pod source IPs (pre-SNAT) for inbound traffic decisions.
+
+**SmartGroups:**
+
+| Name | Type | Selector |
+|------|------|----------|
+| `frontend-vnet` | CIDR | `10.10.0.0/23` |
+| `backend-vnet` | CIDR | `10.20.0.0/23` |
+| `db-vnet` | CIDR | `10.5.0.0/22` |
+| `all-aks-clusters` | CIDR union | Both AKS VNets |
+| `frontend-service` | Hostname | `frontend.azure.aviatrixdemo.local` |
+| `backend-service` | Hostname | `backend.azure.aviatrixdemo.local` |
+| `database` | Hostname | `db.azure.aviatrixdemo.local` |
+| `geo-blocked` | Geo feed | Country: Iran |
+| `threat-intel` | Threat feed | Aviatrix ThreatGuard |
+
+**WebGroups (domain-based egress filtering):**
+
+| Name | Domains |
+|------|---------|
+| `azure-required` | `*.microsoft.com`, `*.azure.com`, `*.azurecr.io`, `mcr.microsoft.com`, `*.blob.core.windows.net`, `*.azmk8s.io`, Ubuntu/Debian repos, and more |
+| `kubernetes-io` | `kubernetes.io`, `*.kubernetes.io` |
+| `docker-hub` | `registry-1.docker.io`, `*.docker.io`, `auth.docker.io` |
+| `npm-registry` | `registry.npmjs.org`, `*.npmjs.org` |
+| `github-aviatrix` | `github.com/AviatrixSystems/*`, `api.github.com` |
+
+**DCF Rule Priority Summary:**
+
+| Priority | Rule | Action |
+|----------|------|--------|
+| 0 | Block geo-blocked sources | Deny |
+| 1 | Block ThreatGuard IPs | Deny |
+| 10–15 | East-west TCP (port 8080) between clusters and DB | Permit |
+| 20 | AKS-required HTTPS egress (azure-required + kubernetes-io + docker-hub) | Permit |
+| 21 | AKS-required HTTP egress (Ubuntu/Debian apt repos) | Permit |
+| 30–33 | Additional egress: npm, GitHub Aviatrix paths | Permit |
+| 50–99 | Reserved for Aviatrix k8s-firewall CRD-injected rules | Dynamic |
+
+### Kubernetes CRD-Based Firewall Policies
+
+The Aviatrix k8s-firewall Helm chart installs two CRDs in each cluster:
+
+- `firewallpolicies.networking.aviatrix.com` — define per-pod firewall rules using label selectors
+- `webgrouppolicies.networking.aviatrix.com` — define domain-based filtering for labeled pods
+
+These CRDs allow application teams to manage DCF policies as Kubernetes resources, without Terraform access. Policies are synced to Aviatrix SmartGroups and WebGroups automatically by the k8s-firewall controller.
+
+**Example: Allow infosec pods to reach VirusTotal**
+```bash
+kubectl apply -f k8s-apps/dcf-crd/firewallpolicy-infosec.yaml --context frontend
+kubectl get firewallpolicies -n gatus --context frontend
+```
+
+**Example: Allow dev namespace pods to reach additional package registries**
+```bash
+kubectl apply -f k8s-apps/dcf-crd/webgrouppolicy-dev.yaml --context frontend
+kubectl get webgrouppolicies -n dev --context frontend
+```
+
+---
+
+## Day 2 Operations
+
+### Scale Node Pool
+
+```bash
+cd nodes/frontend/
+
+# Edit terraform.tfvars — adjust min_count, max_count, node_count
+vim terraform.tfvars
+
+# Apply changes (~2-3 minutes)
+terraform apply
+```
+
+### Upgrade Kubernetes Version
+
+Upgrade the control plane first, then the node pool:
+
+```bash
+# Step 1: Upgrade control plane
+cd clusters/frontend/
+vim terraform.tfvars  # Update kubernetes_version
+terraform apply
+
+# Step 2: Upgrade node pool
+cd ../../nodes/frontend/
+terraform apply
+# Terraform runs a rolling node replacement
+```
+
+### Add an Additional DNS Record
+
+ExternalDNS manages records automatically via annotations. For a manual static record:
+```bash
+az network private-dns record-set a add-record \
+  --resource-group <name_prefix>-shared-rg \
+  --zone-name azure.aviatrixdemo.local \
+  --record-set-name myservice \
+  --ipv4-address 10.10.0.100
+```
+
+---
+
+## Destroy Instructions
+
+Always destroy in **reverse order**. Kubernetes resources (ingresses, services) must be deleted first so that ExternalDNS can clean up Private DNS records before Terraform removes the DNS zone.
+
+### Step 1: Delete Kubernetes Resources
+
+```bash
+# Frontend cluster
+kubectl delete ingress --all -A --context frontend
+kubectl delete svc -A --field-selector spec.type=LoadBalancer --context frontend
+
+# Backend cluster
+kubectl delete ingress --all -A --context backend
+kubectl delete svc -A --field-selector spec.type=LoadBalancer --context backend
+
+# Wait ~60s for ExternalDNS to remove DNS records
+sleep 60
+
+# Verify DNS records are cleaned up (only db.* should remain as a Terraform-managed record)
+az network private-dns record-set list \
+  --resource-group <name_prefix>-shared-rg \
+  --zone-name azure.aviatrixdemo.local \
+  --output table
+```
+
+### Step 2: Destroy Node Pools (Parallel)
+
+```bash
+# Terminal 1
+cd nodes/frontend/ && terraform destroy
+
+# Terminal 2
+cd nodes/backend/ && terraform destroy
+```
+
+### Step 3: Destroy AKS Clusters (Parallel)
+
+```bash
+# Terminal 1
+cd clusters/frontend/ && terraform destroy
+
+# Terminal 2
+cd clusters/backend/ && terraform destroy
+```
+
+### Step 4: Destroy Network Layer
+
+```bash
+cd network/ && terraform destroy
+```
+
+### Step 5: Clean Up kubectl Contexts (Optional)
+
+```bash
+kubectl config delete-context frontend
+kubectl config delete-context backend
+```
+
+---
+
+## Troubleshooting
+
+### Pods Can't Reach Other Clusters
+
+1. **Check SNAT configuration** in Aviatrix Controller → Gateways → select spoke gateway → Source NAT. Verify `100.64.0.0/16` SNAT entry exists.
+
+2. **Verify the UDR has a route for 0.0.0.0/0:**
+   ```bash
+   az network route-table show \
+     --resource-group <name_prefix>-frontend-rg \
+     --name <name_prefix>-frontend-udr \
+     --query "routes" -o table
+   ```
+
+3. **Test DNS resolution from inside the cluster:**
+   ```bash
+   kubectl run -it --rm debug --image=nicolaka/netshoot --restart=Never \
+     --context frontend -- nslookup backend.azure.aviatrixdemo.local
+   ```
+
+4. **Check Aviatrix spoke gateway connectivity** in CoPilot → Topology, verify both spokes are connected to transit.
+
+### AppGW Backend Shows Unhealthy
+
+The AppGW health probe checks `GET /health HTTP/1.1 Host: health.local` → NGINX → Gatus `/health`.
+
+1. **Verify NGINX is running with the correct internal LB IP:**
+   ```bash
+   kubectl get svc -n ingress-nginx --context frontend
+   # EXTERNAL-IP must be 10.10.0.200, not a public IP or <pending>
+   ```
+
+2. **Verify the Gatus ingress is bound:**
+   ```bash
+   kubectl get ingress -n gatus --context frontend
+   # ADDRESS should be 10.10.0.200
+   ```
+
+3. **Verify Gatus pods are healthy:**
+   ```bash
+   kubectl get pods -n gatus --context frontend
+   # All pods should be 1/1 Running
+   ```
+
+4. **Check NGINX is routing `/health` correctly:**
+   ```bash
+   kubectl run -it --rm debug --image=nicolaka/netshoot --restart=Never \
+     --context frontend -- curl -s http://10.10.0.200/health
+   # Expected: 200 OK
+   ```
+
+5. **Check AppGW backend health detail:**
+   ```bash
+   az network application-gateway show-backend-health \
+     --resource-group <name_prefix>-frontend-rg \
+     --name <name_prefix>-frontend-appgw \
+     --output json
+   ```
+
+### NGINX Ingress Stuck in Pending (No IP Assigned)
+
+If the NGINX ingress controller Service shows `<pending>` for EXTERNAL-IP instead of `10.10.0.200`:
+
+1. **Check AKS has permission to create internal LBs in the system subnet:**
+   ```bash
+   az role assignment list \
+     --assignee <aks-managed-identity-principal-id> \
+     --scope /subscriptions/<sub-id>/resourceGroups/<name_prefix>-frontend-rg \
+     --output table
+   # Should include Network Contributor
+   ```
+
+2. **Check the NGINX controller pod logs:**
+   ```bash
+   kubectl logs -n ingress-nginx \
+     -l app.kubernetes.io/name=ingress-nginx --context frontend --tail=20
+   ```
+
+3. **Verify the subnet name matches the annotation** (`frontend-system`). The subnet must exist in the AKS VNet.
+
+### ExternalDNS Not Creating DNS Records
+
+1. **Check ExternalDNS logs:**
+   ```bash
+   kubectl logs -n kube-system -l app.kubernetes.io/name=external-dns \
+     --context frontend --tail=20
+   ```
+
+2. **Verify Workload Identity is configured correctly:**
+   ```bash
+   kubectl describe sa external-dns -n kube-system --context frontend
+   # Annotations should include azure.workload.identity/client-id
+   ```
+
+3. **Verify the `azure.json` secret is mounted:**
+   ```bash
+   kubectl get secret -n kube-system --context frontend | grep azure
+   ```
+
+### AppGW Provisioning Fails or Times Out
+
+If `terraform apply` on the network layer fails with AppGW-related errors:
+
+1. **Do not associate the Aviatrix UDR with the AppGW subnet.** The AppGW subnet (`frontend-appgw`, `backend-appgw`) must have no route table. Associating the `0.0.0.0/0 → VirtualAppliance` UDR breaks AppGW management plane traffic.
+
+2. **Verify the AppGW subnet does not overlap** with the Aviatrix GW subnet (`10.x.0.0/28`) or the system subnet (`10.x.0.128/25`). AppGW uses `10.x.0.64/26`.
+
+3. **Check subscription quota** for Standard_v2 Application Gateways in the region.
+
+### Terraform Remote State Errors
+
+If a layer fails with `No such file or directory` for a state file:
+
+```
+Error: Failed to read state file
+path = "../../network/terraform.tfstate"
+```
+
+Ensure the previous layer has been successfully applied and its `terraform.tfstate` exists:
+```bash
+ls -la network/terraform.tfstate
+ls -la clusters/frontend/terraform.tfstate
+```
+
+---
+
+## Resource Inventory
+
+### Compute Resources
+
+| Component | Resource Type | Qty | VM Size | Notes |
+|-----------|--------------|-----|---------|-------|
+| **Aviatrix Gateways** | | | | |
+| Transit Gateway | Azure VM | 1 | Standard_B2ms | FireNet-enabled, no HA |
+| Frontend Spoke GW | Azure VM | 1 | Standard_B2ms | Single IP SNAT, no HA |
+| Backend Spoke GW | Azure VM | 1 | Standard_B2ms | Single IP SNAT, no HA |
+| DB Spoke GW | Azure VM | 1 | Standard_B2ms | Single IP SNAT, no HA |
+| **AKS Clusters** | | | | |
+| Frontend Control Plane | AKS | 1 | — | K8s 1.32, Free tier |
+| Backend Control Plane | AKS | 1 | — | K8s 1.32, Free tier |
+| **AKS Node Pools** | | | | |
+| Frontend Node Pool | Azure VMSS | 2 (desired) | Standard_D2s_v3 | min=1, max=3 |
+| Backend Node Pool | Azure VMSS | 2 (desired) | Standard_D2s_v3 | min=1, max=3 |
+| **Test VM** | | | | |
+| DB Linux VM | Azure VM | 1 | Standard_B2s | DB spoke, Apache |
+
+**Total VMs (at desired state):** 10
+
+### Networking Resources
+
+| Component | Qty | Details |
+|-----------|-----|---------|
+| Virtual Networks | 4 | Transit (`10.2.0.0/20`), Frontend (`10.10.0.0/23`), Backend (`10.20.0.0/23`), DB (`10.5.0.0/22`) |
+| Subnets | 14+ | Aviatrix GW (/28), AppGW (/26), System (/25), Nodes (/24) per AKS VNet; GW + VMs in DB VNet |
+| Route Tables (UDR) | 3 | Frontend (nodes + system subnets), Backend (nodes + system subnets), DB |
+| Application Gateways | 2 | Standard_v2, one per AKS VNet |
+| Public IPs | 2 | Standard SKU Static, one per AppGW |
+| Internal Load Balancers | 2 | Standard, NGINX Ingress Controller (managed by AKS) |
+| Private DNS Zone | 1 | `azure.aviatrixdemo.local` |
+| DNS Zone VNet Links | 4 | Linked to all VNets for resolution |
+| Static DNS Records | 1 | `db.azure.aviatrixdemo.local` → DB VM IP |
+
+### Subnet Layout (per AKS VNet, example: Frontend `10.10.0.0/23`)
+
+| Subnet Name | CIDR | Size | Purpose | UDR |
+|-------------|------|------|---------|-----|
+| `frontend-avx-gw` | `10.10.0.0/28` | 16 IPs | Aviatrix spoke gateway | No |
+| `frontend-appgw` | `10.10.0.64/26` | 64 IPs | Application Gateway | **No** (required) |
+| `frontend-system` | `10.10.0.128/25` | 128 IPs | NGINX internal LB, system pods | Yes |
+| `frontend-nodes` | `10.10.1.0/24` | 256 IPs | AKS node VMs | Yes |
+
+---
+
+## Monthly Cost Estimate (East US 2, Pay-as-you-go)
+
+> Prices are pay-as-you-go rates as of March 2026. Actual costs vary with traffic, autoscaling, and reserved instance discounts (up to 40% savings with 1-year reservations). Aviatrix licensing is billed separately and is not included below.
+
+### Compute
+
+| Resource | VM Size | Qty | Hourly Rate | Monthly (730 hrs) |
+|----------|---------|-----|-------------|-------------------|
+| Aviatrix Transit GW | Standard_B2ms | 1 | $0.0832 | $60.74 |
+| Aviatrix Frontend Spoke GW | Standard_B2ms | 1 | $0.0832 | $60.74 |
+| Aviatrix Backend Spoke GW | Standard_B2ms | 1 | $0.0832 | $60.74 |
+| Aviatrix DB Spoke GW | Standard_B2ms | 1 | $0.0832 | $60.74 |
+| AKS Frontend Nodes | Standard_D2s_v3 | 2 | $0.0960 each | $140.16 |
+| AKS Backend Nodes | Standard_D2s_v3 | 2 | $0.0960 each | $140.16 |
+| DB Test VM | Standard_B2s | 1 | $0.0416 | $30.37 |
+| **Subtotal Compute** | | | | **$553.65** |
+
+### AKS Control Plane
+
+| Resource | Tier | Qty | Monthly |
+|----------|------|-----|---------|
+| Frontend AKS Control Plane | Free | 1 | $0.00 |
+| Backend AKS Control Plane | Free | 1 | $0.00 |
+| **Subtotal AKS Control Plane** | | | **$0.00** |
+
+> If you upgrade to Standard tier (SLA-backed): $73.00/cluster/month × 2 = **$146.00/month** additional.
+
+### Application Gateways
+
+| Component | Rate | Qty | Monthly |
+|-----------|------|-----|---------|
+| Standard_v2 fixed rate | $0.246/hr | 2 | $359.16 |
+| Capacity Units (variable, ~1 CU at lab traffic) | $0.008/CU/hr | 2 × 1 CU | $11.68 |
+| **Subtotal Application Gateways** | | | **~$370.84** |
+
+> At higher traffic loads, 1 CU per AppGW is a minimum. Production workloads may consume 2–10 CUs per AppGW, adding $11–$58 per AppGW per month in variable costs.
+
+### Networking
+
+| Resource | Rate | Qty | Monthly |
+|----------|------|-----|---------|
+| Public IP (Standard Static) | $0.005/hr | 2 | $7.30 |
+| Internal Standard LB (NGINX, ≤5 rules) | $0.025/hr | 2 | $36.50 |
+| Private DNS Zone | $0.50/zone | 1 | $0.50 |
+| Private DNS Queries | ~$0.40/1M | ~1M | ~$0.40 |
+| VNets, Subnets, UDRs | Free | — | $0.00 |
+| **Subtotal Networking** | | | **~$44.70** |
+
+### Storage
+
+| Resource | Type | Qty | Monthly |
+|----------|------|-----|---------|
+| AKS Node OS Disks (P10, 128 GiB, LRS) | Premium SSD | 4 | $78.84 |
+| DB VM OS Disk (P6, 64 GiB, LRS) | Premium SSD | 1 | ~$9.87 |
+| **Subtotal Storage** | | | **~$88.71** |
+
+### Data Transfer (Estimated)
+
+| Type | Est. Volume | Rate | Monthly |
+|------|-------------|------|---------|
+| Cross-VNet via Aviatrix transit | ~50 GB | Included in GW | $0.00 |
+| Internet egress (AppGW outbound) | ~20 GB | $0.087/GB | ~$1.74 |
+| AppGW data processing | ~20 GB | $0.008/GB | ~$0.16 |
+| **Subtotal Data Transfer** | | | **~$1.90** |
+
+### Total Monthly Cost Summary
+
+| Category | Monthly Cost |
+|----------|-------------|
+| Compute (VMs) | $553.65 |
+| AKS Control Plane (Free tier) | $0.00 |
+| Application Gateways | ~$370.84 |
+| Networking (IPs, LBs, DNS) | ~$44.70 |
+| Storage (OS disks) | ~$88.71 |
+| Data Transfer | ~$1.90 |
+| **TOTAL (estimated)** | **~$1,060/month** |
+
+### Cost Breakdown
+
+```
+Compute (VMs)            █████████████░░░░░░░░░  52.2%  ($554)
+Application Gateways     ████████░░░░░░░░░░░░░░  35.0%  ($371)
+Storage                  ██░░░░░░░░░░░░░░░░░░░░   8.4%  ($89)
+Networking               █░░░░░░░░░░░░░░░░░░░░░   4.2%  ($45)
+Data Transfer            ░░░░░░░░░░░░░░░░░░░░░░   0.2%  (~$2)
+```
+
+> **Cost reduction options:**
+> - **Azure Reserved Instances (1-year):** ~40% discount on VM and AppGW compute — saves ~$370/month
+> - **AKS Free tier:** Suitable for labs; upgrade to Standard tier ($146/month) only if SLA is required
+> - **Stop when not in use:** AKS clusters and gateways can be stopped; AppGW can be scaled to 0 instances
+> - **AppGW is the dominant non-VM cost** due to the Standard_v2 fixed hourly rate ($0.246/hr regardless of traffic). No cheaper alternative exists for this architecture's asymmetric routing fix.
+
+### Important Cost Exclusions
+
+- **Aviatrix Licensing:** Separate licensing based on deployment type (PAYG via Azure Marketplace or BYOL). Contact Aviatrix for current rates.
+- **Azure Monitor / Log Analytics:** If enabled for AKS diagnostics or AppGW access logs.
+- **Azure Policy:** Enabled on AKS clusters; typically free for built-in policies.
+- **Azure Support:** If not on the free Basic tier.
+
+---
+
+## Networking Details
+
+### CIDR Allocation
+
+| Network | CIDR | Purpose |
+|---------|------|---------|
+| Transit VNet | `10.2.0.0/20` | Aviatrix transit gateway |
+| Frontend VNet | `10.10.0.0/23` | AKS frontend cluster |
+| Backend VNet | `10.20.0.0/23` | AKS backend cluster |
+| DB VNet | `10.5.0.0/22` | Test database spoke |
+| Pod Overlay | `100.64.0.0/16` | Cilium pod IPs (same across all clusters, RFC 6598) |
+| Service CIDR | `172.16.0.0/16` | Kubernetes service IPs |
+| DNS Service IP | `172.16.0.10` | CoreDNS |
+
+### Cilium Configuration
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| Network plugin | `azure` | Azure CNI managed by AKS |
+| Network plugin mode | `overlay` | Cilium overlay for pod IPs |
+| Pod CIDR | `100.64.0.0/16` | RFC 6598, same across all clusters |
+| IP masquerade | Disabled (Azure-managed) | azure-ip-masq-agent excludes `100.64.0.0/16`; Aviatrix SNAT handles the translation. Not configurable via Cilium in this managed mode. |
+| `outboundType` | `userDefinedRouting` | All egress via Aviatrix UDR |
+
+---
+
+## Tested With
+
+| Component | Version |
+|-----------|---------|
+| Terraform | >= 1.5 |
+| Aviatrix Provider | ~> 8.2 |
+| AzureRM Provider | ~> 4.0 |
+| TLS Provider | ~> 4.0 |
+| mc-transit module | ~> 8.0 |
+| mc-spoke module | ~> 8.0 |
+| Kubernetes | 1.32 |
+| NGINX Ingress Chart | 4.12.0 |
+| ExternalDNS Chart | 1.15.x |
+| k8s-firewall Chart | Latest |
+| Gatus | v5.14.0 |
+
+---
+
+## Additional Resources
+
+- [Aviatrix Terraform Provider](https://registry.terraform.io/providers/AviatrixSystems/aviatrix/latest/docs)
+- [Azure CNI Powered by Cilium](https://learn.microsoft.com/en-us/azure/aks/azure-cni-powered-by-cilium)
+- [AKS outboundType userDefinedRouting](https://learn.microsoft.com/en-us/azure/aks/egress-outboundtype)
+- [Azure Application Gateway for AKS](https://learn.microsoft.com/en-us/azure/application-gateway/ingress-controller-overview)
+- [Aviatrix Distributed Cloud Firewall](https://docs.aviatrix.com/documentation/latest/security/dcf-reference-design-guide.html)
+- [Workload Identity on AKS](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview)
+
+## Contributing
+
+When making changes:
+
+1. Always run `terraform fmt -recursive` before committing
+2. Run `terraform validate` in all modified layers
+3. Update this README if architectural decisions change
+4. Test full deploy and destroy before submitting changes
+5. Add new variables to `terraform.tfvars.example` with comments

--- a/blueprints/azure-aks-multicluster/clusters/backend/data.tf
+++ b/blueprints/azure-aks-multicluster/clusters/backend/data.tf
@@ -1,0 +1,8 @@
+data "terraform_remote_state" "network" {
+  backend = "local"
+  config = {
+    path = "../../network/terraform.tfstate"
+  }
+}
+
+data "azurerm_client_config" "current" {}

--- a/blueprints/azure-aks-multicluster/clusters/backend/main.tf
+++ b/blueprints/azure-aks-multicluster/clusters/backend/main.tf
@@ -1,0 +1,129 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  cluster_name = data.terraform_remote_state.network.outputs.backend_cluster_name
+  rg_name      = data.terraform_remote_state.network.outputs.backend_resource_group_name
+  name_prefix  = data.terraform_remote_state.network.outputs.name_prefix
+}
+
+#####################
+# User-Assigned Managed Identity for AKS
+#####################
+
+resource "azurerm_user_assigned_identity" "aks" {
+  name                = "${local.cluster_name}-identity"
+  location            = var.azure_region
+  resource_group_name = local.rg_name
+}
+
+resource "azurerm_role_assignment" "aks_vnet_contributor" {
+  scope                = data.terraform_remote_state.network.outputs.backend_vnet_id
+  role_definition_name = "Network Contributor"
+  principal_id         = azurerm_user_assigned_identity.aks.principal_id
+}
+
+resource "azurerm_role_assignment" "aks_route_table" {
+  scope                = data.terraform_remote_state.network.outputs.backend_route_table_id
+  role_definition_name = "Network Contributor"
+  principal_id         = azurerm_user_assigned_identity.aks.principal_id
+}
+
+#####################
+# ExternalDNS Managed Identity (Workload Identity)
+#####################
+
+resource "azurerm_user_assigned_identity" "external_dns" {
+  name                = "${local.cluster_name}-external-dns"
+  location            = var.azure_region
+  resource_group_name = local.rg_name
+}
+
+resource "azurerm_role_assignment" "external_dns_zone_contributor" {
+  scope                = data.terraform_remote_state.network.outputs.private_dns_zone_id
+  role_definition_name = "Private DNS Zone Contributor"
+  principal_id         = azurerm_user_assigned_identity.external_dns.principal_id
+}
+
+resource "azurerm_role_assignment" "external_dns_rg_reader" {
+  scope                = data.terraform_remote_state.network.outputs.backend_resource_group_id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_user_assigned_identity.external_dns.principal_id
+}
+
+#####################
+# AKS Cluster
+#####################
+
+resource "azurerm_kubernetes_cluster" "aks" {
+  name                = local.cluster_name
+  location            = var.azure_region
+  resource_group_name = local.rg_name
+  dns_prefix          = local.cluster_name
+  kubernetes_version  = var.kubernetes_version
+
+  oidc_issuer_enabled       = true
+  workload_identity_enabled = true
+
+  default_node_pool {
+    name                 = "system"
+    vm_size              = var.node_pool_config.vm_size
+    node_count           = var.node_pool_config.node_count
+    min_count            = var.node_pool_config.min_count
+    max_count            = var.node_pool_config.max_count
+    auto_scaling_enabled = true
+    vnet_subnet_id       = data.terraform_remote_state.network.outputs.backend_nodes_subnet_id
+
+    upgrade_settings {
+      max_surge = "10%"
+    }
+  }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.aks.id]
+  }
+
+  network_profile {
+    network_plugin      = "azure"
+    network_plugin_mode = "overlay"
+    network_policy      = "cilium" # Activates Azure CNI Powered by Cilium (replaces kube-proxy with eBPF)
+
+    pod_cidr = data.terraform_remote_state.network.outputs.pod_cidr
+
+    service_cidr   = data.terraform_remote_state.network.outputs.service_cidr
+    dns_service_ip = data.terraform_remote_state.network.outputs.dns_service_ip
+
+    outbound_type = "userDefinedRouting"
+  }
+
+  api_server_access_profile {
+    authorized_ip_ranges = var.authorized_ip_ranges
+  }
+
+  depends_on = [
+    azurerm_role_assignment.aks_vnet_contributor,
+    azurerm_role_assignment.aks_route_table,
+  ]
+}
+
+resource "azurerm_federated_identity_credential" "external_dns" {
+  name                = "external-dns"
+  resource_group_name = local.rg_name
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+  parent_id           = azurerm_user_assigned_identity.external_dns.id
+  subject             = "system:serviceaccount:kube-system:external-dns"
+}

--- a/blueprints/azure-aks-multicluster/clusters/backend/outputs.tf
+++ b/blueprints/azure-aks-multicluster/clusters/backend/outputs.tf
@@ -1,0 +1,79 @@
+output "cluster_name" {
+  description = "AKS cluster name"
+  value       = azurerm_kubernetes_cluster.aks.name
+}
+
+output "cluster_id" {
+  description = "AKS cluster Azure resource ID"
+  value       = azurerm_kubernetes_cluster.aks.id
+}
+
+output "cluster_fqdn" {
+  description = "AKS API server FQDN"
+  value       = azurerm_kubernetes_cluster.aks.fqdn
+}
+
+output "oidc_issuer_url" {
+  description = "OIDC issuer URL (for Workload Identity federation)"
+  value       = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+}
+
+output "kube_config_raw" {
+  description = "Raw kubeconfig for kubectl access"
+  value       = azurerm_kubernetes_cluster.aks.kube_config_raw
+  sensitive   = true
+}
+
+output "host" {
+  description = "AKS API server URL"
+  value       = azurerm_kubernetes_cluster.aks.kube_config[0].host
+  sensitive   = true
+}
+
+output "client_certificate" {
+  description = "Client certificate for Kubernetes provider auth"
+  value       = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].client_certificate)
+  sensitive   = true
+}
+
+output "client_key" {
+  description = "Client key for Kubernetes provider auth"
+  value       = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].client_key)
+  sensitive   = true
+}
+
+output "cluster_ca_certificate" {
+  description = "Cluster CA certificate"
+  value       = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].cluster_ca_certificate)
+  sensitive   = true
+}
+
+output "resource_group_name" {
+  description = "Resource group containing the AKS cluster"
+  value       = azurerm_kubernetes_cluster.aks.resource_group_name
+}
+
+output "node_resource_group" {
+  description = "Auto-generated resource group for AKS node VMs (MC_...)"
+  value       = azurerm_kubernetes_cluster.aks.node_resource_group
+}
+
+output "kubelet_identity_object_id" {
+  description = "Object ID of the kubelet managed identity"
+  value       = azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id
+}
+
+output "aks_identity_principal_id" {
+  description = "Principal ID of the AKS cluster managed identity"
+  value       = azurerm_user_assigned_identity.aks.principal_id
+}
+
+output "external_dns_client_id" {
+  description = "Client ID of the ExternalDNS managed identity"
+  value       = azurerm_user_assigned_identity.external_dns.client_id
+}
+
+output "kubectl_config_command" {
+  description = "Command to configure kubectl for this cluster"
+  value       = "az aks get-credentials --resource-group ${azurerm_kubernetes_cluster.aks.resource_group_name} --name ${azurerm_kubernetes_cluster.aks.name} --overwrite-existing"
+}

--- a/blueprints/azure-aks-multicluster/clusters/backend/terraform.tfvars.example
+++ b/blueprints/azure-aks-multicluster/clusters/backend/terraform.tfvars.example
@@ -1,0 +1,17 @@
+# Azure region — must match network layer
+azure_region = "eastus2"
+
+# Kubernetes version
+# kubernetes_version = "1.31"
+
+# Node pool sizing
+node_pool_config = {
+  node_count = 2
+  min_count  = 1
+  max_count  = 3
+  vm_size    = "Standard_D2s_v3"
+}
+
+# Restrict API server access to your IP for security (recommended)
+# authorized_ip_ranges = ["<YOUR_IP>/32"]
+authorized_ip_ranges = ["0.0.0.0/0"]

--- a/blueprints/azure-aks-multicluster/clusters/backend/variables.tf
+++ b/blueprints/azure-aks-multicluster/clusters/backend/variables.tf
@@ -1,0 +1,37 @@
+variable "azure_region" {
+  description = "Azure region in azurerm format (e.g., 'eastus2')"
+  type        = string
+  default     = "eastus2"
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version for the AKS cluster"
+  type        = string
+  default     = "1.32"
+}
+
+variable "node_pool_config" {
+  description = "Configuration for the default system node pool"
+  type = object({
+    node_count = number
+    min_count  = number
+    max_count  = number
+    vm_size    = string
+  })
+  default = {
+    node_count = 2
+    min_count  = 1
+    max_count  = 3
+    vm_size    = "Standard_D2s_v3"
+  }
+}
+
+variable "authorized_ip_ranges" {
+  description = <<-EOT
+    IP ranges authorized to access the AKS API server.
+    Add your current public IP (e.g., ["1.2.3.4/32"]).
+    Use ["0.0.0.0/0"] to allow all (not recommended for production).
+  EOT
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}

--- a/blueprints/azure-aks-multicluster/clusters/frontend/data.tf
+++ b/blueprints/azure-aks-multicluster/clusters/frontend/data.tf
@@ -1,0 +1,8 @@
+data "terraform_remote_state" "network" {
+  backend = "local"
+  config = {
+    path = "../../network/terraform.tfstate"
+  }
+}
+
+data "azurerm_client_config" "current" {}

--- a/blueprints/azure-aks-multicluster/clusters/frontend/main.tf
+++ b/blueprints/azure-aks-multicluster/clusters/frontend/main.tf
@@ -1,0 +1,146 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  cluster_name = data.terraform_remote_state.network.outputs.frontend_cluster_name
+  rg_name      = data.terraform_remote_state.network.outputs.frontend_resource_group_name
+  name_prefix  = data.terraform_remote_state.network.outputs.name_prefix
+}
+
+#####################
+# User-Assigned Managed Identity for AKS
+#####################
+
+resource "azurerm_user_assigned_identity" "aks" {
+  name                = "${local.cluster_name}-identity"
+  location            = var.azure_region
+  resource_group_name = local.rg_name
+}
+
+# AKS identity needs Network Contributor on the VNet to manage NICs and load balancers
+resource "azurerm_role_assignment" "aks_vnet_contributor" {
+  scope                = data.terraform_remote_state.network.outputs.frontend_vnet_id
+  role_definition_name = "Network Contributor"
+  principal_id         = azurerm_user_assigned_identity.aks.principal_id
+}
+
+# AKS identity needs to read/write the UDR route table
+resource "azurerm_role_assignment" "aks_route_table" {
+  scope                = data.terraform_remote_state.network.outputs.frontend_route_table_id
+  role_definition_name = "Network Contributor"
+  principal_id         = azurerm_user_assigned_identity.aks.principal_id
+}
+
+#####################
+# ExternalDNS Managed Identity (Workload Identity)
+#####################
+
+resource "azurerm_user_assigned_identity" "external_dns" {
+  name                = "${local.cluster_name}-external-dns"
+  location            = var.azure_region
+  resource_group_name = local.rg_name
+}
+
+# ExternalDNS needs to manage records in the private DNS zone
+resource "azurerm_role_assignment" "external_dns_zone_contributor" {
+  scope                = data.terraform_remote_state.network.outputs.private_dns_zone_id
+  role_definition_name = "Private DNS Zone Contributor"
+  principal_id         = azurerm_user_assigned_identity.external_dns.principal_id
+}
+
+# ExternalDNS also needs Reader on the resource group that contains the DNS zone
+resource "azurerm_role_assignment" "external_dns_rg_reader" {
+  scope                = data.terraform_remote_state.network.outputs.frontend_resource_group_id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_user_assigned_identity.external_dns.principal_id
+}
+
+#####################
+# AKS Cluster
+#####################
+
+resource "azurerm_kubernetes_cluster" "aks" {
+  name                = local.cluster_name
+  location            = var.azure_region
+  resource_group_name = local.rg_name
+  dns_prefix          = local.cluster_name
+  kubernetes_version  = var.kubernetes_version
+
+  # Enable OIDC issuer for Workload Identity (Azure equivalent of IRSA)
+  oidc_issuer_enabled       = true
+  workload_identity_enabled = true
+
+  default_node_pool {
+    name                 = "system"
+    vm_size              = var.node_pool_config.vm_size
+    node_count           = var.node_pool_config.node_count
+    min_count            = var.node_pool_config.min_count
+    max_count            = var.node_pool_config.max_count
+    auto_scaling_enabled = true
+    vnet_subnet_id       = data.terraform_remote_state.network.outputs.frontend_nodes_subnet_id
+
+    upgrade_settings {
+      max_surge = "10%"
+    }
+  }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.aks.id]
+  }
+
+  network_profile {
+    network_plugin      = "azure"
+    network_plugin_mode = "overlay" # Cilium overlay — pod IPs in 100.64.0.0/16 are NOT in the VNet
+    network_policy      = "cilium"  # Activates Azure CNI Powered by Cilium (replaces kube-proxy with eBPF)
+
+    # Pod CIDR: same across both clusters (overlapping by design).
+    # Aviatrix spoke gateway SNATs 100.64.x.x → spoke GW IP for transit routing.
+    # Cilium has enableIPv4Masquerade=false (configured in nodes layer),
+    # so pods send packets with their original 100.64.x.x source IPs to the spoke GW.
+    pod_cidr = data.terraform_remote_state.network.outputs.pod_cidr
+
+    service_cidr   = data.terraform_remote_state.network.outputs.service_cidr
+    dns_service_ip = data.terraform_remote_state.network.outputs.dns_service_ip
+
+    # All egress routes through the Aviatrix spoke gateway via the UDR
+    # pre-associated with the nodes subnet in the network layer.
+    outbound_type = "userDefinedRouting"
+  }
+
+  api_server_access_profile {
+    authorized_ip_ranges = var.authorized_ip_ranges
+  }
+
+  depends_on = [
+    azurerm_role_assignment.aks_vnet_contributor,
+    azurerm_role_assignment.aks_route_table,
+  ]
+}
+
+#####################
+# ExternalDNS Federated Identity Credential
+# Binds the ExternalDNS K8s ServiceAccount to the Azure managed identity.
+# Must be created after the cluster (needs OIDC issuer URL).
+#####################
+
+resource "azurerm_federated_identity_credential" "external_dns" {
+  name                = "external-dns"
+  resource_group_name = local.rg_name
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+  parent_id           = azurerm_user_assigned_identity.external_dns.id
+  subject             = "system:serviceaccount:kube-system:external-dns"
+}

--- a/blueprints/azure-aks-multicluster/clusters/frontend/outputs.tf
+++ b/blueprints/azure-aks-multicluster/clusters/frontend/outputs.tf
@@ -1,0 +1,79 @@
+output "cluster_name" {
+  description = "AKS cluster name"
+  value       = azurerm_kubernetes_cluster.aks.name
+}
+
+output "cluster_id" {
+  description = "AKS cluster Azure resource ID"
+  value       = azurerm_kubernetes_cluster.aks.id
+}
+
+output "cluster_fqdn" {
+  description = "AKS API server FQDN"
+  value       = azurerm_kubernetes_cluster.aks.fqdn
+}
+
+output "oidc_issuer_url" {
+  description = "OIDC issuer URL (for Workload Identity federation)"
+  value       = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+}
+
+output "kube_config_raw" {
+  description = "Raw kubeconfig for kubectl access"
+  value       = azurerm_kubernetes_cluster.aks.kube_config_raw
+  sensitive   = true
+}
+
+output "host" {
+  description = "AKS API server URL (for Kubernetes/Helm providers)"
+  value       = azurerm_kubernetes_cluster.aks.kube_config[0].host
+  sensitive   = true
+}
+
+output "client_certificate" {
+  description = "Client certificate for Kubernetes provider auth"
+  value       = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].client_certificate)
+  sensitive   = true
+}
+
+output "client_key" {
+  description = "Client key for Kubernetes provider auth"
+  value       = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].client_key)
+  sensitive   = true
+}
+
+output "cluster_ca_certificate" {
+  description = "Cluster CA certificate for Kubernetes provider auth"
+  value       = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].cluster_ca_certificate)
+  sensitive   = true
+}
+
+output "resource_group_name" {
+  description = "Resource group containing the AKS cluster"
+  value       = azurerm_kubernetes_cluster.aks.resource_group_name
+}
+
+output "node_resource_group" {
+  description = "Auto-generated resource group for AKS node VMs (MC_...)"
+  value       = azurerm_kubernetes_cluster.aks.node_resource_group
+}
+
+output "kubelet_identity_object_id" {
+  description = "Object ID of the kubelet managed identity (for ACR pull permissions)"
+  value       = azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id
+}
+
+output "aks_identity_principal_id" {
+  description = "Principal ID of the AKS cluster managed identity"
+  value       = azurerm_user_assigned_identity.aks.principal_id
+}
+
+output "external_dns_client_id" {
+  description = "Client ID of the ExternalDNS managed identity (for Workload Identity annotation)"
+  value       = azurerm_user_assigned_identity.external_dns.client_id
+}
+
+output "kubectl_config_command" {
+  description = "Command to configure kubectl for this cluster"
+  value       = "az aks get-credentials --resource-group ${azurerm_kubernetes_cluster.aks.resource_group_name} --name ${azurerm_kubernetes_cluster.aks.name} --overwrite-existing"
+}

--- a/blueprints/azure-aks-multicluster/clusters/frontend/terraform.tfvars.example
+++ b/blueprints/azure-aks-multicluster/clusters/frontend/terraform.tfvars.example
@@ -1,0 +1,18 @@
+# Azure region — must match network layer
+azure_region = "eastus2"
+
+# Kubernetes version
+# kubernetes_version = "1.31"
+
+# Node pool sizing
+node_pool_config = {
+  node_count = 2
+  min_count  = 1
+  max_count  = 3
+  vm_size    = "Standard_D2s_v3"
+}
+
+# Restrict API server access to your IP for security (recommended)
+# Run: curl ifconfig.me  to get your current IP
+# authorized_ip_ranges = ["<YOUR_IP>/32"]
+authorized_ip_ranges = ["0.0.0.0/0"]

--- a/blueprints/azure-aks-multicluster/clusters/frontend/variables.tf
+++ b/blueprints/azure-aks-multicluster/clusters/frontend/variables.tf
@@ -1,0 +1,37 @@
+variable "azure_region" {
+  description = "Azure region in azurerm format (e.g., 'eastus2')"
+  type        = string
+  default     = "eastus2"
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version for the AKS cluster"
+  type        = string
+  default     = "1.32"
+}
+
+variable "node_pool_config" {
+  description = "Configuration for the default system node pool"
+  type = object({
+    node_count = number
+    min_count  = number
+    max_count  = number
+    vm_size    = string
+  })
+  default = {
+    node_count = 2
+    min_count  = 1
+    max_count  = 3
+    vm_size    = "Standard_D2s_v3"
+  }
+}
+
+variable "authorized_ip_ranges" {
+  description = <<-EOT
+    IP ranges authorized to access the AKS API server.
+    Add your current public IP (e.g., ["1.2.3.4/32"]).
+    Use ["0.0.0.0/0"] to allow all (not recommended for production).
+  EOT
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}

--- a/blueprints/azure-aks-multicluster/k8s-apps/backend/gatus.yaml
+++ b/blueprints/azure-aks-multicluster/k8s-apps/backend/gatus.yaml
@@ -1,0 +1,205 @@
+# NOTE: This file uses the domain "azure.aviatrixdemo.local" which must match
+# the private_dns_zone_name variable in the network layer. If you changed
+# that variable, update all occurrences of the domain below.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gatus
+  labels:
+    app.kubernetes.io/part-of: aks-demo
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backend
+  namespace: gatus
+data:
+  config.yaml: |
+    storage:
+      type: memory
+    metrics: true
+    endpoints:
+      # Internal Services — East-West through Aviatrix transit
+      - name: "Prod Database"
+        group: "Internal"
+        url: "http://db.azure.aviatrixdemo.local"
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 300"
+      - name: "Frontend Service"
+        group: "Internal"
+        url: "http://frontend.azure.aviatrixdemo.local:8080"
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 500"
+
+      # Egress - Allowed Traffic (governed by DCF WebGroups)
+      - name: "kubernetes.io"
+        group: "Egress"
+        url: "https://kubernetes.io"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      - name: "github.com/.../terraform-provider-aviatrix"
+        group: "Egress"
+        url: "https://github.com/AviatrixSystems/terraform-provider-aviatrix"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      - name: "github.com/.../avxlabs-docs"
+        group: "Egress"
+        url: "https://github.com/AviatrixSystems/avxlabs-docs"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      - name: "registry.npmjs.org"
+        group: "Egress"
+        url: "https://registry.npmjs.org"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      # Threats - Should be BLOCKED by DCF (GeoBlock + ThreatIQ)
+      - name: "GeoBlock - Iran"
+        group: "Threats"
+        url: "icmp://www.irna.ir"
+        interval: 60s
+        conditions: ["[CONNECTED] == true"]
+
+      # NOTE: This IP must appear in your Aviatrix ThreatGuard feed to be blocked.
+      # Verify against your current threat intelligence feed and replace if needed.
+      - name: "Threat Feed - Malicious IP"
+        group: "Threats"
+        url: "icmp://102.130.117.167"
+        interval: 60s
+        conditions: ["[CONNECTED] == true"]
+
+    ui:
+      logo: "https://aviatrix.com/wp-content/uploads/2019/10/cropped-Aviatrix-Logo@2x-1-32x32.png"
+      header: "Backend Cluster - ${HOSTNAME}"
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backend
+  namespace: gatus
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: gatus
+  labels:
+    app: backend
+    cluster: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      name: backend
+      labels:
+        app: backend
+        cluster: backend
+        # Label used by Aviatrix k8s-firewall controller for DCF SmartGroup targeting
+        aviatrix.com/app: backend
+    spec:
+      serviceAccountName: backend
+      terminationGracePeriodSeconds: 5
+      containers:
+        - image: twinproduction/gatus:v5.14.0
+          imagePullPolicy: IfNotPresent
+          name: backend
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 250m
+              memory: 100M
+            requests:
+              cpu: 50m
+              memory: 30M
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 5
+          volumeMounts:
+            - mountPath: /config
+              name: backend-config
+      volumes:
+        - configMap:
+            name: backend
+          name: backend-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: gatus
+  labels:
+    app: backend
+    service: backend
+  annotations:
+    # Internal Azure Load Balancer — reachable from frontend cluster via Aviatrix transit
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+    # ExternalDNS will create DNS record: backend.azure.aviatrixdemo.local
+    external-dns.alpha.kubernetes.io/hostname: backend.azure.aviatrixdemo.local
+    external-dns.alpha.kubernetes.io/ttl: "60"
+spec:
+  type: LoadBalancer
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: backend
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: backend-ingress
+  namespace: gatus
+  annotations:
+    nginx.ingress.kubernetes.io/healthcheck-path: /health
+    # ExternalDNS will create DNS record: backend-web.azure.aviatrixdemo.local
+    external-dns.alpha.kubernetes.io/hostname: backend-web.azure.aviatrixdemo.local
+    external-dns.alpha.kubernetes.io/ttl: "60"
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8080

--- a/blueprints/azure-aks-multicluster/k8s-apps/dcf-crd/firewallpolicy-infosec.yaml
+++ b/blueprints/azure-aks-multicluster/k8s-apps/dcf-crd/firewallpolicy-infosec.yaml
@@ -1,0 +1,49 @@
+#####################
+# FirewallPolicy CRD Example - InfoSec Namespace
+#
+# This policy demonstrates K8s-native DCF policy management.
+# Pods with label "app: infosec" can access security tools like VirusTotal.
+#
+# Prerequisites:
+#   helm install --repo https://aviatrixsystems.github.io/k8s-firewall-charts k8s-firewall k8s-firewall
+#
+# Apply:
+#   kubectl apply -f firewallpolicy-infosec.yaml
+#
+# Verify:
+#   kubectl get firewallpolicies -n gatus
+#   kubectl get events -n gatus
+#####################
+
+apiVersion: networking.aviatrix.com/v1alpha1
+kind: FirewallPolicy
+metadata:
+  name: infosec-egress
+  namespace: gatus
+spec:
+  rules:
+    - name: allow-virustotal
+      logging: true
+      selector:
+        matchLabels:
+          app: infosec
+      action: permit
+      protocol: tcp
+      ports:
+        - "443"
+      destinationSmartGroups:
+        - name: public-internet
+      webGroups:
+        - name: security-tools
+
+  webGroups:
+    - name: security-tools
+      domains:
+        - "www.virustotal.com"
+        - "virustotal.com"
+        - "*.virustotal.com"
+
+  smartGroups:
+    - name: public-internet
+      selectors:
+        - cidr: 0.0.0.0/0

--- a/blueprints/azure-aks-multicluster/k8s-apps/dcf-crd/webgrouppolicy-dev.yaml
+++ b/blueprints/azure-aks-multicluster/k8s-apps/dcf-crd/webgrouppolicy-dev.yaml
@@ -1,0 +1,50 @@
+#####################
+# WebGroupPolicy CRD Example - Dev Namespace
+#
+# This policy allows pods in the dev namespace to access
+# additional development resources not covered by the base Terraform policy.
+#
+# Use case: Developer needs to access a new API temporarily for testing.
+# Instead of modifying Terraform, apply a CRD-based policy.
+#
+# Prerequisites:
+#   helm install --repo https://aviatrixsystems.github.io/k8s-firewall-charts k8s-firewall k8s-firewall
+#
+# Apply:
+#   kubectl apply -f webgrouppolicy-dev.yaml
+#
+# Verify:
+#   kubectl get webgrouppolicies -n dev
+#   kubectl get events -n dev
+#####################
+
+apiVersion: networking.aviatrix.com/v1alpha1
+kind: WebGroupPolicy
+metadata:
+  name: dev-external-apis
+  namespace: dev
+spec:
+  selector:
+    matchLabels:
+      environment: development
+
+  action: permit
+  protocol: tcp
+  ports:
+    - "443"
+  logging: true
+
+  domains:
+    # Package registries
+    - "pypi.org"
+    - "*.pypi.org"
+    - "files.pythonhosted.org"
+    # Docker Hub
+    - "hub.docker.com"
+    - "registry-1.docker.io"
+    - "*.docker.io"
+    # GitHub (broader access for dev)
+    - "github.com"
+    - "*.github.com"
+    - "raw.githubusercontent.com"
+    - "api.github.com"

--- a/blueprints/azure-aks-multicluster/k8s-apps/frontend/gatus.yaml
+++ b/blueprints/azure-aks-multicluster/k8s-apps/frontend/gatus.yaml
@@ -1,0 +1,205 @@
+# NOTE: This file uses the domain "azure.aviatrixdemo.local" which must match
+# the private_dns_zone_name variable in the network layer. If you changed
+# that variable, update all occurrences of the domain below.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gatus
+  labels:
+    app.kubernetes.io/part-of: aks-demo
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend
+  namespace: gatus
+data:
+  config.yaml: |
+    storage:
+      type: memory
+    metrics: true
+    endpoints:
+      # Internal Services — East-West through Aviatrix transit
+      - name: "Prod Database"
+        group: "Internal"
+        url: "http://db.azure.aviatrixdemo.local"
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 300"
+      - name: "Backend Service"
+        group: "Internal"
+        url: "http://backend.azure.aviatrixdemo.local:8080"
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 500"
+
+      # Egress - Allowed Traffic (governed by DCF WebGroups)
+      - name: "kubernetes.io"
+        group: "Egress"
+        url: "https://kubernetes.io"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      - name: "github.com/.../terraform-provider-aviatrix"
+        group: "Egress"
+        url: "https://github.com/AviatrixSystems/terraform-provider-aviatrix"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      - name: "github.com/.../avxlabs-docs"
+        group: "Egress"
+        url: "https://github.com/AviatrixSystems/avxlabs-docs"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      - name: "registry.npmjs.org"
+        group: "Egress"
+        url: "https://registry.npmjs.org"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      # Threats - Should be BLOCKED by DCF (GeoBlock + ThreatIQ)
+      - name: "GeoBlock - Iran"
+        group: "Threats"
+        url: "icmp://www.irna.ir"
+        interval: 60s
+        conditions: ["[CONNECTED] == true"]
+
+      # NOTE: This IP must appear in your Aviatrix ThreatGuard feed to be blocked.
+      # Verify against your current threat intelligence feed and replace if needed.
+      - name: "Threat Feed - Malicious IP"
+        group: "Threats"
+        url: "icmp://102.130.117.167"
+        interval: 60s
+        conditions: ["[CONNECTED] == true"]
+
+    ui:
+      logo: "https://aviatrix.com/wp-content/uploads/2019/10/cropped-Aviatrix-Logo@2x-1-32x32.png"
+      header: "Frontend Cluster - ${HOSTNAME}"
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: frontend
+  namespace: gatus
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: gatus
+  labels:
+    app: frontend
+    cluster: frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      name: frontend
+      labels:
+        app: frontend
+        cluster: frontend
+        # Label used by Aviatrix k8s-firewall controller for DCF SmartGroup targeting
+        aviatrix.com/app: frontend
+    spec:
+      serviceAccountName: frontend
+      terminationGracePeriodSeconds: 5
+      containers:
+        - image: twinproduction/gatus:v5.14.0
+          imagePullPolicy: IfNotPresent
+          name: frontend
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 250m
+              memory: 100M
+            requests:
+              cpu: 50m
+              memory: 30M
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 5
+          volumeMounts:
+            - mountPath: /config
+              name: frontend-config
+      volumes:
+        - configMap:
+            name: frontend
+          name: frontend-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: gatus
+  labels:
+    app: frontend
+    service: frontend
+  annotations:
+    # Internal Azure Load Balancer — reachable from backend cluster via Aviatrix transit
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+    # ExternalDNS will create DNS record: frontend.azure.aviatrixdemo.local
+    external-dns.alpha.kubernetes.io/hostname: frontend.azure.aviatrixdemo.local
+    external-dns.alpha.kubernetes.io/ttl: "60"
+spec:
+  type: LoadBalancer
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: frontend
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend-ingress
+  namespace: gatus
+  annotations:
+    nginx.ingress.kubernetes.io/healthcheck-path: /health
+    # ExternalDNS will create DNS record: frontend-web.azure.aviatrixdemo.local
+    external-dns.alpha.kubernetes.io/hostname: frontend-web.azure.aviatrixdemo.local
+    external-dns.alpha.kubernetes.io/ttl: "60"
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 8080

--- a/blueprints/azure-aks-multicluster/network/dcf.tf
+++ b/blueprints/azure-aks-multicluster/network/dcf.tf
@@ -1,0 +1,514 @@
+#####################
+# Aviatrix Distributed Cloud Firewall (DCF)
+#
+# Architecture:
+#   - VNet SmartGroups  : match traffic by VNet name (post-SNAT, transit-level)
+#   - Hostname SGs      : match destination services by FQDN
+#   - WebGroups         : SNI/URL filters for HTTPS egress inspection
+#   - Rules (priority-ordered):
+#       0–9   : Threat prevention (geo-block, ThreatIQ)
+#       10–29 : East-west (inter-VNet service access)
+#       20    : Azure required services (AKS nodes/pods)
+#       30–49 : Explicit egress allows
+#       50–99 : Reserved for K8s CRD policies (FirewallPolicy / WebGroupPolicy)
+#
+# NOTES:
+#   - DCF inspects traffic at the Aviatrix spoke gateway BEFORE SNAT.
+#     Pod source IPs (100.64.x.x) are visible to DCF rules. Aviatrix K8s
+#     SmartGroups dynamically resolve pod IPs from cluster label selectors.
+#   - For transit-level rules (east-west between spokes), traffic arrives
+#     post-SNAT (spoke GW IP). Use VNet-type SmartGroups for those.
+#   - Hostname SmartGroups resolve FQDNs via the Azure Private DNS zone.
+#####################
+
+#####################
+# SmartGroups — VNet-based (transit-level)
+#####################
+
+resource "aviatrix_smart_group" "frontend_vnet" {
+  name = "${var.name_prefix}-sg-frontend-vnet"
+  selector {
+    match_expressions {
+      type = "vpc"
+      name = "${var.name_prefix}-frontend-vnet"
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "backend_vnet" {
+  name = "${var.name_prefix}-sg-backend-vnet"
+  selector {
+    match_expressions {
+      type = "vpc"
+      name = "${var.name_prefix}-backend-vnet"
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "db_vnet" {
+  name = "${var.name_prefix}-sg-db-vnet"
+  selector {
+    match_expressions {
+      type = "vpc"
+      name = "${var.name_prefix}-db-vnet"
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "all_aks_clusters" {
+  name = "${var.name_prefix}-sg-all-aks"
+  selector {
+    match_expressions {
+      type = "vpc"
+      name = "${var.name_prefix}-frontend-vnet"
+    }
+    match_expressions {
+      type = "vpc"
+      name = "${var.name_prefix}-backend-vnet"
+    }
+  }
+}
+
+#####################
+# SmartGroups — Hostname-based (service FQDNs)
+#####################
+
+resource "aviatrix_smart_group" "backend_service" {
+  name = "${var.name_prefix}-sg-backend-service"
+  selector {
+    match_expressions {
+      fqdn = "backend.${var.private_dns_zone_name}"
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "frontend_service" {
+  name = "${var.name_prefix}-sg-frontend-service"
+  selector {
+    match_expressions {
+      fqdn = "frontend.${var.private_dns_zone_name}"
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "database" {
+  name = "${var.name_prefix}-sg-database"
+  selector {
+    match_expressions {
+      fqdn = "db.${var.private_dns_zone_name}"
+    }
+  }
+}
+
+#####################
+# SmartGroups — External feeds (threat intelligence)
+#####################
+
+resource "aviatrix_smart_group" "geo_blocked" {
+  name = "${var.name_prefix}-sg-geo-blocked"
+  selector {
+    match_expressions {
+      external = "geo"
+      ext_args = {
+        country_iso_code = "IR" # Iran
+      }
+    }
+    match_expressions {
+      external = "geo"
+      ext_args = {
+        country_iso_code = "KP" # North Korea
+      }
+    }
+    match_expressions {
+      external = "geo"
+      ext_args = {
+        country_iso_code = "RU" # Russia
+      }
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "threat_intel" {
+  name = "${var.name_prefix}-sg-threat-intel"
+  selector {
+    match_expressions {
+      external = "threatiq"
+      ext_args = {
+        severity = "major"
+      }
+    }
+    match_expressions {
+      external = "threatiq"
+      ext_args = {
+        severity = "critical"
+      }
+    }
+  }
+}
+
+#####################
+# Built-in SmartGroups
+#####################
+
+locals {
+  # Built-in "Public Internet" SmartGroup UUID (system-defined, matches all non-RFC1918)
+  public_internet_uuid = "def000ad-0000-0000-0000-000000000001"
+}
+
+#####################
+# WebGroups — SNI/URL filters for HTTPS egress
+#####################
+
+# Azure services required by AKS nodes and Cilium
+resource "aviatrix_web_group" "azure_required" {
+  name = "${var.name_prefix}-wg-azure-required"
+  selector {
+    match_expressions {
+      snifilter = "*.microsoft.com"
+    }
+    match_expressions {
+      snifilter = "*.microsoftonline.com"
+    }
+    match_expressions {
+      snifilter = "*.azurecr.io" # Azure Container Registry
+    }
+    match_expressions {
+      snifilter = "mcr.microsoft.com" # Microsoft Container Registry
+    }
+    match_expressions {
+      snifilter = "*.blob.core.windows.net" # Azure Blob (image layers)
+    }
+    match_expressions {
+      snifilter = "*.azure.com"
+    }
+    match_expressions {
+      snifilter = "*.azure.net"
+    }
+    # AKS-specific endpoints
+    match_expressions {
+      snifilter = "*.azmk8s.io" # AKS API server
+    }
+    match_expressions {
+      snifilter = "management.azure.com"
+    }
+    # Ubuntu/Debian package repos (for node bootstrapping)
+    match_expressions {
+      snifilter = "packages.microsoft.com"
+    }
+    match_expressions {
+      snifilter = "security.ubuntu.com"
+    }
+    match_expressions {
+      snifilter = "archive.ubuntu.com"
+    }
+  }
+}
+
+resource "aviatrix_web_group" "kubernetes_io" {
+  name = "${var.name_prefix}-wg-kubernetes-io"
+  selector {
+    match_expressions {
+      snifilter = "kubernetes.io"
+    }
+    match_expressions {
+      snifilter = "*.kubernetes.io"
+    }
+    match_expressions {
+      snifilter = "registry.k8s.io"
+    }
+    match_expressions {
+      snifilter = "*.pkg.dev" # Artifact Registry (k8s images)
+    }
+  }
+}
+
+resource "aviatrix_web_group" "docker_hub" {
+  name = "${var.name_prefix}-wg-docker-hub"
+  selector {
+    match_expressions {
+      snifilter = "registry-1.docker.io"
+    }
+    match_expressions {
+      snifilter = "auth.docker.io"
+    }
+    match_expressions {
+      snifilter = "index.docker.io"
+    }
+    match_expressions {
+      snifilter = "*.docker.com"
+    }
+  }
+}
+
+resource "aviatrix_web_group" "npm_registry" {
+  name = "${var.name_prefix}-wg-npm-registry"
+  selector {
+    match_expressions {
+      snifilter = "registry.npmjs.org"
+    }
+    match_expressions {
+      snifilter = "npmjs.org"
+    }
+    match_expressions {
+      snifilter = "www.npmjs.com"
+    }
+  }
+}
+
+resource "aviatrix_web_group" "github_aviatrix" {
+  name = "${var.name_prefix}-wg-github-aviatrix"
+  selector {
+    # A WebGroup can only contain one filter type (snifilter OR urlfilter, not both)
+    match_expressions {
+      snifilter = "github.com"
+    }
+    match_expressions {
+      snifilter = "*.github.com"
+    }
+    match_expressions {
+      snifilter = "*.githubusercontent.com"
+    }
+    match_expressions {
+      snifilter = "aviatrixsystems.github.io"
+    }
+  }
+}
+
+#####################
+# Enable Distributed Cloud Firewall
+#####################
+
+resource "aviatrix_distributed_firewalling_config" "enable" {
+  enable_distributed_firewalling = true
+}
+
+#####################
+# DCF Ruleset
+#####################
+
+resource "aviatrix_dcf_ruleset" "aks_demo" {
+  name      = "${var.name_prefix}-aks-multicluster"
+  attach_to = "defa11a1-3000-4001-0000-000000000000"
+
+  #############################
+  # THREAT PREVENTION (Priority 0-9)
+  #############################
+
+  rules {
+    name             = "Block GeoBlocked Countries"
+    action           = "DENY"
+    priority         = 0
+    protocol         = "ANY"
+    logging          = true
+    src_smart_groups = [aviatrix_smart_group.all_aks_clusters.uuid]
+    dst_smart_groups = [aviatrix_smart_group.geo_blocked.uuid]
+  }
+
+  rules {
+    name             = "Block Threat Intel IPs"
+    action           = "DENY"
+    priority         = 1
+    protocol         = "ANY"
+    logging          = true
+    src_smart_groups = [aviatrix_smart_group.all_aks_clusters.uuid]
+    dst_smart_groups = [aviatrix_smart_group.threat_intel.uuid]
+  }
+
+  #############################
+  # INTER-VNET EAST-WEST (Priority 10-29)
+  #############################
+
+  rules {
+    name             = "Frontend to Database"
+    action           = "PERMIT"
+    priority         = 10
+    protocol         = "TCP"
+    logging          = true
+    src_smart_groups = [aviatrix_smart_group.frontend_vnet.uuid]
+    dst_smart_groups = [aviatrix_smart_group.database.uuid]
+    port_ranges {
+      lo = 80
+    }
+  }
+
+  rules {
+    name             = "Backend to Database"
+    action           = "PERMIT"
+    priority         = 11
+    protocol         = "TCP"
+    logging          = true
+    src_smart_groups = [aviatrix_smart_group.backend_vnet.uuid]
+    dst_smart_groups = [aviatrix_smart_group.database.uuid]
+    port_ranges {
+      lo = 80
+    }
+  }
+
+  rules {
+    name             = "Frontend to Backend Services"
+    action           = "PERMIT"
+    priority         = 14
+    protocol         = "TCP"
+    logging          = true
+    src_smart_groups = [aviatrix_smart_group.frontend_vnet.uuid]
+    dst_smart_groups = [aviatrix_smart_group.backend_service.uuid]
+    port_ranges {
+      lo = 8080
+    }
+  }
+
+  rules {
+    name             = "Backend to Frontend Services"
+    action           = "PERMIT"
+    priority         = 15
+    protocol         = "TCP"
+    logging          = true
+    src_smart_groups = [aviatrix_smart_group.backend_vnet.uuid]
+    dst_smart_groups = [aviatrix_smart_group.frontend_service.uuid]
+    port_ranges {
+      lo = 8080
+    }
+  }
+
+  #############################
+  # EGRESS — Azure Required (Priority 20)
+  #############################
+
+  rules {
+    name                 = "AKS Required Azure Services"
+    action               = "PERMIT"
+    priority             = 20
+    protocol             = "TCP"
+    logging              = true
+    src_smart_groups     = [aviatrix_smart_group.all_aks_clusters.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.azure_required.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  # AKS nodes also need port 80 for some package managers and HTTP redirects
+  rules {
+    name                 = "AKS Required Azure Services HTTP"
+    action               = "PERMIT"
+    priority             = 21
+    protocol             = "TCP"
+    logging              = false
+    src_smart_groups     = [aviatrix_smart_group.all_aks_clusters.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.azure_required.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 80
+    }
+  }
+
+  #############################
+  # EGRESS — Allowed Destinations (Priority 30-49)
+  #############################
+
+  rules {
+    name                 = "Allow Kubernetes-io"
+    action               = "PERMIT"
+    priority             = 30
+    protocol             = "TCP"
+    logging              = true
+    src_smart_groups     = [aviatrix_smart_group.all_aks_clusters.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.kubernetes_io.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  rules {
+    name                 = "Allow Docker Hub"
+    action               = "PERMIT"
+    priority             = 31
+    protocol             = "TCP"
+    logging              = true
+    src_smart_groups     = [aviatrix_smart_group.all_aks_clusters.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.docker_hub.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  rules {
+    name                 = "Allow npm Registry"
+    action               = "PERMIT"
+    priority             = 32
+    protocol             = "TCP"
+    logging              = true
+    src_smart_groups     = [aviatrix_smart_group.all_aks_clusters.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.npm_registry.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  rules {
+    name                 = "Allow GitHub Aviatrix Repos"
+    action               = "PERMIT"
+    priority             = 33
+    protocol             = "TCP"
+    logging              = true
+    watch                = true
+    src_smart_groups     = [aviatrix_smart_group.all_aks_clusters.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.github_aviatrix.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  #############################
+  # PLACEHOLDER: K8s CRD POLICIES (Priority 50-99)
+  # Inserted programmatically by Aviatrix k8s-firewall controller.
+  # See k8s-apps/dcf-crd/ for FirewallPolicy / WebGroupPolicy CRD examples.
+  #############################
+
+  depends_on = [
+    aviatrix_distributed_firewalling_config.enable,
+    module.frontend_spoke,
+    module.backend_spoke,
+    module.db_spoke,
+  ]
+}
+
+#####################
+# Outputs
+#####################
+
+output "dcf_ruleset_uuid" {
+  description = "UUID of the DCF ruleset"
+  value       = aviatrix_dcf_ruleset.aks_demo.id
+}
+
+output "smartgroup_frontend_vnet_uuid" {
+  description = "UUID of frontend VNet SmartGroup"
+  value       = aviatrix_smart_group.frontend_vnet.uuid
+}
+
+output "smartgroup_backend_vnet_uuid" {
+  description = "UUID of backend VNet SmartGroup"
+  value       = aviatrix_smart_group.backend_vnet.uuid
+}
+
+output "webgroup_azure_required_uuid" {
+  description = "UUID of Azure Required WebGroup (for CRD reference)"
+  value       = aviatrix_web_group.azure_required.uuid
+}
+
+output "webgroup_github_aviatrix_uuid" {
+  description = "UUID of GitHub Aviatrix WebGroup (for CRD reference)"
+  value       = aviatrix_web_group.github_aviatrix.uuid
+}

--- a/blueprints/azure-aks-multicluster/network/main.tf
+++ b/blueprints/azure-aks-multicluster/network/main.tf
@@ -1,0 +1,542 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 8.2"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aviatrix" {
+  skip_version_validation = true
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  clusters = {
+    frontend = {
+      name      = "${var.name_prefix}-frontend"
+      vnet_cidr = var.frontend_vnet_cidr
+    }
+    backend = {
+      name      = "${var.name_prefix}-backend"
+      vnet_cidr = var.backend_vnet_cidr
+    }
+  }
+
+  common_tags = {
+    Environment = "demo"
+    Terraform   = "true"
+    Blueprint   = "azure-aks-multicluster"
+  }
+
+  # Static private IPs for NGINX internal LBs — referenced by AppGW backend pools
+  # and consumed by nodes layer via remote_state outputs.
+  # Must be within system subnet (x.0.128/25), away from AppGW subnet (x.0.64/26).
+  frontend_nginx_lb_ip = "10.10.0.200"
+  backend_nginx_lb_ip  = "10.20.0.200"
+}
+
+#####################
+# Aviatrix Transit Gateway
+#####################
+
+module "azure_transit" {
+  source  = "terraform-aviatrix-modules/mc-transit/aviatrix"
+  version = "~> 8.0"
+
+  name    = "${var.name_prefix}-transit"
+  cloud   = "Azure"
+  account = var.aviatrix_azure_account_name
+  region  = var.aviatrix_azure_region
+  cidr    = var.transit_cidr
+  ha_gw   = false
+
+  # Enable FireNet for future NGFW integration
+  enable_transit_firenet        = true
+  enable_egress_transit_firenet = false
+
+  instance_size     = "Standard_B2ms"
+  connected_transit = true
+
+  # Required for hostname SmartGroups to resolve DNS names
+  enable_vpc_dns_server = true
+
+  # CRITICAL: Exclude the pod CIDR from BGP advertisements.
+  # Both clusters share 100.64.0.0/16 as their Cilium overlay — Aviatrix SNATs
+  # pod traffic to spoke GW IPs before forwarding to transit, so the transit
+  # must never advertise the raw pod CIDR to peers.
+  excluded_advertised_spoke_routes = var.pod_cidr
+}
+
+#####################
+# Frontend VNet + Spoke Gateway
+#####################
+
+module "frontend_vnet" {
+  source = "./modules/aks-vnet"
+
+  name         = "frontend"
+  cluster_name = local.clusters.frontend.name
+  vnet_cidr    = local.clusters.frontend.vnet_cidr
+  region       = var.azure_region
+  name_prefix  = var.name_prefix
+  tags         = merge(local.common_tags, { Cluster = "frontend" })
+}
+
+# UDR: route all egress from AKS nodes through the Aviatrix spoke gateway.
+# This MUST be associated with the nodes subnet before the AKS cluster is created
+# (outbound_type = "userDefinedRouting" requires it to exist at cluster creation time).
+resource "azurerm_route_table" "frontend_udr" {
+  name                          = "${var.name_prefix}-frontend-udr"
+  location                      = var.azure_region
+  resource_group_name           = module.frontend_vnet.resource_group_name
+  bgp_route_propagation_enabled = false
+  tags                          = merge(local.common_tags, { Cluster = "frontend" })
+}
+
+resource "azurerm_subnet_route_table_association" "frontend_nodes_udr" {
+  subnet_id      = module.frontend_vnet.nodes_subnet_id
+  route_table_id = azurerm_route_table.frontend_udr.id
+}
+
+# Aviatrix requires ALL private subnets in the VNet to have a route table
+resource "azurerm_subnet_route_table_association" "frontend_system_udr" {
+  subnet_id      = module.frontend_vnet.system_subnet_id
+  route_table_id = azurerm_route_table.frontend_udr.id
+}
+
+module "frontend_spoke" {
+  source  = "terraform-aviatrix-modules/mc-spoke/aviatrix"
+  version = "~> 8.0"
+
+  cloud      = "Azure"
+  name       = "${var.name_prefix}-frontend-spoke"
+  account    = var.aviatrix_azure_account_name
+  region     = var.aviatrix_azure_region
+  transit_gw = module.azure_transit.transit_gateway.gw_name
+
+  instance_size = "Standard_B2ms"
+  ha_gw         = false
+
+  # Required for hostname SmartGroups
+  enable_vpc_dns_server = true
+
+  # SNAT all spoke traffic (including pod 100.64.x.x IPs) to the spoke GW IP.
+  # DCF inspects the original pod IPs before SNAT. single_ip_snat avoids the
+  # [AVXERR-NAT-0029] conflict caused by the UDR 0/0 being misidentified as an
+  # onprem-learned route by customized_snat mode.
+  single_ip_snat = true
+
+  # Deploy spoke GW into the VNet created by aks-vnet module
+  use_existing_vpc = true
+  vpc_id           = module.frontend_vnet.aviatrix_vpc_id # "vnet_name:rg_name"
+  gw_subnet        = module.frontend_vnet.avx_gateway_subnet_cidr
+
+  depends_on = [
+    azurerm_subnet_route_table_association.frontend_nodes_udr,
+    azurerm_subnet_route_table_association.frontend_system_udr,
+  ]
+}
+
+#####################
+# Backend VNet + Spoke Gateway
+#####################
+
+module "backend_vnet" {
+  source = "./modules/aks-vnet"
+
+  name         = "backend"
+  cluster_name = local.clusters.backend.name
+  vnet_cidr    = local.clusters.backend.vnet_cidr
+  region       = var.azure_region
+  name_prefix  = var.name_prefix
+  tags         = merge(local.common_tags, { Cluster = "backend" })
+}
+
+resource "azurerm_route_table" "backend_udr" {
+  name                          = "${var.name_prefix}-backend-udr"
+  location                      = var.azure_region
+  resource_group_name           = module.backend_vnet.resource_group_name
+  bgp_route_propagation_enabled = false
+  tags                          = merge(local.common_tags, { Cluster = "backend" })
+}
+
+resource "azurerm_subnet_route_table_association" "backend_nodes_udr" {
+  subnet_id      = module.backend_vnet.nodes_subnet_id
+  route_table_id = azurerm_route_table.backend_udr.id
+}
+
+resource "azurerm_subnet_route_table_association" "backend_system_udr" {
+  subnet_id      = module.backend_vnet.system_subnet_id
+  route_table_id = azurerm_route_table.backend_udr.id
+}
+
+module "backend_spoke" {
+  source  = "terraform-aviatrix-modules/mc-spoke/aviatrix"
+  version = "~> 8.0"
+
+  cloud      = "Azure"
+  name       = "${var.name_prefix}-backend-spoke"
+  account    = var.aviatrix_azure_account_name
+  region     = var.aviatrix_azure_region
+  transit_gw = module.azure_transit.transit_gateway.gw_name
+
+  instance_size = "Standard_B2ms"
+  ha_gw         = false
+
+  enable_vpc_dns_server = true
+
+  single_ip_snat = true
+
+  use_existing_vpc = true
+  vpc_id           = module.backend_vnet.aviatrix_vpc_id
+  gw_subnet        = module.backend_vnet.avx_gateway_subnet_cidr
+
+  depends_on = [
+    azurerm_subnet_route_table_association.backend_nodes_udr,
+    azurerm_subnet_route_table_association.backend_system_udr,
+  ]
+}
+
+#####################
+# DB Spoke (test VM for east-west traffic demo)
+#####################
+
+resource "azurerm_resource_group" "db" {
+  name     = "${var.name_prefix}-db-rg"
+  location = var.azure_region
+  tags     = merge(local.common_tags, { Role = "db" })
+}
+
+resource "azurerm_virtual_network" "db" {
+  name                = "${var.name_prefix}-db-vnet"
+  location            = azurerm_resource_group.db.location
+  resource_group_name = azurerm_resource_group.db.name
+  address_space       = [var.db_vnet_cidr]
+  tags                = merge(local.common_tags, { Role = "db" })
+}
+
+resource "azurerm_subnet" "db_avx_gw" {
+  name                 = "db-avx-gw"
+  resource_group_name  = azurerm_resource_group.db.name
+  virtual_network_name = azurerm_virtual_network.db.name
+  address_prefixes     = [cidrsubnet(var.db_vnet_cidr, 6, 0)] # /28
+}
+
+resource "azurerm_subnet" "db_vms" {
+  name                 = "db-vms"
+  resource_group_name  = azurerm_resource_group.db.name
+  virtual_network_name = azurerm_virtual_network.db.name
+  address_prefixes     = [cidrsubnet(var.db_vnet_cidr, 2, 1)] # /24
+}
+
+# Aviatrix requires a route table associated with private subnets before deploying
+# the spoke gateway into an existing VNet ([AVXERR-TRANSIT-0067]).
+resource "azurerm_route_table" "db_udr" {
+  name                          = "${var.name_prefix}-db-udr"
+  location                      = var.azure_region
+  resource_group_name           = azurerm_resource_group.db.name
+  bgp_route_propagation_enabled = false
+  tags                          = merge(local.common_tags, { Role = "db" })
+}
+
+resource "azurerm_subnet_route_table_association" "db_vms_udr" {
+  subnet_id      = azurerm_subnet.db_vms.id
+  route_table_id = azurerm_route_table.db_udr.id
+}
+
+module "db_spoke" {
+  source  = "terraform-aviatrix-modules/mc-spoke/aviatrix"
+  version = "~> 8.0"
+
+  cloud      = "Azure"
+  name       = "${var.name_prefix}-db-spoke"
+  account    = var.aviatrix_azure_account_name
+  region     = var.aviatrix_azure_region
+  transit_gw = module.azure_transit.transit_gateway.gw_name
+
+  instance_size  = "Standard_B2ms"
+  ha_gw          = false
+  single_ip_snat = true
+
+  enable_vpc_dns_server = true
+
+  use_existing_vpc = true
+  vpc_id           = "${azurerm_virtual_network.db.name}:${azurerm_resource_group.db.name}"
+  gw_subnet        = azurerm_subnet.db_avx_gw.address_prefixes[0]
+
+  depends_on = [azurerm_subnet_route_table_association.db_vms_udr]
+}
+
+module "db_vm" {
+  source = "./modules/linux-vm"
+
+  name_prefix         = var.name_prefix
+  resource_group_name = azurerm_resource_group.db.name
+  location            = var.azure_region
+  subnet_id           = azurerm_subnet.db_vms.id
+  tags                = merge(local.common_tags, { Role = "db-test-vm" })
+
+  depends_on = [module.db_spoke]
+}
+
+#####################
+# Application Gateway Subnets
+# CRITICAL: Do NOT associate the Aviatrix UDR with these subnets.
+# AppGW management traffic (GatewayManager → ports 65200-65535) must reach
+# the Azure platform directly. A 0.0.0.0/0 → VirtualAppliance route breaks AppGW.
+#####################
+
+resource "azurerm_subnet" "frontend_appgw" {
+  name                 = "frontend-appgw"
+  resource_group_name  = module.frontend_vnet.resource_group_name
+  virtual_network_name = module.frontend_vnet.vnet_name
+  address_prefixes     = [cidrsubnet(var.frontend_vnet_cidr, 3, 1)] # 10.10.0.64/26
+}
+
+resource "azurerm_subnet" "backend_appgw" {
+  name                 = "backend-appgw"
+  resource_group_name  = module.backend_vnet.resource_group_name
+  virtual_network_name = module.backend_vnet.vnet_name
+  address_prefixes     = [cidrsubnet(var.backend_vnet_cidr, 3, 1)] # 10.20.0.64/26
+}
+
+#####################
+# Application Gateway Public IPs
+#####################
+
+resource "azurerm_public_ip" "frontend_appgw" {
+  name                = "${var.name_prefix}-frontend-appgw-pip"
+  location            = var.azure_region
+  resource_group_name = module.frontend_vnet.resource_group_name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  tags                = merge(local.common_tags, { Cluster = "frontend" })
+}
+
+resource "azurerm_public_ip" "backend_appgw" {
+  name                = "${var.name_prefix}-backend-appgw-pip"
+  location            = var.azure_region
+  resource_group_name = module.backend_vnet.resource_group_name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  tags                = merge(local.common_tags, { Cluster = "backend" })
+}
+
+#####################
+# Azure Application Gateways (Standard_v2)
+# Traffic path: Internet → AppGW PIP:80 → NGINX internal LB (10.x.0.200):80 → Gatus pods:8080
+# AppGW terminates the TCP connection — response traffic is VNet-internal, avoiding
+# asymmetric routing through the Aviatrix UDR.
+#####################
+
+resource "azurerm_application_gateway" "frontend" {
+  name                = "${var.name_prefix}-frontend-appgw"
+  location            = var.azure_region
+  resource_group_name = module.frontend_vnet.resource_group_name
+  tags                = merge(local.common_tags, { Cluster = "frontend" })
+
+  sku {
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
+    capacity = 1
+  }
+
+  gateway_ip_configuration {
+    name      = "appgw-ipconfig"
+    subnet_id = azurerm_subnet.frontend_appgw.id
+  }
+
+  frontend_port {
+    name = "port-80"
+    port = 80
+  }
+
+  frontend_ip_configuration {
+    name                 = "appgw-fip"
+    public_ip_address_id = azurerm_public_ip.frontend_appgw.id
+  }
+
+  backend_address_pool {
+    name         = "nginx-pool"
+    ip_addresses = [local.frontend_nginx_lb_ip]
+  }
+
+  probe {
+    name                = "nginx-health"
+    protocol            = "Http"
+    host                = "health.local"
+    path                = "/health"
+    interval            = 30
+    timeout             = 30
+    unhealthy_threshold = 3
+    port                = 80
+    match {
+      status_code = ["200-399"]
+    }
+  }
+
+  backend_http_settings {
+    name                  = "nginx-http"
+    cookie_based_affinity = "Disabled"
+    protocol              = "Http"
+    port                  = 80
+    request_timeout       = 30
+    probe_name            = "nginx-health"
+  }
+
+  http_listener {
+    name                           = "http-listener"
+    frontend_ip_configuration_name = "appgw-fip"
+    frontend_port_name             = "port-80"
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                       = "http-rule"
+    rule_type                  = "Basic"
+    priority                   = 100
+    http_listener_name         = "http-listener"
+    backend_address_pool_name  = "nginx-pool"
+    backend_http_settings_name = "nginx-http"
+  }
+}
+
+resource "azurerm_application_gateway" "backend" {
+  name                = "${var.name_prefix}-backend-appgw"
+  location            = var.azure_region
+  resource_group_name = module.backend_vnet.resource_group_name
+  tags                = merge(local.common_tags, { Cluster = "backend" })
+
+  sku {
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
+    capacity = 1
+  }
+
+  gateway_ip_configuration {
+    name      = "appgw-ipconfig"
+    subnet_id = azurerm_subnet.backend_appgw.id
+  }
+
+  frontend_port {
+    name = "port-80"
+    port = 80
+  }
+
+  frontend_ip_configuration {
+    name                 = "appgw-fip"
+    public_ip_address_id = azurerm_public_ip.backend_appgw.id
+  }
+
+  backend_address_pool {
+    name         = "nginx-pool"
+    ip_addresses = [local.backend_nginx_lb_ip]
+  }
+
+  probe {
+    name                = "nginx-health"
+    protocol            = "Http"
+    host                = "health.local"
+    path                = "/health"
+    interval            = 30
+    timeout             = 30
+    unhealthy_threshold = 3
+    port                = 80
+    match {
+      status_code = ["200-399"]
+    }
+  }
+
+  backend_http_settings {
+    name                  = "nginx-http"
+    cookie_based_affinity = "Disabled"
+    protocol              = "Http"
+    port                  = 80
+    request_timeout       = 30
+    probe_name            = "nginx-health"
+  }
+
+  http_listener {
+    name                           = "http-listener"
+    frontend_ip_configuration_name = "appgw-fip"
+    frontend_port_name             = "port-80"
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                       = "http-rule"
+    rule_type                  = "Basic"
+    priority                   = 100
+    http_listener_name         = "http-listener"
+    backend_address_pool_name  = "nginx-pool"
+    backend_http_settings_name = "nginx-http"
+  }
+}
+
+#####################
+# Shared Services: Private DNS Zone
+#####################
+
+resource "azurerm_resource_group" "shared" {
+  name     = "${var.name_prefix}-shared-rg"
+  location = var.azure_region
+  tags     = merge(local.common_tags, { Role = "shared" })
+}
+
+resource "azurerm_private_dns_zone" "main" {
+  name                = var.private_dns_zone_name
+  resource_group_name = azurerm_resource_group.shared.name
+  tags                = merge(local.common_tags, { Role = "dns" })
+}
+
+# Link private DNS zone to all VNets so pods can resolve service DNS names
+resource "azurerm_private_dns_zone_virtual_network_link" "frontend" {
+  name                  = "${var.name_prefix}-frontend-dns-link"
+  resource_group_name   = azurerm_resource_group.shared.name
+  private_dns_zone_name = azurerm_private_dns_zone.main.name
+  virtual_network_id    = module.frontend_vnet.vnet_id
+  registration_enabled  = false
+  tags                  = local.common_tags
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "backend" {
+  name                  = "${var.name_prefix}-backend-dns-link"
+  resource_group_name   = azurerm_resource_group.shared.name
+  private_dns_zone_name = azurerm_private_dns_zone.main.name
+  virtual_network_id    = module.backend_vnet.vnet_id
+  registration_enabled  = false
+  tags                  = local.common_tags
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "db" {
+  name                  = "${var.name_prefix}-db-dns-link"
+  resource_group_name   = azurerm_resource_group.shared.name
+  private_dns_zone_name = azurerm_private_dns_zone.main.name
+  virtual_network_id    = azurerm_virtual_network.db.id
+  registration_enabled  = false
+  tags                  = local.common_tags
+}
+
+# Static DNS record for the DB VM
+resource "azurerm_private_dns_a_record" "db" {
+  name                = "db"
+  zone_name           = azurerm_private_dns_zone.main.name
+  resource_group_name = azurerm_resource_group.shared.name
+  ttl                 = 300
+  records             = [module.db_vm.vm_private_ip]
+}

--- a/blueprints/azure-aks-multicluster/network/modules/aks-vnet/main.tf
+++ b/blueprints/azure-aks-multicluster/network/modules/aks-vnet/main.tf
@@ -1,0 +1,62 @@
+locals {
+  # Subnet layout within the /23 VNet CIDR
+  # Example: 10.10.0.0/23 →
+  #   avx-gw:  10.10.0.0/28  (Aviatrix spoke gateway — 11 usable IPs)
+  #   system:  10.10.0.128/25 (Internal LBs, ingress — 123 usable IPs)
+  #   nodes:   10.10.1.0/24  (AKS node pool — 251 usable IPs)
+  #
+  # Pod CIDR (100.64.0.0/16) is the Cilium overlay — NOT in VNet address space.
+  # Routes from nodes for non-local traffic are handled via UDR in the parent module.
+
+  rg_name   = "${var.name_prefix}-${var.name}-rg"
+  vnet_name = "${var.name_prefix}-${var.name}-vnet"
+
+  # Derive subnet CIDRs from the /23 VNet CIDR deterministically using cidrsubnet().
+  # Example layout for 10.10.0.0/23:
+  #   avx_gw_subnet : cidrsubnet(x, 5, 0) = 10.10.0.0/28   (first /28  — 11 usable)
+  #   system_subnet : cidrsubnet(x, 2, 1) = 10.10.0.128/25 (second /25 — 123 usable)
+  #   nodes_subnet  : cidrsubnet(x, 1, 1) = 10.10.1.0/24   (second /24 — 251 usable)
+  # No overlap between these three ranges.
+  avx_gw_subnet = cidrsubnet(var.vnet_cidr, 5, 0) # /28 — Aviatrix spoke gateway
+  system_subnet = cidrsubnet(var.vnet_cidr, 2, 1) # /25 — internal LBs / ingress
+  nodes_subnet  = cidrsubnet(var.vnet_cidr, 1, 1) # /24 — AKS node pool
+}
+
+resource "azurerm_resource_group" "vnet" {
+  name     = local.rg_name
+  location = var.region
+  tags     = merge(var.tags, { Name = local.rg_name })
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  name                = local.vnet_name
+  location            = azurerm_resource_group.vnet.location
+  resource_group_name = azurerm_resource_group.vnet.name
+  address_space       = [var.vnet_cidr]
+  tags                = merge(var.tags, { Name = local.vnet_name, Cluster = var.cluster_name })
+}
+
+# Aviatrix spoke gateway subnet — dedicated /28
+resource "azurerm_subnet" "avx_gw" {
+  name                 = "${var.name}-avx-gw"
+  resource_group_name  = azurerm_resource_group.vnet.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = [local.avx_gw_subnet]
+}
+
+# System subnet — internal load balancers, ingress
+resource "azurerm_subnet" "system" {
+  name                 = "${var.name}-system"
+  resource_group_name  = azurerm_resource_group.vnet.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = [local.system_subnet]
+}
+
+# Node subnet — AKS node pool VMs
+# Route table association (UDR → Aviatrix) is done in the parent module after the spoke GW is created
+resource "azurerm_subnet" "nodes" {
+  name                 = "${var.name}-nodes"
+  resource_group_name  = azurerm_resource_group.vnet.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = [local.nodes_subnet]
+}

--- a/blueprints/azure-aks-multicluster/network/modules/aks-vnet/outputs.tf
+++ b/blueprints/azure-aks-multicluster/network/modules/aks-vnet/outputs.tf
@@ -1,0 +1,60 @@
+output "vnet_id" {
+  description = "Azure resource ID of the VNet"
+  value       = azurerm_virtual_network.vnet.id
+}
+
+output "vnet_name" {
+  description = "Name of the VNet"
+  value       = azurerm_virtual_network.vnet.name
+}
+
+output "resource_group_name" {
+  description = "Name of the resource group"
+  value       = azurerm_resource_group.vnet.name
+}
+
+output "resource_group_id" {
+  description = "Azure resource ID of the resource group"
+  value       = azurerm_resource_group.vnet.id
+}
+
+# Aviatrix-specific VNet ID format: "VNet_name:Resource_Group_name"
+output "aviatrix_vpc_id" {
+  description = "VNet ID in Aviatrix format for use_existing_vpc (VNet_name:RG_name)"
+  value       = "${azurerm_virtual_network.vnet.name}:${azurerm_resource_group.vnet.name}"
+}
+
+output "avx_gateway_subnet_cidr" {
+  description = "CIDR of the Aviatrix gateway subnet"
+  value       = azurerm_subnet.avx_gw.address_prefixes[0]
+}
+
+output "avx_gateway_subnet_id" {
+  description = "Azure resource ID of the Aviatrix gateway subnet"
+  value       = azurerm_subnet.avx_gw.id
+}
+
+output "nodes_subnet_id" {
+  description = "Azure resource ID of the AKS nodes subnet"
+  value       = azurerm_subnet.nodes.id
+}
+
+output "nodes_subnet_cidr" {
+  description = "CIDR of the AKS nodes subnet"
+  value       = azurerm_subnet.nodes.address_prefixes[0]
+}
+
+output "system_subnet_id" {
+  description = "Azure resource ID of the system/ingress subnet"
+  value       = azurerm_subnet.system.id
+}
+
+output "system_subnet_cidr" {
+  description = "CIDR of the system/ingress subnet"
+  value       = azurerm_subnet.system.address_prefixes[0]
+}
+
+output "vnet_cidr" {
+  description = "Primary CIDR of the VNet"
+  value       = tolist(azurerm_virtual_network.vnet.address_space)[0]
+}

--- a/blueprints/azure-aks-multicluster/network/modules/aks-vnet/variables.tf
+++ b/blueprints/azure-aks-multicluster/network/modules/aks-vnet/variables.tf
@@ -1,0 +1,30 @@
+variable "name" {
+  description = "Short name for the VNet (e.g., 'frontend', 'backend')"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Full AKS cluster name, used for resource tagging"
+  type        = string
+}
+
+variable "vnet_cidr" {
+  description = "Primary CIDR for the VNet. Pod CIDR is Cilium overlay and NOT added here."
+  type        = string
+}
+
+variable "region" {
+  description = "Azure region in azurerm format (e.g., 'eastus2')"
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "Prefix for all resource names"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/blueprints/azure-aks-multicluster/network/modules/linux-vm/main.tf
+++ b/blueprints/azure-aks-multicluster/network/modules/linux-vm/main.tf
@@ -1,0 +1,63 @@
+locals {
+  vm_name = "${var.name_prefix}-db-vm"
+}
+
+# SSH key pair — private key output for optional access
+resource "tls_private_key" "vm" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "azurerm_network_interface" "vm" {
+  name                = "${local.vm_name}-nic"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  tags                = var.tags
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = var.subnet_id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "vm" {
+  name                = local.vm_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  size                = "Standard_B1s"
+  admin_username      = "azureuser"
+  tags                = merge(var.tags, { Name = local.vm_name, Role = "db-test" })
+
+  network_interface_ids = [azurerm_network_interface.vm.id]
+
+  admin_ssh_key {
+    username   = "azureuser"
+    public_key = tls_private_key.vm.public_key_openssh
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server"
+    version   = "latest"
+  }
+
+  # Install nginx web server on boot — used as east-west test target
+  custom_data = base64encode(<<-EOF
+    #!/bin/bash
+    apt-get update -y
+    apt-get install -y nginx
+    systemctl enable nginx
+    systemctl start nginx
+    # Return hostname in response body for easy identification
+    echo "<h1>DB Test VM: $(hostname)</h1><p>Private IP: $(hostname -I | awk '{print $1}')</p>" \
+      > /var/www/html/index.html
+  EOF
+  )
+}

--- a/blueprints/azure-aks-multicluster/network/modules/linux-vm/outputs.tf
+++ b/blueprints/azure-aks-multicluster/network/modules/linux-vm/outputs.tf
@@ -1,0 +1,20 @@
+output "vm_private_ip" {
+  description = "Private IP address of the VM"
+  value       = azurerm_network_interface.vm.private_ip_address
+}
+
+output "vm_name" {
+  description = "Name of the virtual machine"
+  value       = azurerm_linux_virtual_machine.vm.name
+}
+
+output "vm_id" {
+  description = "Azure resource ID of the VM"
+  value       = azurerm_linux_virtual_machine.vm.id
+}
+
+output "private_key_pem" {
+  description = "SSH private key for the VM (sensitive — for emergency access only)"
+  value       = tls_private_key.vm.private_key_pem
+  sensitive   = true
+}

--- a/blueprints/azure-aks-multicluster/network/modules/linux-vm/variables.tf
+++ b/blueprints/azure-aks-multicluster/network/modules/linux-vm/variables.tf
@@ -1,0 +1,25 @@
+variable "name_prefix" {
+  description = "Prefix for all resource names"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group to deploy the VM into"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region in azurerm format (e.g., 'eastus2')"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Subnet ID for the VM's NIC"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/blueprints/azure-aks-multicluster/network/outputs.tf
+++ b/blueprints/azure-aks-multicluster/network/outputs.tf
@@ -1,0 +1,237 @@
+#####################
+# Transit
+#####################
+
+output "transit_gateway_name" {
+  description = "Aviatrix transit gateway name"
+  value       = module.azure_transit.transit_gateway.gw_name
+}
+
+output "transit_vnet_id" {
+  description = "Transit VNet ID"
+  value       = module.azure_transit.vpc.id
+}
+
+#####################
+# Frontend
+#####################
+
+output "frontend_vnet_id" {
+  description = "Frontend VNet Azure resource ID"
+  value       = module.frontend_vnet.vnet_id
+}
+
+output "frontend_vnet_name" {
+  description = "Frontend VNet name"
+  value       = module.frontend_vnet.vnet_name
+}
+
+output "frontend_resource_group_name" {
+  description = "Frontend resource group name"
+  value       = module.frontend_vnet.resource_group_name
+}
+
+output "frontend_resource_group_id" {
+  description = "Frontend resource group Azure resource ID"
+  value       = module.frontend_vnet.resource_group_id
+}
+
+output "frontend_nodes_subnet_id" {
+  description = "Frontend AKS nodes subnet ID (has UDR → Aviatrix GW pre-associated)"
+  value       = module.frontend_vnet.nodes_subnet_id
+}
+
+output "frontend_nodes_subnet_cidr" {
+  description = "Frontend AKS nodes subnet CIDR"
+  value       = module.frontend_vnet.nodes_subnet_cidr
+}
+
+output "frontend_system_subnet_id" {
+  description = "Frontend system/ingress subnet ID"
+  value       = module.frontend_vnet.system_subnet_id
+}
+
+output "frontend_system_subnet_cidr" {
+  description = "Frontend system/ingress subnet CIDR"
+  value       = module.frontend_vnet.system_subnet_cidr
+}
+
+output "frontend_spoke_gateway_name" {
+  description = "Frontend Aviatrix spoke gateway name"
+  value       = module.frontend_spoke.spoke_gateway.gw_name
+}
+
+output "frontend_spoke_gateway_private_ip" {
+  description = "Frontend Aviatrix spoke gateway private IP"
+  value       = module.frontend_spoke.spoke_gateway.private_ip
+}
+
+output "frontend_route_table_id" {
+  description = "Frontend UDR route table ID (for AKS identity role assignment)"
+  value       = azurerm_route_table.frontend_udr.id
+}
+
+output "frontend_cluster_name" {
+  description = "Expected AKS cluster name for the frontend cluster"
+  value       = local.clusters.frontend.name
+}
+
+#####################
+# Backend
+#####################
+
+output "backend_vnet_id" {
+  description = "Backend VNet Azure resource ID"
+  value       = module.backend_vnet.vnet_id
+}
+
+output "backend_vnet_name" {
+  description = "Backend VNet name"
+  value       = module.backend_vnet.vnet_name
+}
+
+output "backend_resource_group_name" {
+  description = "Backend resource group name"
+  value       = module.backend_vnet.resource_group_name
+}
+
+output "backend_resource_group_id" {
+  description = "Backend resource group Azure resource ID"
+  value       = module.backend_vnet.resource_group_id
+}
+
+output "backend_nodes_subnet_id" {
+  description = "Backend AKS nodes subnet ID (has UDR → Aviatrix GW pre-associated)"
+  value       = module.backend_vnet.nodes_subnet_id
+}
+
+output "backend_nodes_subnet_cidr" {
+  description = "Backend AKS nodes subnet CIDR"
+  value       = module.backend_vnet.nodes_subnet_cidr
+}
+
+output "backend_system_subnet_id" {
+  description = "Backend system/ingress subnet ID"
+  value       = module.backend_vnet.system_subnet_id
+}
+
+output "backend_system_subnet_cidr" {
+  description = "Backend system/ingress subnet CIDR"
+  value       = module.backend_vnet.system_subnet_cidr
+}
+
+output "backend_spoke_gateway_name" {
+  description = "Backend Aviatrix spoke gateway name"
+  value       = module.backend_spoke.spoke_gateway.gw_name
+}
+
+output "backend_spoke_gateway_private_ip" {
+  description = "Backend Aviatrix spoke gateway private IP"
+  value       = module.backend_spoke.spoke_gateway.private_ip
+}
+
+output "backend_route_table_id" {
+  description = "Backend UDR route table ID (for AKS identity role assignment)"
+  value       = azurerm_route_table.backend_udr.id
+}
+
+output "backend_cluster_name" {
+  description = "Expected AKS cluster name for the backend cluster"
+  value       = local.clusters.backend.name
+}
+
+#####################
+# DB
+#####################
+
+output "db_vnet_id" {
+  description = "DB VNet Azure resource ID"
+  value       = azurerm_virtual_network.db.id
+}
+
+output "db_resource_group_name" {
+  description = "DB resource group name"
+  value       = azurerm_resource_group.db.name
+}
+
+output "db_vm_private_ip" {
+  description = "DB test VM private IP"
+  value       = module.db_vm.vm_private_ip
+}
+
+output "db_vm_name" {
+  description = "DB test VM name"
+  value       = module.db_vm.vm_name
+}
+
+#####################
+# DNS
+#####################
+
+output "private_dns_zone_name" {
+  description = "Azure Private DNS zone name"
+  value       = azurerm_private_dns_zone.main.name
+}
+
+output "private_dns_zone_id" {
+  description = "Azure Private DNS zone resource ID"
+  value       = azurerm_private_dns_zone.main.id
+}
+
+output "dns_resource_group_name" {
+  description = "Resource group containing the private DNS zone"
+  value       = azurerm_resource_group.shared.name
+}
+
+#####################
+# Common
+#####################
+
+output "pod_cidr" {
+  description = "Cilium overlay pod CIDR (same across all clusters)"
+  value       = var.pod_cidr
+}
+
+output "service_cidr" {
+  description = "Kubernetes service CIDR"
+  value       = var.service_cidr
+}
+
+output "dns_service_ip" {
+  description = "Kubernetes DNS service IP"
+  value       = var.dns_service_ip
+}
+
+output "azure_region" {
+  description = "Azure region (azurerm format)"
+  value       = var.azure_region
+}
+
+output "name_prefix" {
+  description = "Resource name prefix"
+  value       = var.name_prefix
+}
+
+#####################
+# Application Gateways
+#####################
+
+output "frontend_appgw_public_ip" {
+  description = "Public IP of the frontend Application Gateway (internet-facing Gatus access)"
+  value       = azurerm_public_ip.frontend_appgw.ip_address
+}
+
+output "backend_appgw_public_ip" {
+  description = "Public IP of the backend Application Gateway (internet-facing Gatus access)"
+  value       = azurerm_public_ip.backend_appgw.ip_address
+}
+
+output "frontend_nginx_lb_ip" {
+  description = "Static private IP for the frontend NGINX internal load balancer"
+  value       = local.frontend_nginx_lb_ip
+}
+
+output "backend_nginx_lb_ip" {
+  description = "Static private IP for the backend NGINX internal load balancer"
+  value       = local.backend_nginx_lb_ip
+}

--- a/blueprints/azure-aks-multicluster/network/variables.tf
+++ b/blueprints/azure-aks-multicluster/network/variables.tf
@@ -1,0 +1,74 @@
+variable "name_prefix" {
+  description = "Prefix for all resource names (e.g., 'aks-demo')"
+  type        = string
+  default     = "aks-demo"
+}
+
+variable "aviatrix_azure_account_name" {
+  description = "Aviatrix access account name for Azure (configured in Aviatrix Controller)"
+  type        = string
+}
+
+variable "azure_region" {
+  description = "Azure region for azurerm resources (e.g., 'eastus2')"
+  type        = string
+  default     = "eastus2"
+}
+
+variable "aviatrix_azure_region" {
+  description = "Azure region in Aviatrix format (e.g., 'East US 2')"
+  type        = string
+  default     = "East US 2"
+}
+
+variable "transit_cidr" {
+  description = "CIDR for the Aviatrix Transit VNet"
+  type        = string
+  default     = "10.2.0.0/20"
+}
+
+variable "frontend_vnet_cidr" {
+  description = "Primary CIDR for the frontend AKS VNet"
+  type        = string
+  default     = "10.10.0.0/23"
+}
+
+variable "backend_vnet_cidr" {
+  description = "Primary CIDR for the backend AKS VNet"
+  type        = string
+  default     = "10.20.0.0/23"
+}
+
+variable "db_vnet_cidr" {
+  description = "CIDR for the DB test VNet"
+  type        = string
+  default     = "10.5.0.0/22"
+}
+
+variable "pod_cidr" {
+  description = <<-EOT
+    Cilium overlay CIDR for pod IPs — same across all clusters (overlapping by design).
+    Aviatrix spoke gateways SNAT this range to the spoke GW IP before sending to transit,
+    allowing overlapping pod CIDRs across clusters.
+  EOT
+  type        = string
+  default     = "100.64.0.0/16"
+}
+
+variable "service_cidr" {
+  description = "Kubernetes service CIDR (must not overlap with VNet or pod CIDR)"
+  type        = string
+  default     = "172.16.0.0/16"
+}
+
+variable "dns_service_ip" {
+  description = "IP address for the Kubernetes DNS service (must be within service_cidr)"
+  type        = string
+  default     = "172.16.0.10"
+}
+
+variable "private_dns_zone_name" {
+  description = "Azure Private DNS zone name for service discovery"
+  type        = string
+  default     = "azure.aviatrixdemo.local"
+}

--- a/blueprints/azure-aks-multicluster/nodes/backend/data.tf
+++ b/blueprints/azure-aks-multicluster/nodes/backend/data.tf
@@ -1,0 +1,15 @@
+data "terraform_remote_state" "network" {
+  backend = "local"
+  config = {
+    path = "../../network/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "cluster" {
+  backend = "local"
+  config = {
+    path = "../../clusters/backend/terraform.tfstate"
+  }
+}
+
+data "azurerm_client_config" "current" {}

--- a/blueprints/azure-aks-multicluster/nodes/backend/helm.tf
+++ b/blueprints/azure-aks-multicluster/nodes/backend/helm.tf
@@ -1,0 +1,128 @@
+#####################
+# NGINX Ingress Controller
+# Provides L7 ingress for services in the backend cluster.
+# Creates an internal Azure Load Balancer at a static private IP in the system subnet.
+# AppGW (internet-facing) forwards traffic to this internal LB — response traffic is
+# VNet-internal (AppGW → NGINX → AppGW → client), avoiding asymmetric routing
+# through the Aviatrix UDR.
+#####################
+
+resource "helm_release" "nginx_ingress" {
+  name             = "ingress-nginx"
+  repository       = "https://kubernetes.github.io/ingress-nginx"
+  chart            = "ingress-nginx"
+  version          = var.nginx_ingress_chart_version
+  namespace        = "ingress-nginx"
+  create_namespace = true
+
+  values = [
+    yamlencode({
+      controller = {
+        service = {
+          # Static private IP in the system subnet (10.20.0.128/25).
+          # AppGW backend pool targets this IP. Response traffic is VNet-internal
+          # (AppGW → NGINX LB → AppGW → client), avoiding asymmetric routing through Aviatrix.
+          loadBalancerIP = data.terraform_remote_state.network.outputs.backend_nginx_lb_ip
+          annotations = {
+            "service.beta.kubernetes.io/azure-load-balancer-internal"        = "true"
+            "service.beta.kubernetes.io/azure-load-balancer-internal-subnet" = "backend-system"
+            "service.beta.kubernetes.io/azure-load-balancer-ip-address"      = data.terraform_remote_state.network.outputs.backend_nginx_lb_ip
+          }
+        }
+        metrics = {
+          enabled = true
+        }
+      }
+    })
+  ]
+
+
+}
+
+#####################
+# ExternalDNS (Azure Private DNS)
+# Automatically creates DNS records in the Azure Private DNS zone
+# for services/ingresses with the correct annotations.
+#
+# Uses Workload Identity — no credentials stored in the cluster.
+#####################
+
+resource "helm_release" "external_dns" {
+  name             = "external-dns"
+  repository       = "https://kubernetes-sigs.github.io/external-dns/"
+  chart            = "external-dns"
+  version          = var.external_dns_chart_version
+  namespace        = "kube-system"
+  create_namespace = false
+
+  values = [
+    yamlencode({
+      provider = {
+        name = "azure-private-dns"
+      }
+
+      # ExternalDNS azure-private-dns provider requires /etc/kubernetes/azure.json
+      # even when using Workload Identity. secretConfiguration creates the Secret
+      # and mounts it at the specified path automatically.
+      secretConfiguration = {
+        enabled   = true
+        mountPath = "/etc/kubernetes"
+        data = {
+          "azure.json" = jsonencode({
+            tenantId                     = data.azurerm_client_config.current.tenant_id
+            subscriptionId               = data.azurerm_client_config.current.subscription_id
+            resourceGroup                = data.terraform_remote_state.network.outputs.dns_resource_group_name
+            useWorkloadIdentityExtension = true
+            userAssignedIdentityID       = data.terraform_remote_state.cluster.outputs.external_dns_client_id
+          })
+        }
+      }
+
+      serviceAccount = {
+        create = true
+        name   = "external-dns"
+        annotations = {
+          "azure.workload.identity/client-id" = data.terraform_remote_state.cluster.outputs.external_dns_client_id
+        }
+      }
+
+      podLabels = {
+        "azure.workload.identity/use" = "true"
+      }
+
+      txtOwnerId = local.cluster_name
+      txtPrefix  = "${local.cluster_name}-"
+
+      # Only manage records in our private DNS zone
+      domainFilters = [local.dns_zone_name]
+
+      # sync: creates and deletes records; upsert-only: only creates
+      policy = "sync"
+
+      # Filter to services and ingresses with ExternalDNS annotations
+      sources = ["service", "ingress"]
+
+      logLevel = "info"
+    })
+  ]
+
+
+}
+
+#####################
+# Aviatrix K8s Firewall (DCF CRD Controller)
+# Enables FirewallPolicy and WebGroupPolicy CRDs in the cluster.
+# The controller syncs pod label/namespace selectors to Aviatrix SmartGroups,
+# allowing per-pod DCF rules to be defined as Kubernetes resources.
+#####################
+
+resource "helm_release" "k8s_firewall" {
+  name             = "k8s-firewall"
+  repository       = "https://aviatrixsystems.github.io/k8s-firewall-charts"
+  chart            = "k8s-firewall"
+  version          = var.k8s_firewall_chart_version
+  namespace        = "aviatrix-firewall"
+  create_namespace = true
+
+
+}

--- a/blueprints/azure-aks-multicluster/nodes/backend/main.tf
+++ b/blueprints/azure-aks-multicluster/nodes/backend/main.tf
@@ -1,0 +1,49 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.20"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.16"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "kubernetes" {
+  host                   = data.terraform_remote_state.cluster.outputs.host
+  client_certificate     = data.terraform_remote_state.cluster.outputs.client_certificate
+  client_key             = data.terraform_remote_state.cluster.outputs.client_key
+  cluster_ca_certificate = data.terraform_remote_state.cluster.outputs.cluster_ca_certificate
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.terraform_remote_state.cluster.outputs.host
+    client_certificate     = data.terraform_remote_state.cluster.outputs.client_certificate
+    client_key             = data.terraform_remote_state.cluster.outputs.client_key
+    cluster_ca_certificate = data.terraform_remote_state.cluster.outputs.cluster_ca_certificate
+  }
+}
+
+locals {
+  cluster_name  = data.terraform_remote_state.cluster.outputs.cluster_name
+  dns_zone_name = data.terraform_remote_state.network.outputs.private_dns_zone_name
+  name_prefix   = data.terraform_remote_state.network.outputs.name_prefix
+}
+
+# NOTE: AKS Azure CNI Powered by Cilium does not expose a cilium-config ConfigMap.
+# Pod masquerade is controlled by azure-ip-masq-agent, which already lists
+# 100.64.0.0/16 (pod CIDR) in NonMasqueradeCIDRs. DCF rules operate at VNet level
+# (post-SNAT to spoke GW IP). Pod-level DCF requires the Aviatrix K8s controller.

--- a/blueprints/azure-aks-multicluster/nodes/backend/outputs.tf
+++ b/blueprints/azure-aks-multicluster/nodes/backend/outputs.tf
@@ -1,0 +1,14 @@
+output "nginx_ingress_lb_ip" {
+  description = "Private IP of the NGINX Ingress Controller internal load balancer"
+  value       = data.terraform_remote_state.network.outputs.backend_nginx_lb_ip
+}
+
+output "appgw_public_ip" {
+  description = "Public IP of the Application Gateway (internet-facing access to Gatus)"
+  value       = data.terraform_remote_state.network.outputs.backend_appgw_public_ip
+}
+
+output "pod_masquerade_note" {
+  description = "AKS azure-ip-masq-agent already lists 100.64.0.0/16 in NonMasqueradeCIDRs"
+  value       = "pod CIDR 100.64.0.0/16 excluded from masquerade by azure-ip-masq-agent"
+}

--- a/blueprints/azure-aks-multicluster/nodes/backend/variables.tf
+++ b/blueprints/azure-aks-multicluster/nodes/backend/variables.tf
@@ -1,0 +1,23 @@
+variable "azure_region" {
+  description = "Azure region in azurerm format (e.g., 'eastus2')"
+  type        = string
+  default     = "eastus2"
+}
+
+variable "nginx_ingress_chart_version" {
+  description = "NGINX Ingress Controller Helm chart version"
+  type        = string
+  default     = "4.12.0"
+}
+
+variable "external_dns_chart_version" {
+  description = "ExternalDNS Helm chart version"
+  type        = string
+  default     = "1.15.0"
+}
+
+variable "k8s_firewall_chart_version" {
+  description = "Aviatrix k8s-firewall Helm chart version (DCF CRD controller)"
+  type        = string
+  default     = "8.2.0"
+}

--- a/blueprints/azure-aks-multicluster/nodes/frontend/data.tf
+++ b/blueprints/azure-aks-multicluster/nodes/frontend/data.tf
@@ -1,0 +1,15 @@
+data "terraform_remote_state" "network" {
+  backend = "local"
+  config = {
+    path = "../../network/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "cluster" {
+  backend = "local"
+  config = {
+    path = "../../clusters/frontend/terraform.tfstate"
+  }
+}
+
+data "azurerm_client_config" "current" {}

--- a/blueprints/azure-aks-multicluster/nodes/frontend/helm.tf
+++ b/blueprints/azure-aks-multicluster/nodes/frontend/helm.tf
@@ -1,0 +1,128 @@
+#####################
+# NGINX Ingress Controller
+# Provides L7 ingress for services in the frontend cluster.
+# Creates an internal Azure Load Balancer at a static private IP in the system subnet.
+# AppGW (internet-facing) forwards traffic to this internal LB — response traffic is
+# VNet-internal (AppGW → NGINX → AppGW → client), avoiding asymmetric routing
+# through the Aviatrix UDR.
+#####################
+
+resource "helm_release" "nginx_ingress" {
+  name             = "ingress-nginx"
+  repository       = "https://kubernetes.github.io/ingress-nginx"
+  chart            = "ingress-nginx"
+  version          = var.nginx_ingress_chart_version
+  namespace        = "ingress-nginx"
+  create_namespace = true
+
+  values = [
+    yamlencode({
+      controller = {
+        service = {
+          # Static private IP in the system subnet (10.10.0.128/25).
+          # AppGW backend pool targets this IP. Response traffic is VNet-internal
+          # (AppGW → NGINX LB → AppGW → client), avoiding asymmetric routing through Aviatrix.
+          loadBalancerIP = data.terraform_remote_state.network.outputs.frontend_nginx_lb_ip
+          annotations = {
+            "service.beta.kubernetes.io/azure-load-balancer-internal"        = "true"
+            "service.beta.kubernetes.io/azure-load-balancer-internal-subnet" = "frontend-system"
+            "service.beta.kubernetes.io/azure-load-balancer-ip-address"      = data.terraform_remote_state.network.outputs.frontend_nginx_lb_ip
+          }
+        }
+        metrics = {
+          enabled = true
+        }
+      }
+    })
+  ]
+
+
+}
+
+#####################
+# ExternalDNS (Azure Private DNS)
+# Automatically creates DNS records in the Azure Private DNS zone
+# for services/ingresses with the correct annotations.
+#
+# Uses Workload Identity — no credentials stored in the cluster.
+#####################
+
+resource "helm_release" "external_dns" {
+  name             = "external-dns"
+  repository       = "https://kubernetes-sigs.github.io/external-dns/"
+  chart            = "external-dns"
+  version          = var.external_dns_chart_version
+  namespace        = "kube-system"
+  create_namespace = false
+
+  values = [
+    yamlencode({
+      provider = {
+        name = "azure-private-dns"
+      }
+
+      # ExternalDNS azure-private-dns provider requires /etc/kubernetes/azure.json
+      # even when using Workload Identity. secretConfiguration creates the Secret
+      # and mounts it at the specified path automatically.
+      secretConfiguration = {
+        enabled   = true
+        mountPath = "/etc/kubernetes"
+        data = {
+          "azure.json" = jsonencode({
+            tenantId                     = data.azurerm_client_config.current.tenant_id
+            subscriptionId               = data.azurerm_client_config.current.subscription_id
+            resourceGroup                = data.terraform_remote_state.network.outputs.dns_resource_group_name
+            useWorkloadIdentityExtension = true
+            userAssignedIdentityID       = data.terraform_remote_state.cluster.outputs.external_dns_client_id
+          })
+        }
+      }
+
+      serviceAccount = {
+        create = true
+        name   = "external-dns"
+        annotations = {
+          "azure.workload.identity/client-id" = data.terraform_remote_state.cluster.outputs.external_dns_client_id
+        }
+      }
+
+      podLabels = {
+        "azure.workload.identity/use" = "true"
+      }
+
+      txtOwnerId = local.cluster_name
+      txtPrefix  = "${local.cluster_name}-"
+
+      # Only manage records in our private DNS zone
+      domainFilters = [local.dns_zone_name]
+
+      # sync: creates and deletes records; upsert-only: only creates
+      policy = "sync"
+
+      # Filter to services and ingresses with ExternalDNS annotations
+      sources = ["service", "ingress"]
+
+      logLevel = "info"
+    })
+  ]
+
+
+}
+
+#####################
+# Aviatrix K8s Firewall (DCF CRD Controller)
+# Enables FirewallPolicy and WebGroupPolicy CRDs in the cluster.
+# The controller syncs pod label/namespace selectors to Aviatrix SmartGroups,
+# allowing per-pod DCF rules to be defined as Kubernetes resources.
+#####################
+
+resource "helm_release" "k8s_firewall" {
+  name             = "k8s-firewall"
+  repository       = "https://aviatrixsystems.github.io/k8s-firewall-charts"
+  chart            = "k8s-firewall"
+  version          = var.k8s_firewall_chart_version
+  namespace        = "aviatrix-firewall"
+  create_namespace = true
+
+
+}

--- a/blueprints/azure-aks-multicluster/nodes/frontend/main.tf
+++ b/blueprints/azure-aks-multicluster/nodes/frontend/main.tf
@@ -1,0 +1,49 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.20"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.16"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "kubernetes" {
+  host                   = data.terraform_remote_state.cluster.outputs.host
+  client_certificate     = data.terraform_remote_state.cluster.outputs.client_certificate
+  client_key             = data.terraform_remote_state.cluster.outputs.client_key
+  cluster_ca_certificate = data.terraform_remote_state.cluster.outputs.cluster_ca_certificate
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.terraform_remote_state.cluster.outputs.host
+    client_certificate     = data.terraform_remote_state.cluster.outputs.client_certificate
+    client_key             = data.terraform_remote_state.cluster.outputs.client_key
+    cluster_ca_certificate = data.terraform_remote_state.cluster.outputs.cluster_ca_certificate
+  }
+}
+
+locals {
+  cluster_name  = data.terraform_remote_state.cluster.outputs.cluster_name
+  dns_zone_name = data.terraform_remote_state.network.outputs.private_dns_zone_name
+  name_prefix   = data.terraform_remote_state.network.outputs.name_prefix
+}
+
+# NOTE: AKS Azure CNI Powered by Cilium does not expose a cilium-config ConfigMap.
+# Pod masquerade is controlled by azure-ip-masq-agent, which already lists
+# 100.64.0.0/16 (pod CIDR) in NonMasqueradeCIDRs. DCF rules operate at VNet level
+# (post-SNAT to spoke GW IP). Pod-level DCF requires the Aviatrix K8s controller.

--- a/blueprints/azure-aks-multicluster/nodes/frontend/outputs.tf
+++ b/blueprints/azure-aks-multicluster/nodes/frontend/outputs.tf
@@ -1,0 +1,14 @@
+output "nginx_ingress_lb_ip" {
+  description = "Private IP of the NGINX Ingress Controller internal load balancer"
+  value       = data.terraform_remote_state.network.outputs.frontend_nginx_lb_ip
+}
+
+output "appgw_public_ip" {
+  description = "Public IP of the Application Gateway (internet-facing access to Gatus)"
+  value       = data.terraform_remote_state.network.outputs.frontend_appgw_public_ip
+}
+
+output "pod_masquerade_note" {
+  description = "AKS azure-ip-masq-agent already lists 100.64.0.0/16 in NonMasqueradeCIDRs"
+  value       = "pod CIDR 100.64.0.0/16 excluded from masquerade by azure-ip-masq-agent"
+}

--- a/blueprints/azure-aks-multicluster/nodes/frontend/variables.tf
+++ b/blueprints/azure-aks-multicluster/nodes/frontend/variables.tf
@@ -1,0 +1,23 @@
+variable "azure_region" {
+  description = "Azure region in azurerm format (e.g., 'eastus2')"
+  type        = string
+  default     = "eastus2"
+}
+
+variable "nginx_ingress_chart_version" {
+  description = "NGINX Ingress Controller Helm chart version"
+  type        = string
+  default     = "4.12.0"
+}
+
+variable "external_dns_chart_version" {
+  description = "ExternalDNS Helm chart version"
+  type        = string
+  default     = "1.15.0"
+}
+
+variable "k8s_firewall_chart_version" {
+  description = "Aviatrix k8s-firewall Helm chart version (DCF CRD controller)"
+  type        = string
+  default     = "8.2.0"
+}

--- a/blueprints/azure-aks-multicluster/terraform.tfvars.example
+++ b/blueprints/azure-aks-multicluster/terraform.tfvars.example
@@ -1,0 +1,61 @@
+# =============================================================================
+# Azure AKS Multicluster — Aviatrix Blueprint
+# =============================================================================
+#
+# Copy this file to the relevant layer directory and fill in your values.
+# Each layer reads the previous layer's state via terraform_remote_state.
+#
+# Authentication:
+#   Azure:    export ARM_SUBSCRIPTION_ID, ARM_TENANT_ID, ARM_CLIENT_ID, ARM_CLIENT_SECRET
+#             (or use: az login)
+#   Aviatrix: export AVIATRIX_CONTROLLER_IP, AVIATRIX_USERNAME, AVIATRIX_PASSWORD
+#
+# Deployment order:
+#   1. network/       (terraform apply)
+#   2. clusters/frontend + clusters/backend  (parallel)
+#   3. nodes/frontend + nodes/backend        (parallel)
+#   4. k8s-apps/      (kubectl apply — manual)
+#
+# Destroy order (reverse):
+#   1. nodes/frontend + nodes/backend        (terraform destroy, parallel)
+#   2. clusters/frontend + clusters/backend  (terraform destroy, parallel)
+#   3. network/       (terraform destroy)
+# =============================================================================
+
+# ----------------------------
+# network/terraform.tfvars
+# ----------------------------
+
+name_prefix                 = "aks-demo"
+aviatrix_azure_account_name = "your-azure-account-name"  # Configured in Aviatrix Controller
+azure_region                = "eastus2"
+aviatrix_azure_region       = "East US 2"
+
+# Optional CIDR overrides (defaults shown)
+# transit_cidr       = "10.2.0.0/20"
+# frontend_vnet_cidr = "10.10.0.0/23"
+# backend_vnet_cidr  = "10.20.0.0/23"
+# db_vnet_cidr       = "10.5.0.0/22"
+# pod_cidr           = "100.64.0.0/16"   # Cilium overlay (overlapping across clusters)
+# service_cidr       = "172.16.0.0/16"
+# dns_service_ip     = "172.16.0.10"
+# private_dns_zone_name = "azure.aviatrixdemo.local"
+
+# ----------------------------
+# clusters/{frontend,backend}/terraform.tfvars
+# ----------------------------
+
+# azure_region        = "eastus2"
+# kubernetes_version  = "1.32"
+
+# node_pool_config = {
+#   node_count = 2
+#   min_count  = 1
+#   max_count  = 3
+#   vm_size    = "Standard_D2s_v3"
+# }
+
+# Restrict to your IP (recommended):
+# Run: curl -s ifconfig.me
+# authorized_ip_ranges = ["<YOUR_IP>/32"]
+# authorized_ip_ranges = ["0.0.0.0/0"]   # Allow all (demo only)


### PR DESCRIPTION
## Summary

- Adds a new `blueprints/azure-aks-multicluster` blueprint mirroring the existing `aws-eks-multicluster` blueprint for Azure
- Deploys a multi-cluster AKS environment with Aviatrix transit networking and Distributed Cloud Firewall (DCF)
- Fully tested end-to-end: deploy, Gatus dashboards accessible, east-west traffic verified, DCF policies active

## Architecture

4-layer deployment (network → clusters → nodes → k8s-apps):

- **Azure CNI Powered by Cilium** with RFC 6598 pod overlay (`100.64.0.0/16`, overlapping across clusters by design)
- **`outbound_type = userDefinedRouting`** — all egress via Aviatrix spoke GW UDR with `single_ip_snat`
- **Azure Application Gateway (Standard_v2)** for internet-facing access — solves asymmetric routing caused by the Aviatrix UDR that breaks a public Azure LB (Layer 4). AppGW terminates TCP; all response traffic is VNet-internal
- **NGINX Ingress Controller** on internal static LB (`10.x.0.200`) as AppGW backend target
- **ExternalDNS** with Workload Identity → Azure Private DNS zone
- **Aviatrix k8s-firewall** Helm chart for `FirewallPolicy`/`WebGroupPolicy` CRDs
- DCF SmartGroups, WebGroups, and policy ruleset (geo-block, ThreatIQ, east-west TCP, AKS-required egress)
- Gatus health dashboards on both clusters (internet-accessible via AppGW)

## Key Azure vs AWS Differences

| Concern | AWS (EKS) | Azure (AKS) |
|---------|-----------|-------------|
| Pod networking | VPC CNI + ENIConfig secondary CIDR | Azure CNI Powered by Cilium overlay |
| Internet ingress | Public NLB (IP target type) | AppGW → NGINX internal LB (asymmetric routing fix) |
| Service account auth | IRSA | Workload Identity |
| DNS | Route53 private zone | Azure Private DNS zone |
| Egress | NAT GW (replaced by Aviatrix) | UDR → Aviatrix spoke GW |

## Test plan

- [x] `terraform fmt -recursive` passes
- [x] Full 4-layer deploy completes successfully
- [x] Both AppGW backends report Healthy
- [x] Gatus dashboards accessible at AppGW public IPs (HTTP 200)
- [x] East-west connectivity verified (frontend ↔ backend ↔ db via Aviatrix transit)
- [x] DCF CRD policies apply without errors
- [x] `terraform destroy` completes in reverse order without orphaned resources
- [x] README complete with prerequisites, deployment guide, cost estimates, test scenarios, and troubleshooting

🤖 Generated with [Claude Code](https://claude.com/claude-code)