### PR TITLE
Add prevent-lateral-movement-vm-tags blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Blueprints are **complete, deployable lab environments** that demonstrate Aviatr
 | Blueprint | Description | Cloud(s) | Tier | Status |
 |-----------|-------------|----------|------|--------|
 | [aws-eks-multicluster](blueprints/aws-eks-multicluster/) | Distributed Cloud Firewall with EKS | AWS | Community | 🚧 In Progress |
+| [prevent-lateral-movement-vm-tags](blueprints/prevent-lateral-movement-vm-tags/) | Zero Trust segmentation with DCF and VM tags to prevent lateral movement | AWS | Community | 🔄 In Review |
 
 ## Manual Deployment
 

--- a/blueprints/prevent-lateral-movement-vm-tags/.gitignore
+++ b/blueprints/prevent-lateral-movement-vm-tags/.gitignore
@@ -1,0 +1,50 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Environment files
+.env
+.env.*
+.env.blueprint
+
+# Test output
+/tmp/
+*.tmp
+
+# Credentials and local scripts
+set-credentials.sh
+
+# Terraform plan files
+tfplan
+*.tfplan
+
+# macOS
+.DS_Store
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~

--- a/blueprints/prevent-lateral-movement-vm-tags/ARCHITECTURE.md
+++ b/blueprints/prevent-lateral-movement-vm-tags/ARCHITECTURE.md
@@ -1,0 +1,252 @@
+# Architecture Deep Dive — Prevent Lateral Movement - VM Tags
+
+This document explains every component deployed by this blueprint, how they connect, and why each decision was made. Read this before a customer demo call.
+
+---
+
+## Big Picture
+
+The blueprint proves one thing: **a compromised workload in one environment cannot reach workloads in another environment** — even though they share the same Aviatrix transit network.
+
+It does this using **Aviatrix Distributed Cloud Firewall (DCF)** with **SmartGroups** — a tag-based policy engine that classifies workloads automatically and enforces Zero Trust without security group sprawl.
+
+---
+
+## Component Map
+
+```
+┌─────────────────────────────────────────────────────┐
+│                Aviatrix Control Plane                │
+│  ┌──────────────┐        ┌──────────────────────┐   │
+│  │  Controller  │◄──────►│       CoPilot        │   │
+│  │  (Terraform/ │        │  (Topology, DCF UI,  │   │
+│  │   API)       │        │   FlowIQ, Monitor)   │   │
+│  └──────┬───────┘        └──────────────────────┘   │
+│         │ manages via API                            │
+└─────────┼───────────────────────────────────────────┘
+          │
+          ▼
+┌─────────────────────────────────────────────────────┐
+│                    AWS (us-east-1)                   │
+│                                                      │
+│  ┌─────────────────────────────────────────────┐    │
+│  │            Transit VPC (10.0.0.0/23)         │    │
+│  │     ┌────────────────────────────────┐       │    │
+│  │     │  Aviatrix Transit Gateway      │       │    │
+│  │     │  (zt-seg-transit-gw, t3.small) │       │    │
+│  │     └───┬─────────────┬─────────┬───┘       │    │
+│  └─────────┼─────────────┼─────────┼───────────┘    │
+│            │             │         │                  │
+│     ┌──────┘      ┌──────┘  ┌──────┘                 │
+│     ▼             ▼         ▼                         │
+│  Dev VPC      Prod VPC    DB VPC                     │
+│  10.1.0.0/24  10.2.0.0/24 10.3.0.0/24               │
+│  Spoke GW     Spoke GW    Spoke GW                   │
+│  Dev VM       Prod VM     DB VM                      │
+│  EICE         EICE+Gatus                             │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## Component Details
+
+### 1. Aviatrix Controller (pre-existing prerequisite)
+
+**What it is:** The management plane for all Aviatrix resources. Terraform talks to the Controller API to create gateways, SmartGroups, and DCF policies.
+
+**What it does in this blueprint:**
+- Receives Terraform API calls to create/manage all Aviatrix resources
+- Orchestrates gateway deployment in AWS
+- Stores and enforces DCF policy configuration
+- Manages SmartGroup membership in real time
+
+> **DCF must be enabled on the Controller before deploying.** Enable it at: Security > Distributed Cloud Firewall > Configuration > Enable. This blueprint manages SmartGroups and policies only — it deliberately does not enable/disable DCF so that `terraform destroy` never conflicts with other active policies on shared Controllers.
+
+**What to show in the demo:** The Controller itself is mostly invisible during the demo — everything is shown in CoPilot. Mention it exists as the management plane.
+
+---
+
+### 2. Aviatrix CoPilot (pre-existing prerequisite)
+
+**What it is:** The GUI for visualization, monitoring, and day-2 operations. Accessed through the Controller — click the CoPilot link in the top navigation bar.
+
+**Key views for the demo:**
+
+| CoPilot View | Navigation | What to show |
+|---|---|---|
+| Topology | Cloud Fabric > Topology | Hub-and-spoke architecture — all gateways connected |
+| SmartGroups | Security > DCF > SmartGroups | Tag-based groups with VM membership |
+| DCF Rules | Security > DCF > Rules | All 5 policies with priority order |
+| DCF Monitor | Security > DCF > Monitor | Live PERMITTED/DENIED traffic entries |
+
+---
+
+### 3. Transit VPC + Aviatrix Transit Gateway
+
+**What it is:** The central hub of the hub-and-spoke network. All spoke-to-spoke traffic passes through here.
+
+**CIDR:** `10.0.0.0/23`
+**Gateway size:** `t3.small`
+**Key settings:**
+- `enable_segmentation = true` — required for DCF to evaluate traffic between spokes
+- `connected_transit = true` — allows spoke-to-spoke connectivity through the transit
+
+**Why it matters:** Without the transit gateway, the three spoke VPCs would be isolated islands. The transit gateway connects them AND gives DCF a point to evaluate and enforce policy on all cross-VPC traffic.
+
+---
+
+### 4. Spoke Gateways + VPCs (Dev, Prod, DB)
+
+**What they are:** Three spoke VPCs, each with an Aviatrix Spoke Gateway attached to the Transit Gateway.
+
+| Spoke | VPC CIDR | Purpose |
+|-------|----------|---------|
+| Dev | 10.1.0.0/24 | Development workloads (less trusted) |
+| Prod | 10.2.0.0/24 | Production workloads (business-critical) |
+| DB | 10.3.0.0/24 | Database workloads (most sensitive) |
+
+**Each VPC contains:**
+- Public subnet (for the gateway)
+- Private subnet (for test VMs)
+- Internet Gateway (for gateway internet access)
+- Route tables directing cross-VPC traffic through the Aviatrix gateway
+
+**How traffic flows:** When the Dev VM tries to ping the DB VM, the traffic goes:
+`Dev VM → Dev Spoke Gateway → Transit Gateway → DB Spoke Gateway → DB VM`
+
+At the Transit Gateway, DCF intercepts and evaluates the traffic against the policy list. If no PERMIT rule matches, the `default-deny-all` policy at priority 1000 drops it.
+
+---
+
+### 5. DCF SmartGroups
+
+**What they are:** Dynamic, tag-based groupings of workloads. When a VM has a matching tag, it's automatically classified into the SmartGroup — no manual IP management.
+
+| SmartGroup | Tag Selector | Members |
+|---|---|---|
+| `dev-smartgroup` | `Environment=development` | Dev test VM |
+| `prod-smartgroup` | `Environment=production` | Prod test VM + Gatus monitoring VM |
+| `db-smartgroup` | `Environment=database` | DB test VM |
+
+**Why tags instead of IPs:** New workloads tagged `Environment=production` instantly inherit all production policies. No engineer needs to update a security group or firewall rule. This is the automation story — *tag once, secured forever.*
+
+**What to show in demo:** Click into a SmartGroup to show the tag selector, then show the VM members list. The key message: "This is how Zero Trust scales — policy follows the workload, not the IP address."
+
+---
+
+### 6. DCF Policies
+
+Five policies, evaluated in priority order (lowest number = evaluated first):
+
+| Priority | Policy | Source | Destination | Protocol | Action | Why |
+|---|---|---|---|---|---|---|
+| 100 | `allow-prod-to-db` | prod | db | ANY | PERMIT | Production legitimately needs to read/write the database |
+| 110 | `allow-dev-to-prod-read-only` | dev | prod | ICMP only | PERMIT | Dev can ping prod for diagnostics — TCP is blocked |
+| 200 | `deny-dev-to-db` | dev | db | ANY | DENY | **The key Zero Trust control** — dev cannot reach production data |
+| 210 | `deny-prod-to-dev` | prod | dev | ANY | DENY | Compromised production cannot pivot to dev environment |
+| 1000 | `default-deny-all` | ANY | ANY | ANY | DENY | Zero Trust baseline — nothing is trusted by default |
+
+**Priority evaluation:** The first matching policy wins. Traffic from dev to db hits priority 200 (DENY) before reaching the default-deny at 1000. Traffic from prod to db hits priority 100 (PERMIT) immediately.
+
+**Watch mode:** The `deny-dev-to-db` policy has `watch = true` — this highlights it in CoPilot DCF Monitor so you can easily see it fire during the demo.
+
+---
+
+### 7. Test VMs
+
+Three `t3.micro` EC2 instances (Amazon Linux 2), one per spoke VPC, deployed in private subnets.
+
+**Private IP assignment:** IPs are pinned at deploy time (10th host in the private subnet) so Gatus can reference them without waiting for DHCP assignment.
+
+**Tags:** Each VM is tagged `Environment=<environment>` — this is what puts them into the correct SmartGroup automatically.
+
+**Security groups:** SSH is restricted — no `0.0.0.0/0` access. Dev and prod VMs accept SSH only from their EC2 Instance Connect Endpoint security group. DB VM accepts SSH only from within its VPC CIDR.
+
+---
+
+### 8. EC2 Instance Connect Endpoints (EICE)
+
+**What they are:** AWS-managed tunnels that let you SSH into private EC2 instances using only your existing AWS credentials — no bastion host, no public IP, no key file management.
+
+**Deployed for:** Dev and Prod spoke VPCs (not DB — it's a target-only VM with no need for interactive access).
+
+**How to use:**
+```bash
+aws ec2-instance-connect ssh --instance-id <instance-id> --region us-east-1
+```
+
+**Security model:**
+- EICE has its own security group (`eice-sg`) that allows only outbound SSH (port 22) to the spoke VPC CIDR
+- Test VM security groups allow SSH ingress only from the EICE security group — no direct internet SSH possible
+- The EICE itself authenticates using your AWS IAM identity (not a password or key)
+
+**Why this matters for the demo:** SEs can SSH into any test VM from their laptop with a single command, without needing to manage key pairs or a bastion host. This makes running live test scenarios on a customer call frictionless.
+
+---
+
+### 9. Gatus Live Dashboard
+
+**What it is:** An open-source monitoring tool running in a Docker container on a `t3.micro` EC2 instance in the Prod VPC. Exposed publicly via an Application Load Balancer — no SSH required to view it.
+
+**What it monitors:**
+
+| Probe | From | To | Protocol | Expected | Why |
+|---|---|---|---|---|---|
+| G1 | Gatus (prod) | DB VM | ICMP | 🟢 GREEN | `allow-prod-to-db` — legitimate traffic |
+| G2 | Gatus (prod) | Dev VM | ICMP | 🔴 RED | `deny-prod-to-dev` — lateral movement blocked |
+| G3 | Gatus (prod) | Dev VM | TCP:22 | 🔴 RED | `default-deny-all` — default deny catches everything else |
+
+**Why Gatus is in the Prod SmartGroup:** The Gatus VM is tagged `Environment=production` so it's classified into `prod-smartgroup`. This means the `allow-prod-to-db` policy applies — Gatus probes can reach the DB VM and show GREEN. If it were tagged differently and unclassified, `default-deny-all` would block all its probes.
+
+**Gatus gap:** Policies 110 and 200 (dev-originated traffic) can't be covered by Gatus because Gatus only runs in the prod spoke. Manual SSH from the dev VM is required for those two policies.
+
+**Demo tip:** Open the Gatus URL in a browser tab before the call. Leave it running — the audience watches live enforcement in real time with no commands needed. One green tile (legitimate traffic) and two red tiles (lateral movement blocked) tell the whole story visually.
+
+---
+
+## How It All Connects — Traffic Flow Example
+
+**Scenario: Attacker compromises Dev VM, tries to reach DB**
+
+```
+1. Dev VM (10.1.0.74) sends ICMP to DB VM (10.3.0.74)
+2. Traffic enters Dev Spoke Gateway
+3. Dev Spoke Gateway forwards to Transit Gateway
+4. DCF at Transit Gateway evaluates against policy list:
+   - Priority 100 (allow-prod-to-db): source is dev, not prod → SKIP
+   - Priority 110 (allow-dev-to-prod-read-only): dest is db, not prod → SKIP
+   - Priority 200 (deny-dev-to-db): source is dev ✓, dest is db ✓ → DENY ✓
+5. Traffic is dropped. DCF Monitor logs a DENIED entry.
+6. Gatus dashboard: no change (Gatus is in prod, not dev)
+7. Manual test: ping times out from dev VM
+```
+
+**Customer message:** "The attacker is stopped at the network fabric — not at the destination host. There's nothing to compromise at the DB because the traffic never arrives."
+
+---
+
+## Deployment Time Breakdown
+
+| Phase | Duration | What happens |
+|---|---|---|
+| VPC + Subnet creation | ~1 min | AWS networking resources |
+| Transit Gateway deployment | ~3–5 min | Aviatrix gateway in transit VPC |
+| Spoke Gateway deployment (×3, parallel) | ~3–5 min | Three gateways deploy in parallel |
+| Transit-Spoke attachments | ~1 min | Routing established |
+| DCF + SmartGroups + Policies | ~30 sec | Policy configuration via Controller API |
+| Test VMs + Gatus + ALB | ~2 min | EC2 instances and load balancer |
+| Gatus startup (Docker) | ~3–5 min | After apply — wait before opening dashboard |
+| **Total** | **~15 min** | |
+
+---
+
+## What's NOT Deployed (By Design)
+
+| Item | Why not |
+|---|---|
+| CoPilot | Pre-existing prerequisite — the Controller can only associate one CoPilot at a time |
+| NAT Gateway | Not needed — gateways have public IPs via EIPs |
+| VPN / Direct Connect | Out of scope for this demo |
+| HA Gateways | Demo environment — HA can be enabled via `transit_gateway.ha_enabled = true` variable |
+| Multi-region | Single region demo — Aviatrix DCF works identically across regions and clouds |

--- a/blueprints/prevent-lateral-movement-vm-tags/README.md
+++ b/blueprints/prevent-lateral-movement-vm-tags/README.md
@@ -1,0 +1,403 @@
+# Prevent Lateral Movement - VM Tags
+
+Deploy **Zero Trust microsegmentation** in 15 minutes using Aviatrix Distributed Cloud Firewall (DCF) and SmartGroups. This blueprint enforces tag-based network segmentation across AWS VPCs — preventing lateral movement, accelerating compliance, and eliminating security group sprawl.
+
+> [!TIP]
+> **🤖 Optimized for Claude Code** — Run `/deploy-blueprint prevent-lateral-movement-vm-tags` for AI-guided deployment with prerequisite checks, or `/analyze-blueprint prevent-lateral-movement-vm-tags` for resource and cost details. [Get Claude Code](https://claude.ai/code)
+
+---
+
+## Prerequisites
+
+### Aviatrix Control Plane
+
+| Component | Requirement | Notes |
+|-----------|-------------|-------|
+| **Aviatrix Controller** | v7.1+ | Must be deployed, accessible, and have your AWS account onboarded under **Accounts > Access Accounts** |
+| **Aviatrix CoPilot** | Required | Used for topology visualization, DCF Monitor, and SmartGroup verification during the demo |
+| **DCF** | Must be **enabled** | Enable DCF before deploying: Controller > Security > Distributed Cloud Firewall > Configuration > Enable. This blueprint manages SmartGroups and policies only — it does not enable/disable DCF, so `terraform destroy` will never conflict with other active policies. |
+
+### Local Tools
+
+| Tool | Version | Installation | Purpose |
+|------|---------|--------------|---------|
+| **Terraform** | >= 1.5 | [Install Guide](https://developer.hashicorp.com/terraform/install) | Infrastructure provisioning |
+| **AWS CLI** | v2 | [Install Guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) | AWS authentication and EC2 Instance Connect |
+
+### AWS IAM Permissions
+
+Two IAM roles must exist in your AWS account **before** deploying. The Aviatrix Controller uses these roles to launch and manage gateways.
+
+| Role | Policies Required | Purpose |
+|------|------------------|---------|
+| `aviatrix-role-app` | `PowerUserAccess` + `IAMReadOnlyAccess` + custom `AviatrixIAMAccess`* | Controller assumes this role to manage AWS resources |
+| `aviatrix-role-ec2` | `AmazonS3ReadOnlyAccess` | Attached to gateway EC2 instances for software updates |
+
+**\*Custom `AviatrixIAMAccess` policy actions required:**
+`iam:CreateInstanceProfile`, `iam:DeleteInstanceProfile`, `iam:AddRoleToInstanceProfile`, `iam:RemoveRoleFromInstanceProfile`, `iam:GetInstanceProfile`, `iam:TagInstanceProfile`, `iam:UntagInstanceProfile`, `iam:PassRole`, `iam:GetRole`, `iam:GetRolePolicy`, `iam:ListInstanceProfiles`, `iam:ListRoles`
+
+> **Trust relationships:** `aviatrix-role-app` must trust the AWS account where your Controller runs (`arn:aws:iam::<controller-account-id>:root`). `aviatrix-role-ec2` must trust the EC2 service (`ec2.amazonaws.com`).
+>
+> If these roles don't exist, see the [Aviatrix onboarding documentation](https://docs.aviatrix.com/documentation/latest/getting-started/onboarding-aws-access-account.html).
+
+### Environment Variables
+
+Set these before running Terraform:
+
+```bash
+# Aviatrix Controller credentials
+export AVIATRIX_CONTROLLER_IP="<your-controller-ip>"
+export AVIATRIX_USERNAME="admin"
+export AVIATRIX_PASSWORD="<your-password>"
+
+# AWS credentials (choose one method)
+# Option A: Environment variables
+export AWS_ACCESS_KEY_ID="<your-access-key>"
+export AWS_SECRET_ACCESS_KEY="<your-secret-key>"
+export AWS_DEFAULT_REGION="us-east-1"
+
+# Option B: AWS CLI profile
+export AWS_PROFILE="<your-profile-name>"
+```
+
+### Verify Prerequisites
+
+```bash
+# Confirm AWS credentials are active
+aws sts get-caller-identity
+
+# Confirm EC2 key pair exists in the target region
+aws ec2 describe-key-pairs --region us-east-1 --query 'KeyPairs[].KeyName'
+
+# Confirm sufficient Elastic IP quota (need 4 free EIPs)
+aws ec2 describe-account-attributes --attribute-names max-elastic-ips --query 'AccountAttributes[0].AttributeValues[0].AttributeValue'
+aws ec2 describe-addresses --query 'Addresses | length(@)'
+# Available EIPs = quota - current count. Must be >= 4.
+```
+
+Also confirm in the Aviatrix Controller that your AWS account is onboarded under **Accounts > Access Accounts** before proceeding. Gateway creation will time out if the account is not onboarded.
+
+---
+
+## Architecture Overview
+
+![Architecture Diagram](architecture.svg)
+
+> **For a detailed breakdown of every component, how they connect, and what to explain during a customer demo, see [ARCHITECTURE.md](ARCHITECTURE.md).**
+
+This blueprint deploys the following into a single AWS region:
+
+| Component | Count | Description |
+|-----------|-------|-------------|
+| Aviatrix Transit Gateway | 1 | Central hub connecting all spokes |
+| Aviatrix Spoke Gateways | 3 | One each for Dev, Prod, and DB VPCs |
+| AWS VPCs | 4 | Transit + Dev + Prod + DB |
+| EC2 Test VMs | 3 | One per spoke VPC for connectivity testing |
+| EC2 Instance Connect Endpoints | 2 | Secure, keyless SSH tunnel to Dev and Prod VMs — no bastion, no public IP needed |
+| DCF SmartGroups | 3 | Tag-based groups: dev, prod, db |
+| DCF Policies | 5 | Zero Trust rules — see table below |
+| Gatus Dashboard | 1 | Live connectivity dashboard (ALB-exposed, browser accessible) |
+
+**DCF Policies configured:**
+
+| Priority | Policy | Action | What it proves |
+|----------|--------|--------|----------------|
+| 100 | `allow-prod-to-db` | PERMIT | Legitimate business traffic flows |
+| 110 | `allow-dev-to-prod-read-only` | PERMIT (ICMP only) | Protocol-level granularity |
+| 200 | `deny-dev-to-db` | DENY | Lateral movement from dev to production data blocked |
+| 210 | `deny-prod-to-dev` | DENY | Compromised prod cannot reach dev |
+| 1000 | `default-deny-all` | DENY | Zero Trust default — no implicit trust |
+
+---
+
+## Resources Created
+
+| Resource | Quantity | Estimated Cost/Hour |
+|----------|----------|---------------------|
+| Aviatrix Transit Gateway (t3.small) | 1 | $0.05 |
+| Aviatrix Spoke Gateways (t3.small) | 3 | $0.15 |
+| EC2 Test VMs (t3.micro) | 3 | $0.03 |
+| EC2 Gatus Instance (t3.micro) | 1 | $0.01 |
+| Application Load Balancer | 1 | $0.02 |
+| Elastic IPs | 4 | $0.02 |
+| EC2 Instance Connect Endpoints | 2 | Free |
+| VPCs, Subnets, Route Tables, IGWs | Multiple | Free |
+| DCF SmartGroups + Policies | 3 + 5 | Free |
+
+**Total: ~$0.28/hour (~$6.70/day)**
+
+> Destroy resources after testing to avoid ongoing charges.
+
+---
+
+## Quickstart
+
+```bash
+git clone https://github.com/AviatrixSystems/aviatrix-blueprints.git
+cd aviatrix-blueprints/blueprints/prevent-lateral-movement-vm-tags
+
+# Set credentials (see Prerequisites)
+export AVIATRIX_CONTROLLER_IP="<your-controller-ip>"
+export AVIATRIX_USERNAME="admin"
+export AVIATRIX_PASSWORD="<your-password>"
+export AWS_PROFILE="<your-profile>"
+
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your values
+
+terraform init
+terraform apply
+```
+
+**Total deployment time: ~15 minutes**
+
+---
+
+## Deployment Guide
+
+### Step 1: Clone and Navigate
+
+```bash
+git clone https://github.com/AviatrixSystems/aviatrix-blueprints.git
+cd aviatrix-blueprints/blueprints/prevent-lateral-movement-vm-tags
+```
+
+### Step 2: Configure Variables
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars` with your values:
+
+```hcl
+aws_account_name      = "my-aws-account"  # Must match account name in Controller > Accounts
+aws_region            = "us-east-1"
+name_prefix           = "zt-seg"
+test_vm_key_name      = "my-keypair"      # Must exist in the target region
+test_vm_instance_type = "t3.micro"
+```
+
+### Step 3: Deploy
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+Type `yes` when prompted. **Deployment takes approximately 10–15 minutes.**
+
+### Step 4: Open the Gatus Live Dashboard
+
+```bash
+terraform output gatus_dashboard_url
+```
+
+Open the URL in a browser. Wait 3–5 minutes after apply for the Gatus instance to boot and pass ALB health checks. If you see **503**, wait 60 seconds and refresh.
+
+**What you'll see:**
+
+| Tile | Status | What it proves |
+|------|--------|----------------|
+| Prod → DB (ALLOWED) | 🟢 Healthy | `allow-prod-to-db` policy permitting legitimate traffic |
+| Prod → Dev ICMP (BLOCKED) | 🔴 Unhealthy | `deny-prod-to-dev` blocking lateral movement |
+| Prod → Dev TCP (BLOCKED) | 🔴 Unhealthy | `default-deny-all` catching everything else |
+
+Dashboard probes update every 10 seconds. Leave it open during the demo — the audience sees live DCF enforcement without any commands.
+
+### Step 5: Verify in CoPilot
+
+1. Log into your Controller and click **CoPilot** in the top navigation
+2. **Cloud Fabric > Topology** — verify Transit + 3 Spoke gateways are visible and connected
+3. **Security > Distributed Cloud Firewall > SmartGroups** — verify 3 SmartGroups exist with correct VM membership
+4. **Security > Distributed Cloud Firewall > Rules** — verify all 5 policies are configured
+5. **Security > Distributed Cloud Firewall > Monitor** — use this during test scenarios to see live PERMITTED/DENIED entries
+
+---
+
+## Test Scenarios
+
+### Automated — Gatus Dashboard (from Prod)
+
+| # | Flow | Protocol | Expected | DCF Policy |
+|---|------|----------|----------|------------|
+| G1 | Prod → DB | ICMP | 🟢 GREEN | `allow-prod-to-db` (priority 100) |
+| G2 | Prod → Dev | ICMP | 🔴 RED | `deny-prod-to-dev` (priority 210) |
+| G3 | Prod → Dev | TCP:22 | 🔴 RED | `default-deny-all` (priority 1000) |
+
+### Manual — SSH Testing
+
+Connect to any test VM using EC2 Instance Connect (no key file or bastion needed):
+
+```bash
+# Get instance IDs
+terraform output test_vm_ids
+
+# SSH to any VM
+aws ec2-instance-connect ssh --instance-id <instance-id> --region us-east-1
+```
+
+| # | Flow | Protocol | Expected | DCF Policy |
+|---|------|----------|----------|------------|
+| M1 | Dev → DB | ICMP | ❌ BLOCKED | `deny-dev-to-db` (priority 200) |
+| M2 | Prod → DB | ICMP | ✅ ALLOWED | `allow-prod-to-db` (priority 100) |
+| M3 | Dev → Prod | ICMP | ✅ ALLOWED | `allow-dev-to-prod-read-only` (priority 110) |
+| M3 | Dev → Prod | TCP | ❌ BLOCKED | `default-deny-all` (priority 1000) |
+| M4 | Prod → Dev | ICMP | ❌ BLOCKED | `deny-prod-to-dev` (priority 210) |
+
+**Run a test:**
+
+```bash
+# ICMP test
+ping <target-private-ip>
+
+# TCP test (wait up to 10s for timeout — timeout means DCF blocked it)
+nc -zv -w 10 <target-private-ip> 22
+```
+
+**Policy coverage matrix:**
+
+| Priority | Policy | Gatus | Manual |
+|----------|--------|-------|--------|
+| 100 | `allow-prod-to-db` | ✅ G1 | ✅ M2 |
+| 110 | `allow-dev-to-prod-read-only` | ❌ gap* | ✅ M3 |
+| 200 | `deny-dev-to-db` | ❌ gap* | ✅ M1 |
+| 210 | `deny-prod-to-dev` | ✅ G2 | ✅ M4 |
+| 1000 | `default-deny-all` | ✅ G3 | ✅ M3 |
+
+*Gatus runs in the prod spoke and cannot initiate probes from dev. Policies 110 and 200 require manual SSH testing from the dev VM.
+
+---
+
+## Demo Walkthrough
+
+Use this sequence to tell the Zero Trust story on a customer call (~15 minutes):
+
+### 1. The Problem (2 min)
+> *"Traditional security groups create flat networks — once two workloads are connected, everything can talk to everything. 83% of ransomware attacks succeed through lateral movement across unsegmented networks."*
+
+**Show:** CoPilot > Topology — the hub-and-spoke architecture visually separating Dev, Prod, and DB.
+
+### 2. SmartGroups: Automated Zero Trust Boundaries (3 min)
+> *"New workloads tagged `Environment=production` instantly inherit Zero Trust policies — no manual security group updates, no tickets, no delay."*
+
+**Show:** Security > DCF > SmartGroups — click into `dev-smartgroup`, show the `Environment=development` selector.
+
+### 3. Zero Trust Policies: Default-Deny + Explicit Allow (3 min)
+**Show:** Security > DCF > Rules — walk through the policy list:
+- Priority 100 (`allow-prod-to-db`): *"Explicit allow for legitimate business need"*
+- Priority 200 (`deny-dev-to-db`): *"Zero Trust blocks dev from production data — prevents lateral movement"*
+- Priority 1000 (`default-deny-all`): *"No implicit trust — everything is blocked unless explicitly permitted"*
+
+### 4. Live Testing: Proving it Works (5 min)
+**Show the Gatus dashboard** — two red tiles proving lateral movement is blocked in real time.
+
+Then SSH from dev VM and try to ping the DB:
+```bash
+ping <db-vm-private-ip>  # Times out — DCF blocked it
+```
+
+**Show CoPilot > DCF > Monitor** — the DENIED entry appears with source, destination, and policy name.
+
+### 5. Business Value (2 min)
+| Outcome | Traditional | Aviatrix Zero Trust |
+|---------|-------------|---------------------|
+| Deployment time | 2–4 weeks (manual SG rules) | ⚡ 15 minutes |
+| Lateral movement | ❌ Flat network | ✅ Blocked |
+| Policy management | Manual per-workload | ✅ Tag-based automation |
+| Compliance audit trail | VPC Flow Logs (delayed) | ✅ Real-time DCF Monitor |
+
+---
+
+## Cleanup
+
+### Destroy Notes
+
+This blueprint does not manage DCF enable/disable — only SmartGroups and policies. `terraform destroy` removes only the resources this blueprint created. Your Controller's DCF configuration remains untouched.
+
+### Destroy
+
+```bash
+terraform destroy
+```
+
+Type `yes` when prompted. **Destroy takes approximately 8–10 minutes.**
+
+### Manual Cleanup (if destroy fails)
+
+Delete resources in this order:
+
+1. **DCF Policies** — CoPilot: Security > DCF > Rules > delete all policies
+2. **SmartGroups** — CoPilot: Security > DCF > SmartGroups > delete all groups
+3. **Spoke Gateways** — CoPilot: Cloud Fabric > Gateways > delete each spoke
+4. **Transit Gateway** — CoPilot: Cloud Fabric > Gateways > delete transit
+5. **EC2 Instances** — AWS Console: EC2 > Instances > terminate all VMs
+6. **VPCs** — AWS Console: VPC > Your VPCs > delete all VPCs
+
+### Verify Cleanup
+
+```bash
+# Check for remaining VPCs
+aws ec2 describe-vpcs \
+  --filters "Name=tag:Blueprint,Values=prevent-lateral-movement-vm-tags" \
+  --query 'Vpcs[].VpcId'
+
+# Check for remaining instances
+aws ec2 describe-instances \
+  --filters "Name=tag:Blueprint,Values=prevent-lateral-movement-vm-tags" \
+  --query 'Reservations[].Instances[].InstanceId'
+```
+
+Both commands should return `[]`.
+
+---
+
+## Troubleshooting
+
+**Gateway creation times out**
+- Verify AWS account is onboarded in the Controller under **Accounts > Access Accounts**
+- Confirm `aviatrix-role-app` and `aviatrix-role-ec2` IAM roles exist in your AWS account
+- Check sufficient EIP quota (need 4 free EIPs): `aws ec2 describe-addresses --query 'Addresses | length(@)'`
+
+**DCF policies not enforcing**
+- Verify DCF is enabled: Controller > Security > DCF > Configuration
+- Check SmartGroup membership: Security > DCF > SmartGroups > click group > confirm VMs are listed
+- Ensure test VMs have the correct `Environment` tag (verify in EC2 console)
+- Wait 1–2 minutes for policy changes to propagate
+
+**Gatus dashboard shows 503**
+- ALB health check hasn't passed yet — wait 60 seconds and refresh
+- The Gatus EC2 instance needs ~3–5 minutes to boot, pull Docker image, and start the container
+
+**`terraform destroy` fails with DCF error**
+- This should not occur as this blueprint does not manage DCF enable/disable
+- If it does, verify you are running the latest version of the blueprint
+
+**Can't SSH to test VMs**
+- Use EC2 Instance Connect: `aws ec2-instance-connect ssh --instance-id <id> --region us-east-1`
+- Confirm the EICE endpoint is deployed (it is by default for dev and prod VMs)
+- DB VM has no EICE — use SSM instead: `aws ssm start-session --target <instance-id>`
+
+---
+
+## Tested With
+
+| Component | Version |
+|-----------|---------|
+| Aviatrix Controller | 7.2.x |
+| Aviatrix Terraform Provider | 8.2.x |
+| Terraform | 1.9.x |
+| AWS Provider | 6.32.x |
+
+> Provider version must match your Controller version. See the [full compatibility matrix](https://registry.terraform.io/providers/AviatrixSystems/aviatrix/latest/docs/guides/release-compatibility).
+
+---
+
+## Contributing
+
+See the [Contributing Guide](../../CONTRIBUTING.md).
+
+## License
+
+Apache 2.0 — see [LICENSE](../../LICENSE).

--- a/blueprints/prevent-lateral-movement-vm-tags/architecture.svg
+++ b/blueprints/prevent-lateral-movement-vm-tags/architecture.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <!-- Placeholder architecture diagram -->
+  <!-- TODO: Create proper architecture diagram showing:
+       - Transit Gateway in center
+       - Three spokes (Dev, Prod, DB) connected to transit
+       - Test VMs in each spoke
+       - DCF policy arrows showing allowed/denied traffic
+  -->
+  <rect width="800" height="600" fill="#f8f9fa"/>
+  <text x="400" y="280" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" fill="#666">
+    Architecture Diagram Placeholder
+  </text>
+  <text x="400" y="320" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#999">
+    Create a visual diagram showing:
+  </text>
+  <text x="400" y="345" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#999">
+    • Transit Gateway (center)
+  </text>
+  <text x="400" y="365" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#999">
+    • Three Spoke Gateways (Dev, Prod, DB)
+  </text>
+  <text x="400" y="385" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#999">
+    • Test VMs in each spoke
+  </text>
+  <text x="400" y="405" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#999">
+    • Green arrows for allowed traffic
+  </text>
+  <text x="400" y="425" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#999">
+    • Red X for denied traffic
+  </text>
+</svg>

--- a/blueprints/prevent-lateral-movement-vm-tags/dcf.tf
+++ b/blueprints/prevent-lateral-movement-vm-tags/dcf.tf
@@ -1,0 +1,151 @@
+# ============================================================================
+# Distributed Cloud Firewall (DCF) Configuration
+# ============================================================================
+
+# ============================================================================
+# SmartGroups - Define network segments
+# ============================================================================
+# NOTE: DCF must already be enabled on your Controller before deploying this
+# blueprint. Enable it at: Controller > Security > Distributed Cloud Firewall
+# > Configuration > Enable. This blueprint does not manage DCF enable/disable
+# so that terraform destroy never conflicts with other active DCF policies.
+
+# Development Environment SmartGroup
+resource "aviatrix_smart_group" "dev" {
+  name = "${var.name_prefix}-dev-smartgroup"
+
+  selector {
+    match_expressions {
+      type         = "vm"
+      account_name = var.aws_account_name
+      region       = var.aws_region
+      tags = {
+        Environment = "development"
+      }
+    }
+  }
+}
+
+# Production Environment SmartGroup
+resource "aviatrix_smart_group" "prod" {
+  name = "${var.name_prefix}-prod-smartgroup"
+
+  selector {
+    match_expressions {
+      type         = "vm"
+      account_name = var.aws_account_name
+      region       = var.aws_region
+      tags = {
+        Environment = "production"
+      }
+    }
+  }
+}
+
+# Database Environment SmartGroup
+resource "aviatrix_smart_group" "db" {
+  name = "${var.name_prefix}-db-smartgroup"
+
+  selector {
+    match_expressions {
+      type         = "vm"
+      account_name = var.aws_account_name
+      region       = var.aws_region
+      tags = {
+        Environment = "database"
+      }
+    }
+  }
+}
+
+# ============================================================================
+# DCF Policies - Prevent Lateral Movement - VM Tags Rules
+# ============================================================================
+
+resource "aviatrix_distributed_firewalling_policy_list" "main" {
+  depends_on = [
+    aviatrix_smart_group.dev,
+    aviatrix_smart_group.prod,
+    aviatrix_smart_group.db
+  ]
+
+  policies {
+    name     = "allow-prod-to-db"
+    action   = "PERMIT"
+    priority = 100
+    protocol = "ANY"
+    logging  = true
+    watch    = false
+
+    src_smart_groups = [
+      aviatrix_smart_group.prod.uuid
+    ]
+    dst_smart_groups = [
+      aviatrix_smart_group.db.uuid
+    ]
+  }
+
+  policies {
+    name     = "allow-dev-to-prod-read-only"
+    action   = "PERMIT"
+    priority = 110
+    protocol = "ICMP"
+    logging  = true
+    watch    = false
+
+    src_smart_groups = [
+      aviatrix_smart_group.dev.uuid
+    ]
+    dst_smart_groups = [
+      aviatrix_smart_group.prod.uuid
+    ]
+  }
+
+  policies {
+    name     = "deny-dev-to-db"
+    action   = "DENY"
+    priority = 200
+    protocol = "ANY"
+    logging  = true
+    watch    = true # Watch mode to highlight this rule in CoPilot
+
+    src_smart_groups = [
+      aviatrix_smart_group.dev.uuid
+    ]
+    dst_smart_groups = [
+      aviatrix_smart_group.db.uuid
+    ]
+  }
+
+  policies {
+    name     = "deny-prod-to-dev"
+    action   = "DENY"
+    priority = 210
+    protocol = "ANY"
+    logging  = true
+    watch    = false
+
+    src_smart_groups = [
+      aviatrix_smart_group.prod.uuid
+    ]
+    dst_smart_groups = [
+      aviatrix_smart_group.dev.uuid
+    ]
+  }
+
+  policies {
+    name     = "default-deny-all"
+    action   = "DENY"
+    priority = 1000
+    protocol = "ANY"
+    logging  = true
+    watch    = false
+
+    src_smart_groups = [
+      "def000ad-0000-0000-0000-000000000000" # Public Internet
+    ]
+    dst_smart_groups = [
+      "def000ad-0000-0000-0000-000000000000" # Public Internet
+    ]
+  }
+}

--- a/blueprints/prevent-lateral-movement-vm-tags/gatus.tf
+++ b/blueprints/prevent-lateral-movement-vm-tags/gatus.tf
@@ -1,0 +1,227 @@
+# ============================================================================
+# Gatus - Prevent Lateral Movement Live Dashboard
+#
+# Deploys a Gatus instance in the prod spoke VPC to visually reflect
+# segmentation policy outcomes (allowed vs denied traffic).
+# Exposed via an internet-facing ALB — no SSH or SSM required.
+#
+# SE usage: after `terraform apply`, open the `gatus_dashboard_url` output
+# in a browser. No local tooling dependencies.
+#
+# IMPORTANT - DCF SmartGroup classification:
+# This instance is tagged Environment = "production" so it is classified into
+# the prod SmartGroup. This allows the allow-prod-to-db policy (priority 100)
+# to apply — Gatus probes originate from "prod" and can reach "db", producing
+# the GREEN tile in the dashboard. Do not change this tag or the probe results
+# will not reflect the intended DCF policy outcomes.
+# ============================================================================
+
+locals {
+  # Pin private IPs for test VMs so they can be referenced at plan time.
+  # Uses host 10 in each spoke's private /26 subnet to avoid conflicts
+  # with DHCP at the start of the range.
+  #
+  # Default values (with default spokes variable):
+  #   dev  = 10.1.0.74  (cidrhost("10.1.0.64/26", 10))
+  #   prod = 10.2.0.74  (cidrhost("10.2.0.64/26", 10))
+  #   db   = 10.3.0.74  (cidrhost("10.3.0.64/26", 10))
+  test_vm_ips = {
+    for k, v in var.spokes : k => cidrhost(cidrsubnet(v.cidr, 2, 1), 10)
+  }
+}
+
+# ----------------------------------------------------------------------------
+# Second public subnet in prod VPC (required for ALB multi-AZ)
+# ----------------------------------------------------------------------------
+
+resource "aws_subnet" "gatus_alb_subnet" {
+  vpc_id                  = aws_vpc.spokes["prod"].id
+  cidr_block              = cidrsubnet(var.spokes["prod"].cidr, 2, 2)
+  availability_zone       = data.aws_availability_zones.available.names[1]
+  map_public_ip_on_launch = true
+
+  tags = merge(local.common_tags, {
+    Name        = "${var.name_prefix}-gatus-alb-subnet"
+    Environment = "monitoring"
+  })
+}
+
+resource "aws_route_table_association" "gatus_alb_subnet" {
+  subnet_id      = aws_subnet.gatus_alb_subnet.id
+  route_table_id = aws_route_table.spokes_public["prod"].id
+}
+
+# Route Gatus (in prod public subnet) to other spoke VPCs via Aviatrix gateway.
+# Aviatrix only programs routes in private subnet route tables; the public subnet
+# needs this explicit route so Gatus ICMP probes traverse the Aviatrix fabric
+# and are subject to DCF policy evaluation.
+data "aws_instance" "prod_spoke_gw" {
+  # depends_on ensures this data source does not run before the spoke gateway
+  # resource completes. aviatrix_spoke_gateway marks itself done in Terraform
+  # before the underlying EC2 instance reaches "running" state in AWS, so a
+  # tag+state filter races and fails on first apply. Using cloud_instance_id
+  # (assigned at instance creation, before running state) makes the lookup
+  # deterministic on both apply and destroy.
+  depends_on  = [aviatrix_spoke_gateway.spokes]
+  instance_id = aviatrix_spoke_gateway.spokes["prod"].cloud_instance_id
+}
+
+resource "aws_route" "gatus_via_aviatrix" {
+  route_table_id         = aws_route_table.spokes_public["prod"].id
+  destination_cidr_block = "10.0.0.0/8"
+  network_interface_id   = data.aws_instance.prod_spoke_gw.network_interface_id
+
+  depends_on = [aviatrix_spoke_transit_attachment.attachments]
+}
+
+# ----------------------------------------------------------------------------
+# Security Groups
+# ----------------------------------------------------------------------------
+
+resource "aws_security_group" "gatus_alb" {
+  name_prefix = "${var.name_prefix}-gatus-alb-sg"
+  description = "Allows HTTP access to the Gatus dashboard ALB"
+  vpc_id      = aws_vpc.spokes["prod"].id
+
+  ingress {
+    description = "HTTP to Gatus dashboard"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [var.gatus_allowed_cidr]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-gatus-alb-sg"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group" "gatus" {
+  name_prefix = "${var.name_prefix}-gatus-sg"
+  description = "Allows ALB to reach Gatus on port 8080"
+  vpc_id      = aws_vpc.spokes["prod"].id
+
+  ingress {
+    description     = "Gatus UI from ALB only"
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    security_groups = [aws_security_group.gatus_alb.id]
+  }
+
+  egress {
+    description = "Allow all outbound (Gatus needs to reach test VMs)"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-gatus-sg"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# ----------------------------------------------------------------------------
+# Gatus EC2 Instance
+# Placed in the prod public subnet so it can route to other spoke VMs
+# via the Aviatrix transit gateway.
+# ----------------------------------------------------------------------------
+
+resource "aws_instance" "gatus" {
+  ami                         = data.aws_ami.amazon_linux_2.id
+  instance_type               = var.test_vm_instance_type
+  key_name                    = var.test_vm_key_name
+  subnet_id                   = aws_subnet.spokes_public["prod"].id
+  vpc_security_group_ids      = [aws_security_group.gatus.id]
+  associate_public_ip_address = true # needs outbound internet to pull Docker image; inbound still restricted to ALB via SG
+
+  user_data = base64encode(templatefile("${path.module}/gatus_config.tftpl", {
+    dev_ip  = aws_instance.test_vms["dev"].private_ip
+    prod_ip = aws_instance.test_vms["prod"].private_ip
+    db_ip   = aws_instance.test_vms["db"].private_ip
+  }))
+
+  tags = merge(local.common_tags, {
+    Name        = "${var.name_prefix}-gatus"
+    Environment = "production"
+    Role        = "gatus-monitor"
+  })
+
+  depends_on = [aws_instance.test_vms]
+}
+
+# ----------------------------------------------------------------------------
+# Application Load Balancer
+# ----------------------------------------------------------------------------
+
+resource "aws_lb" "gatus" {
+  name               = "${var.name_prefix}-gatus-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.gatus_alb.id]
+
+  subnets = [
+    aws_subnet.spokes_public["prod"].id,
+    aws_subnet.gatus_alb_subnet.id
+  ]
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-gatus-alb"
+  })
+}
+
+resource "aws_lb_target_group" "gatus" {
+  name        = "${var.name_prefix}-gatus-tg"
+  port        = 8080
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.spokes["prod"].id
+  target_type = "instance"
+
+  health_check {
+    path                = "/"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    matcher             = "200"
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-gatus-tg"
+  })
+}
+
+resource "aws_lb_target_group_attachment" "gatus" {
+  target_group_arn = aws_lb_target_group.gatus.arn
+  target_id        = aws_instance.gatus.id
+  port             = 8080
+}
+
+resource "aws_lb_listener" "gatus" {
+  load_balancer_arn = aws_lb.gatus.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.gatus.arn
+  }
+}

--- a/blueprints/prevent-lateral-movement-vm-tags/gatus_config.tftpl
+++ b/blueprints/prevent-lateral-movement-vm-tags/gatus_config.tftpl
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+
+yum update -y
+amazon-linux-extras install -y docker
+systemctl start docker
+systemctl enable docker
+
+mkdir -p /etc/gatus
+
+# Write Gatus config with actual test VM IPs substituted by Terraform templatefile().
+# Endpoints reflect the DCF policies enforced by Aviatrix:
+#   - Prod → DB:      PERMIT (policy: allow-prod-to-db)
+#   - Prod → Dev:     DENY   (policy: deny-prod-to-dev)
+#   - Prod → Dev TCP: DENY   (no permit rule; caught by default-deny-all)
+#
+# Note: this instance must be in the Prod SmartGroup (Environment = "production")
+# for the ALLOW result to appear green. See the DCF classification note in gatus.tf.
+cat > /etc/gatus/config.yaml <<GATUS_CONFIG
+storage:
+  type: memory
+metrics: false
+ui:
+  title: "Prevent Lateral Movement - Live Policy Dashboard"
+  header: "Aviatrix DCF | Real-time segmentation enforcement"
+endpoints:
+  - name: "Prod to DB (ALLOWED — legitimate business traffic)"
+    group: "Should Be GREEN"
+    url: "icmp://${db_ip}"
+    interval: 10s
+    conditions:
+      - "[CONNECTED] == true"
+  - name: "Prod to Dev ICMP (BLOCKED — no lateral movement)"
+    group: "Should Be RED"
+    url: "icmp://${dev_ip}"
+    interval: 10s
+    conditions:
+      - "[CONNECTED] == true"
+  - name: "Prod to Dev TCP (BLOCKED — default deny)"
+    group: "Should Be RED"
+    url: "tcp://${dev_ip}:22"
+    interval: 10s
+    conditions:
+      - "[CONNECTED] == true"
+GATUS_CONFIG
+
+# --network host required so ICMP probes run on the EC2 instance's network stack
+docker run -d \
+  --name gatus \
+  --restart always \
+  --network host \
+  -v /etc/gatus:/config:ro \
+  twinproduction/gatus:latest

--- a/blueprints/prevent-lateral-movement-vm-tags/main.tf
+++ b/blueprints/prevent-lateral-movement-vm-tags/main.tf
@@ -1,0 +1,360 @@
+locals {
+  common_tags = {
+    Blueprint   = "prevent-lateral-movement-vm-tags"
+    ManagedBy   = "Terraform"
+    Environment = "Demo"
+    Owner       = var.name_prefix
+  }
+}
+
+# Get latest Amazon Linux 2 AMI
+data "aws_ami" "amazon_linux_2" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# ============================================================================
+# Transit Gateway and VPC
+# ============================================================================
+
+resource "aws_vpc" "transit" {
+  cidr_block           = var.transit_gateway.cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-transit-vpc"
+  })
+}
+
+resource "aws_subnet" "transit_public" {
+  vpc_id                  = aws_vpc.transit.id
+  cidr_block              = cidrsubnet(var.transit_gateway.cidr, 2, 0)
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-transit-public-subnet"
+  })
+}
+
+resource "aws_internet_gateway" "transit" {
+  vpc_id = aws_vpc.transit.id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-transit-igw"
+  })
+}
+
+resource "aws_route_table" "transit_public" {
+  vpc_id = aws_vpc.transit.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.transit.id
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-transit-public-rt"
+  })
+}
+
+resource "aws_route_table_association" "transit_public" {
+  subnet_id      = aws_subnet.transit_public.id
+  route_table_id = aws_route_table.transit_public.id
+}
+
+# Aviatrix Transit Gateway
+resource "aviatrix_transit_gateway" "main" {
+  cloud_type   = 1 # AWS
+  account_name = var.aws_account_name
+  gw_name      = "${var.name_prefix}-transit-gw"
+  vpc_id       = aws_vpc.transit.id
+  vpc_reg      = var.aws_region
+  gw_size      = "t3.small"
+  subnet       = aws_subnet.transit_public.cidr_block
+  ha_subnet    = var.transit_gateway.ha_enabled ? cidrsubnet(var.transit_gateway.cidr, 2, 1) : null
+  ha_gw_size   = var.transit_gateway.ha_enabled ? "t3.small" : null
+
+  local_as_number               = var.transit_gateway.asn
+  enable_segmentation           = true
+  enable_transit_firenet        = false
+  connected_transit             = true
+  enable_advertise_transit_cidr = true
+  enable_active_standby         = false
+  enable_gateway_load_balancer  = false
+  enable_vpc_dns_server         = false
+  enable_encrypt_volume         = true
+  enable_preserve_as_path       = false
+  enable_bgp_over_lan           = false
+
+  tags = local.common_tags
+}
+
+# ============================================================================
+# Spoke Gateways and VPCs
+# ============================================================================
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_vpc" "spokes" {
+  for_each = var.spokes
+
+  cidr_block           = each.value.cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(local.common_tags, {
+    Name        = "${var.name_prefix}-${each.key}-vpc"
+    Environment = each.value.environment
+  })
+}
+
+resource "aws_subnet" "spokes_public" {
+  for_each = var.spokes
+
+  vpc_id                  = aws_vpc.spokes[each.key].id
+  cidr_block              = cidrsubnet(each.value.cidr, 2, 0)
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
+
+  tags = merge(local.common_tags, {
+    Name        = "${var.name_prefix}-${each.key}-public-subnet"
+    Environment = each.value.environment
+  })
+}
+
+resource "aws_subnet" "spokes_private" {
+  for_each = var.spokes
+
+  vpc_id            = aws_vpc.spokes[each.key].id
+  cidr_block        = cidrsubnet(each.value.cidr, 2, 1)
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = merge(local.common_tags, {
+    Name        = "${var.name_prefix}-${each.key}-private-subnet"
+    Environment = each.value.environment
+  })
+}
+
+resource "aws_internet_gateway" "spokes" {
+  for_each = var.spokes
+
+  vpc_id = aws_vpc.spokes[each.key].id
+
+  tags = merge(local.common_tags, {
+    Name        = "${var.name_prefix}-${each.key}-igw"
+    Environment = each.value.environment
+  })
+}
+
+resource "aws_route_table" "spokes_public" {
+  for_each = var.spokes
+
+  vpc_id = aws_vpc.spokes[each.key].id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.spokes[each.key].id
+  }
+
+  tags = merge(local.common_tags, {
+    Name        = "${var.name_prefix}-${each.key}-public-rt"
+    Environment = each.value.environment
+  })
+}
+
+resource "aws_route_table_association" "spokes_public" {
+  for_each = var.spokes
+
+  subnet_id      = aws_subnet.spokes_public[each.key].id
+  route_table_id = aws_route_table.spokes_public[each.key].id
+}
+
+# Aviatrix Spoke Gateways
+resource "aviatrix_spoke_gateway" "spokes" {
+  for_each = var.spokes
+
+  cloud_type   = 1 # AWS
+  account_name = var.aws_account_name
+  gw_name      = "${var.name_prefix}-${each.key}-spoke-gw"
+  vpc_id       = aws_vpc.spokes[each.key].id
+  vpc_reg      = var.aws_region
+  gw_size      = "t3.small"
+  subnet       = aws_subnet.spokes_public[each.key].cidr_block
+
+  enable_encrypt_volume = true
+  enable_active_standby = false
+
+  tags = merge(local.common_tags, {
+    Environment = each.value.environment
+  })
+}
+
+# ============================================================================
+# EC2 Instance Connect Endpoints (EICE)
+# ============================================================================
+# One endpoint per spoke VPC — allows SEs to SSH tunnel to private test VMs
+# using only their existing AWS credentials. No public IPs, no key management,
+# no IP whitelisting required. The `aws ec2-instance-connect ssh` command in
+# the gatus_dashboards output auto-discovers these endpoints.
+#
+# Only dev and prod need endpoints (Gatus runs there). DB is a target-only VM.
+
+# Security group for EC2 Instance Connect Endpoints.
+# Allows outbound SSH (port 22) to the spoke VPC CIDR only.
+resource "aws_security_group" "eice" {
+  for_each = { for k, v in var.spokes : k => v if k != "db" }
+
+  name_prefix = "${var.name_prefix}-${each.key}-eice-sg"
+  description = "Security group for EC2 Instance Connect Endpoint in ${each.key} spoke"
+  vpc_id      = aws_vpc.spokes[each.key].id
+
+  egress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.spokes[each.key].cidr]
+    description = "SSH to ${each.key} spoke VMs only"
+  }
+
+  tags = merge(local.common_tags, {
+    Name        = "${var.name_prefix}-${each.key}-eice-sg"
+    Environment = each.value.environment
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_ec2_instance_connect_endpoint" "spokes" {
+  for_each = { for k, v in var.spokes : k => v if k != "db" }
+
+  subnet_id          = aws_subnet.spokes_public[each.key].id
+  security_group_ids = [aws_security_group.eice[each.key].id]
+  preserve_client_ip = false
+
+  tags = merge(local.common_tags, {
+    Name        = "${var.name_prefix}-${each.key}-eice"
+    Environment = each.value.environment
+  })
+}
+
+# ============================================================================
+# Test VMs (one per spoke)
+# ============================================================================
+
+resource "aws_security_group" "test_vms" {
+  for_each = var.spokes
+
+  name_prefix = "${var.name_prefix}-${each.key}-vm-sg"
+  description = "Security group for ${each.key} test VM"
+  vpc_id      = aws_vpc.spokes[each.key].id
+
+  # DB has no EICE (target-only VM) — SSH allowed within VPC CIDR only.
+  # Dev/prod SSH is added via aws_security_group_rule below (requires source SG reference).
+  dynamic "ingress" {
+    for_each = each.key == "db" ? [1] : []
+    content {
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = [var.spokes[each.key].cidr]
+      description = "SSH within VPC CIDR only"
+    }
+  }
+
+  # Allow ICMP (ping) from within the RFC1918 range for DCF policy testing
+  ingress {
+    from_port   = -1
+    to_port     = -1
+    protocol    = "icmp"
+    cidr_blocks = ["10.0.0.0/8"]
+    description = "ICMP ping from private address space"
+  }
+
+  # Allow all outbound
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound"
+  }
+
+  tags = merge(local.common_tags, {
+    Name        = "${var.name_prefix}-${each.key}-vm-sg"
+    Environment = each.value.environment
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_instance" "test_vms" {
+  for_each = var.spokes
+
+  ami                    = data.aws_ami.amazon_linux_2.id
+  instance_type          = var.test_vm_instance_type
+  key_name               = var.test_vm_key_name
+  subnet_id              = aws_subnet.spokes_private[each.key].id
+  vpc_security_group_ids = [aws_security_group.test_vms[each.key].id]
+
+  # Pin private IP so Gatus configs can reference it at plan time.
+  # IP is the 10th host in the private /26 subnet for each spoke.
+  private_ip = local.test_vm_ips[each.key]
+
+  user_data = <<-SCRIPT
+    #!/bin/bash
+    yum update -y
+    yum install -y tcpdump netcat nmap
+    hostnamectl set-hostname ${each.key}-test-vm
+    echo "Welcome to ${each.key} test VM" > /etc/motd
+    SCRIPT
+
+  tags = merge(local.common_tags, {
+    Name        = "${var.name_prefix}-${each.key}-test-vm"
+    Environment = each.value.environment
+    Role        = "test-instance"
+  })
+}
+
+# SSH ingress from EICE security group for dev and prod test VMs.
+# Uses aws_security_group_rule (not inline ingress) because source_security_group_id
+# is not supported in inline ingress blocks.
+resource "aws_security_group_rule" "test_vm_ssh_from_eice" {
+  for_each = { for k, v in var.spokes : k => v if k != "db" }
+
+  type                     = "ingress"
+  from_port                = 22
+  to_port                  = 22
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.eice[each.key].id
+  security_group_id        = aws_security_group.test_vms[each.key].id
+  description              = "SSH from EC2 Instance Connect Endpoint only"
+}
+
+# ============================================================================
+# Spoke to Transit Attachments
+# ============================================================================
+
+resource "aviatrix_spoke_transit_attachment" "attachments" {
+  for_each = var.spokes
+
+  spoke_gw_name   = aviatrix_spoke_gateway.spokes[each.key].gw_name
+  transit_gw_name = aviatrix_transit_gateway.main.gw_name
+}

--- a/blueprints/prevent-lateral-movement-vm-tags/outputs.tf
+++ b/blueprints/prevent-lateral-movement-vm-tags/outputs.tf
@@ -1,0 +1,99 @@
+output "transit_gateway_name" {
+  description = "Name of the Aviatrix Transit Gateway"
+  value       = aviatrix_transit_gateway.main.gw_name
+}
+
+output "transit_gateway_id" {
+  description = "ID of the Aviatrix Transit Gateway"
+  value       = aviatrix_transit_gateway.main.id
+}
+
+output "spoke_gateways" {
+  description = "Map of spoke gateway names"
+  value = {
+    for k, v in aviatrix_spoke_gateway.spokes : k => v.gw_name
+  }
+}
+
+output "spoke_vpc_ids" {
+  description = "Map of spoke VPC IDs"
+  value = {
+    for k, v in aws_vpc.spokes : k => v.id
+  }
+}
+
+output "test_vm_private_ips" {
+  description = "Private IP addresses of test VMs"
+  value = {
+    for k, v in aws_instance.test_vms : k => v.private_ip
+  }
+}
+
+output "test_vm_ids" {
+  description = "Instance IDs of test VMs"
+  value = {
+    for k, v in aws_instance.test_vms : k => v.id
+  }
+}
+
+output "smartgroup_uuids" {
+  description = "UUIDs of created SmartGroups"
+  value = {
+    dev  = aviatrix_smart_group.dev.uuid
+    prod = aviatrix_smart_group.prod.uuid
+    db   = aviatrix_smart_group.db.uuid
+  }
+}
+
+output "test_scenarios" {
+  description = "Test scenarios to validate segmentation"
+  value = {
+    scenario_1 = {
+      name         = "Dev trying to access DB (SHOULD BE BLOCKED)"
+      source       = "dev-test-vm (${aws_instance.test_vms["dev"].private_ip})"
+      destination  = "db-test-vm (${aws_instance.test_vms["db"].private_ip})"
+      expected     = "FAIL - Connection should be denied by DCF"
+      test_command = "ping ${aws_instance.test_vms["db"].private_ip}"
+    }
+    scenario_2 = {
+      name         = "Prod accessing DB (SHOULD BE ALLOWED)"
+      source       = "prod-test-vm (${aws_instance.test_vms["prod"].private_ip})"
+      destination  = "db-test-vm (${aws_instance.test_vms["db"].private_ip})"
+      expected     = "SUCCESS - Connection should be permitted"
+      test_command = "ping ${aws_instance.test_vms["db"].private_ip}"
+    }
+    scenario_3 = {
+      name         = "Dev accessing Prod (SHOULD BE ALLOWED - ICMP only)"
+      source       = "dev-test-vm (${aws_instance.test_vms["dev"].private_ip})"
+      destination  = "prod-test-vm (${aws_instance.test_vms["prod"].private_ip})"
+      expected     = "SUCCESS - Ping should work"
+      test_command = "ping ${aws_instance.test_vms["prod"].private_ip}"
+    }
+    scenario_4 = {
+      name         = "Prod trying to access Dev (SHOULD BE BLOCKED)"
+      source       = "prod-test-vm (${aws_instance.test_vms["prod"].private_ip})"
+      destination  = "dev-test-vm (${aws_instance.test_vms["dev"].private_ip})"
+      expected     = "FAIL - Connection should be denied by DCF"
+      test_command = "ping ${aws_instance.test_vms["dev"].private_ip}"
+    }
+  }
+}
+
+output "gatus_dashboard_url" {
+  description = "URL of the live Zero Trust connectivity dashboard (available ~2-3 min after apply once ALB health check passes)"
+  value       = "http://${aws_lb.gatus.dns_name}"
+}
+
+output "copilot_verification_steps" {
+  description = "Steps to verify deployment in CoPilot"
+  value = [
+    "1. Open CoPilot and navigate to Topology",
+    "2. Verify transit gateway and 3 spoke gateways are visible",
+    "3. Navigate to Security > Distributed Cloud Firewall > SmartGroups",
+    "4. Verify 3 SmartGroups exist: dev, prod, db",
+    "5. Navigate to Security > Distributed Cloud Firewall > Rules",
+    "6. Verify 5 policies are configured",
+    "7. Navigate to Security > Distributed Cloud Firewall > Monitor",
+    "8. Run test scenarios and observe traffic (allowed vs denied)"
+  ]
+}

--- a/blueprints/prevent-lateral-movement-vm-tags/terraform.tfvars.example
+++ b/blueprints/prevent-lateral-movement-vm-tags/terraform.tfvars.example
@@ -1,0 +1,58 @@
+# ============================================================================
+# Aviatrix Controller Configuration
+# ============================================================================
+# Set these as environment variables instead:
+# export AVIATRIX_CONTROLLER_IP="<your-controller-ip>"
+# export AVIATRIX_USERNAME="admin"
+# export AVIATRIX_PASSWORD="<your-password>"
+
+# ============================================================================
+# AWS Configuration
+# ============================================================================
+
+# AWS Account name as configured in Aviatrix Controller
+aws_account_name = "my-aws-account"
+
+# AWS region for deployment
+aws_region = "us-east-1"
+
+# ============================================================================
+# Blueprint Configuration
+# ============================================================================
+
+# Prefix for all resource names (keep it short, 8 chars or less)
+name_prefix = "zt-seg"
+
+# EC2 key pair name for SSH access to test VMs
+# Must exist in your AWS account in the specified region
+test_vm_key_name = "my-keypair"
+
+# EC2 instance type for test VMs (t3.micro is fine for testing)
+test_vm_instance_type = "t3.micro"
+
+# ============================================================================
+# Advanced Configuration (Optional - defaults are sensible)
+# ============================================================================
+
+# Transit Gateway configuration
+# transit_gateway = {
+#   cidr       = "10.0.0.0/23"
+#   asn        = 64512
+#   ha_enabled = false
+# }
+
+# Spoke configurations
+# spokes = {
+#   dev = {
+#     cidr        = "10.1.0.0/24"
+#     environment = "development"
+#   }
+#   prod = {
+#     cidr        = "10.2.0.0/24"
+#     environment = "production"
+#   }
+#   db = {
+#     cidr        = "10.3.0.0/24"
+#     environment = "database"
+#   }
+# }

--- a/blueprints/prevent-lateral-movement-vm-tags/variables.tf
+++ b/blueprints/prevent-lateral-movement-vm-tags/variables.tf
@@ -1,0 +1,69 @@
+variable "name_prefix" {
+  description = "Prefix for all resource names"
+  type        = string
+  default     = "zt-seg"
+}
+
+variable "aws_region" {
+  description = "AWS region for deployment"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "aws_account_name" {
+  description = "Aviatrix Access Account name for AWS"
+  type        = string
+}
+
+variable "transit_gateway" {
+  description = "Transit gateway configuration"
+  type = object({
+    cidr       = string
+    asn        = number
+    ha_enabled = bool
+  })
+  default = {
+    cidr       = "10.0.0.0/23"
+    asn        = 64512
+    ha_enabled = false
+  }
+}
+
+variable "spokes" {
+  description = "Spoke gateway configurations"
+  type = map(object({
+    cidr        = string
+    environment = string
+  }))
+  default = {
+    dev = {
+      cidr        = "10.1.0.0/24"
+      environment = "development"
+    }
+    prod = {
+      cidr        = "10.2.0.0/24"
+      environment = "production"
+    }
+    db = {
+      cidr        = "10.3.0.0/24"
+      environment = "database"
+    }
+  }
+}
+
+variable "test_vm_instance_type" {
+  description = "EC2 instance type for test VMs"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "test_vm_key_name" {
+  description = "EC2 key pair name for SSH access to test VMs"
+  type        = string
+}
+
+variable "gatus_allowed_cidr" {
+  description = "CIDR allowed to reach the Gatus dashboard ALB on port 80. Defaults to open; restrict to your IP for demos (e.g. \"1.2.3.4/32\")."
+  type        = string
+  default     = "0.0.0.0/0"
+}

--- a/blueprints/prevent-lateral-movement-vm-tags/versions.tf
+++ b/blueprints/prevent-lateral-movement-vm-tags/versions.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      # Pin this to match your Controller version. The provider version must
+      # match the Controller version exactly (e.g. Controller 8.2.x → provider ~> 8.2).
+      # Full compatibility matrix:
+      # https://registry.terraform.io/providers/AviatrixSystems/aviatrix/latest/docs/guides/release-compatibility
+      version = "~> 8.2"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.32"
+    }
+  }
+}
+
+provider "aviatrix" {
+  # Credentials should be set via environment variables:
+  # AVIATRIX_CONTROLLER_IP
+  # AVIATRIX_USERNAME
+  # AVIATRIX_PASSWORD
+}
+
+provider "aws" {
+  region = var.aws_region
+  # Credentials should be set via environment variables or AWS CLI profile
+}


### PR DESCRIPTION
## Summary

- Adds the **Prevent Lateral Movement - VM Tags** blueprint demonstrating Zero Trust network segmentation with Aviatrix Distributed Cloud Firewall (DCF)
- SmartGroups are defined by EC2 `Environment` tag values (`dev`, `prod`, `db`) — no IP management required
- Default-deny policy with explicit allow rules enforced by DCF at the gateway level
- Includes a live Gatus dashboard (via ALB) for real-time connectivity visualization during demos

## Key Design Decisions

- **DCF as prerequisite**: This blueprint does not manage `aviatrix_distributed_firewalling_config` — DCF must be enabled on the Controller before deploying. This avoids a known destroy conflict where Terraform cannot disable DCF while policies still exist.
- **EC2 Instance Connect Endpoints**: Keyless SSH to private VMs — no bastion host, no key pairs to manage, SSH restricted to EICE security group only.
- **Race condition fix**: `gatus.tf` uses `instance_id = aviatrix_spoke_gateway.spokes["prod"].cloud_instance_id` instead of a filter-based data source to avoid timing issues on first apply.

## What's Included

| File | Purpose |
|------|---------|
| `main.tf` | AWS VPCs, subnets, test VMs, EICE endpoints, Gatus ALB |
| `dcf.tf` | Aviatrix SmartGroups and DCF policy list |
| `gatus.tf` | Gatus monitoring EC2 + ALB for live dashboard |
| `gatus_config.tftpl` | Gatus configuration template |
| `README.md` | Full deployment guide, test scenarios, demo walkthrough |
| `ARCHITECTURE.md` | Deep-dive SE reference with component map and traffic flows |
| `terraform.tfvars.example` | All required variables documented |
| `architecture.svg` | Architecture diagram |

## SE Validation

Tested and validated by Purvik Shah (Aviatrix SE). Fixes applied based on SE feedback:
- Race condition in gatus data source
- DCF destroy conflict resolution (prerequisite model)
- SSH security group tightened to EICE-only access
- Documentation consolidated to single README standard

## Test plan

- [ ] `terraform fmt -check -recursive` passes
- [ ] `terraform init -backend=false && terraform validate` passes
- [ ] Full `terraform apply` completes without errors
- [ ] Gatus dashboard shows correct connectivity matrix (allowed/denied)
- [ ] Manual SSH test confirms DCF policy enforcement
- [ ] `terraform destroy` completes cleanly (DCF policies removed, DCF itself left enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)