### PR TITLE
Update documentation: README, DEPLOYMENT-WORKFLOW, and blueprint READMEs

### DIFF
--- a/DEPLOYMENT-WORKFLOW.md
+++ b/DEPLOYMENT-WORKFLOW.md
@@ -1,23 +1,10 @@
-# Aviatrix Kubernetes Multi-Cloud — Deployment Workflow
+# Deployment Workflow
 
-## Overview
-
-Three deployment patterns, each following a 4-layer sequential workflow.
-Layers must be deployed in order (each depends on the previous).
-Destruction is reverse order.
-
-```
-Layer 1: Network    → Transit GW, Spoke GWs, VPCs, SNAT, DNS, DCF
-Layer 2: Clusters   → EKS/AKS/GKE control planes
-Layer 3: Nodes      → Node groups, Helm charts (CRDs, ingress, ExternalDNS)
-Layer 4: Apps/CRDs  → Namespaces, FirewallPolicy, WebGroupPolicy manifests
-```
-
----
+Step-by-step guide for deploying all three Kubernetes blueprint patterns.
 
 ## Prerequisites
 
-### Environment Variables (required for all layers)
+### Credentials
 
 ```bash
 # Aviatrix Controller
@@ -25,346 +12,280 @@ export AVIATRIX_CONTROLLER_IP="<controller-ip>"
 export AVIATRIX_USERNAME="admin"
 export AVIATRIX_PASSWORD="<password>"
 
-# AWS (via SSO or access keys)
-aws sso login  # or export AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN
+# AWS (STS session or access keys)
+export AWS_ACCESS_KEY_ID="..."
+export AWS_SECRET_ACCESS_KEY="..."
+export AWS_SESSION_TOKEN="..."
 
-# Pattern-specific account name variable
-# Pattern A & B:
+# Account name in Aviatrix (Patterns A & B)
 export TF_VAR_aviatrix_aws_account_name="lab-test-aws"
-# Pattern C:
+
+# Account name in Aviatrix (Pattern C — different variable name)
 export TF_VAR_aws_account_name="lab-test-aws"
 ```
 
-### Automated Setup
+### Tools
 
-For GitHub Actions deployments, run the one-time setup via GUI or CLI:
-
-```bash
-cd .github
-python3 setup_gui.py   # Web GUI (opens browser)
-# or
-./setup.sh             # Interactive CLI
-```
-
-See [WORKFLOW-GUIDE.md](WORKFLOW-GUIDE.md) for full details.
-
-### Tool Versions
-
-| Tool | Minimum Version |
-|------|----------------|
+| Tool | Minimum |
+|---|---|
 | Terraform | >= 1.5 |
-| AWS CLI | >= 2.61 |
+| AWS CLI | >= 2.0 |
 | kubectl | >= 1.28 |
 | Helm | >= 3.0 |
-| Aviatrix Provider | ~> 8.2 |
 
 ### AWS Service Quotas (per region)
 
 | Quota | Pattern A | Pattern B | Pattern C |
-|-------|-----------|-----------|-----------|
+|---|---|---|---|
 | VPCs | 6 | 3 | 5 |
 | Elastic IPs | 12 | 4 | 10 |
 | EKS Clusters | 3 | 1 | 2 |
 
-Request increases before deploying:
+Request increases before deploying if needed:
 ```bash
-aws service-quotas request-service-quota-increase --service-code vpc --quota-code L-F678F1CE --desired-value 20 --region <region>
-aws service-quotas request-service-quota-increase --service-code ec2 --quota-code L-0263D0A3 --desired-value 20 --region <region>
+aws service-quotas request-service-quota-increase \
+  --service-code vpc --quota-code L-F678F1CE --desired-value 20 --region <region>
 ```
 
 ---
 
 ## Architecture Recommendation Toggles
 
-Each pattern includes opt-in toggles for best-practice hardening. All default to `false` — zero impact unless explicitly enabled. Set them in `terraform.tfvars` or via `TF_VAR_*` env vars.
-
-### Cluster Layer Toggles (`clusters/*/terraform.tfvars`)
+All patterns include optional hardening add-ons. All default to `false`.
 
 ```hcl
-enable_private_endpoint      = true   # Private-only EKS API (requires VPN/bastion)
-enable_control_plane_logging = true   # Audit, API, authenticator, scheduler logs
-```
+# nodes/*/terraform.tfvars or -var flags
 
-### Nodes Layer Toggles (`nodes/*/terraform.tfvars`)
-
-```hcl
 # Security
-enable_network_policy   = true   # Calico NetworkPolicy (defense-in-depth alongside DCF)
-enable_gatekeeper       = true   # OPA Gatekeeper (admission policy-as-code)
-enable_external_secrets = true   # External Secrets Operator (AWS Secrets Manager → K8s)
-enable_falco            = true   # Falco runtime threat detection (eBPF)
+enable_network_policy   = true   # Calico NetworkPolicy (defense-in-depth)
+enable_gatekeeper       = true   # OPA Gatekeeper admission control
+enable_external_secrets = true   # AWS Secrets Manager → Kubernetes Secrets
+enable_falco            = true   # Runtime threat detection
 
 # Observability
-enable_prometheus_stack = true   # kube-prometheus-stack (Prometheus + Grafana + alerts)
-enable_fluent_bit       = true   # Fluent Bit log aggregation to CloudWatch
+enable_prometheus_stack = true   # Prometheus + Grafana + alerting
+enable_fluent_bit       = true   # Log aggregation to CloudWatch
 
 # Resilience
-enable_node_termination_handler = true   # AWS NTH (required for SPOT instances)
-enable_cluster_autoscaler       = true   # Dynamic node scaling
-enable_velero                   = true   # Cluster backup to S3
+enable_node_termination_handler = true  # Required for SPOT nodes
+enable_cluster_autoscaler       = true  # Dynamic node scaling
+enable_velero                   = true  # Cluster backup to S3
 ```
 
-### Bootstrap Toggles (`.github/bootstrap/terraform.tfvars`)
-
-```hcl
-enable_state_locking = true   # DynamoDB table for Terraform state locking
-```
-
-### Suggested Profiles
+**Suggested profiles:**
 
 | Profile | Toggles |
-|---------|---------|
-| **Demo/Lab** | All defaults (`false`) — fast deployment, no extras |
-| **Minimum Prod** | `enable_control_plane_logging`, `enable_network_policy`, `enable_node_termination_handler`, `enable_cluster_autoscaler`, `enable_state_locking` |
-| **Full Hardening** | All toggles `true` |
-
-See `ARCHITECTURE-ANALYSIS.md` for detailed rationale and references for each recommendation.
+|---|---|
+| Demo/Lab | All defaults (`false`) |
+| Minimum Prod | `network_policy`, `node_termination_handler`, `cluster_autoscaler` |
+| Full Hardening | All `true` |
 
 ---
 
-## Pattern A: Cluster-as-a-Service
+## Pattern A: k8s-cluster-aas
 
-**Region:** us-west-2 (or any region with sufficient quotas)
-**Architecture:** 3 dedicated clusters (team-a, team-b, team-c), VPC-level DCF isolation
+**Region:** us-west-2 · **Architecture:** 3 dedicated EKS clusters, VPC-level DCF isolation
+
+```bash
+BASE=blueprints/blueprints/k8s-cluster-aas/aws
+```
 
 ### Deploy
 
 ```bash
-cd blueprints/cluster-aas/aws
+# Layer 1: Network (~8 min)
+terraform -chdir=$BASE/network init
+terraform -chdir=$BASE/network apply -var="aviatrix_aws_account_name=lab-test-aws" -auto-approve
 
-# Layer 1: Network (~5-8 min)
-cd network
-terraform init
-terraform apply -auto-approve
-cd ..
-
-# Layer 2: Clusters (~10-15 min each, run in parallel)
+# Layer 2: Clusters — parallel (~15 min)
 for team in team-a team-b team-c; do
-  cd clusters/$team
-  terraform init
-  terraform apply -auto-approve &
-  cd ../..
-done
-wait
+  terraform -chdir=$BASE/clusters/$team init
+  terraform -chdir=$BASE/clusters/$team apply \
+    -var="aviatrix_aws_account_name=lab-test-aws" -auto-approve &
+done && wait
 
-# Add your IAM role to each cluster for kubectl access
-for cluster in caas-team-a caas-team-b caas-team-c; do
-  ROLE_ARN=$(aws iam list-roles --query 'Roles[?contains(RoleName,`SubAccountAdmin`)].Arn' --output text)
-  aws eks create-access-entry --cluster-name $cluster --region us-west-2 --principal-arn "$ROLE_ARN"
-  aws eks associate-access-policy --cluster-name $cluster --region us-west-2 \
-    --principal-arn "$ROLE_ARN" \
-    --policy-arn arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy \
-    --access-scope type=cluster
-done
-
-# Layer 3: Nodes (~5-8 min each, run in parallel)
+# Layer 3: Nodes — parallel (~8 min)
 for team in team-a team-b team-c; do
-  cd nodes/$team
-  terraform init
-  terraform apply -auto-approve &
-  cd ../..
-done
-wait
-
-# Layer 4: CRDs (apply via kubectl)
-for cluster in caas-team-a caas-team-b caas-team-c; do
-  aws eks update-kubeconfig --name $cluster --region us-west-2
-done
-# No namespace CRDs needed for Pattern A — teams own their clusters
+  terraform -chdir=$BASE/nodes/$team init
+  terraform -chdir=$BASE/nodes/$team apply -auto-approve &
+done && wait
 ```
 
-### Verify
+### Configure kubectl
 
 ```bash
-# Check all clusters
-for cluster in caas-team-a caas-team-b caas-team-c; do
-  echo "=== $cluster ==="
-  aws eks update-kubeconfig --name $cluster --region us-west-2
-  kubectl get nodes
+# Cluster names include the random suffix (e.g., caas-4462-team-a)
+PREFIX=$(terraform -chdir=$BASE/network output -raw name_prefix)
+for team in team-a team-b team-c; do
+  aws eks update-kubeconfig --name "${PREFIX}-${team}" --alias $team --region us-west-2
 done
-
-# Check DCF in CoPilot: Security > Distributed Cloud Firewall
-# Verify SmartGroups show VPC members
 ```
 
-### Destroy (reverse order)
+### Test
 
 ```bash
-cd blueprints/cluster-aas/aws
-
+# Deploy test containers
 for team in team-a team-b team-c; do
-  cd nodes/$team && terraform destroy -auto-approve && cd ../..
+  kubectl apply -f $BASE/k8s-apps/traffic-test/$team/
 done
 
-for team in team-a team-b team-c; do
-  cd clusters/$team && terraform destroy -auto-approve && cd ../..
-done
+# Run automated test suite (8 tests, expect 8/8 pass)
+cd $BASE/k8s-apps/traffic-test
+./run-tests.sh team-a team-b team-c
+```
 
-cd network && terraform destroy -auto-approve && cd ..
+### Destroy
+
+```bash
+for team in team-c team-b team-a; do
+  terraform -chdir=$BASE/nodes/$team destroy -auto-approve &
+done && wait
+
+for team in team-c team-b team-a; do
+  terraform -chdir=$BASE/clusters/$team destroy \
+    -var="aviatrix_aws_account_name=lab-test-aws" -auto-approve &
+done && wait
+
+terraform -chdir=$BASE/network destroy -var="aviatrix_aws_account_name=lab-test-aws" -auto-approve
 ```
 
 ---
 
-## Pattern B: Namespace-as-a-Service
+## Pattern B: k8s-namespace-aas
 
-**Region:** us-east-1
-**Architecture:** 1 shared cluster, namespace-level DCF isolation + CRD self-service
+**Region:** us-east-1 · **Architecture:** 1 shared EKS cluster, namespace-level DCF + Calico isolation
+
+```bash
+BASE=blueprints/blueprints/k8s-namespace-aas/aws
+```
 
 ### Deploy
 
 ```bash
-cd blueprints/namespace-aas/aws
+# Layer 1: Network (~8 min)
+terraform -chdir=$BASE/network init
+terraform -chdir=$BASE/network apply -var="aviatrix_aws_account_name=lab-test-aws" -auto-approve
 
-# Layer 1: Network (~5-8 min)
-cd network
-terraform init
-terraform apply -auto-approve
-cd ..
+# Layer 2: Cluster (~15 min)
+terraform -chdir=$BASE/clusters/shared init
+terraform -chdir=$BASE/clusters/shared apply \
+  -var="aviatrix_aws_account_name=lab-test-aws" -auto-approve
 
-# Layer 2: Cluster (~10-15 min)
-cd clusters/shared
-terraform init
-terraform apply -auto-approve
-cd ../..
+# Layer 3: Nodes (~8 min)
+terraform -chdir=$BASE/nodes/shared init
+terraform -chdir=$BASE/nodes/shared apply -auto-approve
 
-# Add IAM role for kubectl access
-ROLE_ARN=$(aws iam list-roles --query 'Roles[?contains(RoleName,`SubAccountAdmin`)].Arn' --output text)
-aws eks create-access-entry --cluster-name naas-shared-eks --region us-east-1 --principal-arn "$ROLE_ARN"
-aws eks associate-access-policy --cluster-name naas-shared-eks --region us-east-1 \
-  --principal-arn "$ROLE_ARN" \
-  --policy-arn arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy \
-  --access-scope type=cluster
+# Layer 4: NetworkPolicy CRDs
+CLUSTER=$(terraform -chdir=$BASE/network output -raw shared_cluster_name)
+aws eks update-kubeconfig --name $CLUSTER --alias naas-shared --region us-east-1
+kubectl --context naas-shared apply -f $BASE/k8s-apps/dcf-crd/network-policies.yaml
+```
 
-# Layer 3: Nodes (~5-8 min)
-cd nodes/shared
-terraform init
-terraform apply -auto-approve
-cd ../..
+### Test
+
+```bash
+# Create test pods per namespace
+for ns in team-a team-b team-c; do
+  kubectl --context naas-shared create namespace $ns --dry-run=client -o yaml | kubectl apply -f -
+  kubectl --context naas-shared -n $ns run nginx --image=nginx:alpine --port=80 --restart=Never
+  kubectl --context naas-shared -n $ns run netshoot \
+    --image=nicolaka/netshoot --command -- sleep infinity --restart=Never
+  kubectl --context naas-shared -n $ns expose pod nginx \
+    --port=443 --target-port=80 --name="${ns}-svc"
+done
+
+# Wait for pods
+for ns in team-a team-b team-c; do
+  kubectl --context naas-shared wait --for=condition=Ready pod/netshoot -n $ns --timeout=60s
+done
+
+# Expected: team-a→team-b PASS, team-a→team-c BLOCKED, team-c→team-b BLOCKED
+kubectl --context naas-shared -n team-a exec netshoot -- curl -m5 http://team-b-svc.team-b.svc.cluster.local:443
+kubectl --context naas-shared -n team-a exec netshoot -- curl -m5 http://team-c-svc.team-c.svc.cluster.local:443
+```
+
+### Destroy
+
+```bash
+kubectl --context naas-shared delete -f $BASE/k8s-apps/dcf-crd/ --ignore-not-found
+terraform -chdir=$BASE/nodes/shared destroy -auto-approve
+terraform -chdir=$BASE/clusters/shared destroy -var="aviatrix_aws_account_name=lab-test-aws" -auto-approve
+terraform -chdir=$BASE/network destroy -var="aviatrix_aws_account_name=lab-test-aws" -auto-approve
+```
+
+---
+
+## Pattern C: k8s-prod-nonprod-hybrid (Recommended)
+
+**Region:** us-east-2 · **Architecture:** 2 EKS clusters (prod/nonprod), two-layer DCF isolation
+
+```bash
+BASE=blueprints/blueprints/k8s-prod-nonprod-hybrid/aws
+```
+
+### Deploy
+
+```bash
+# Layer 1: Network (~8 min)
+terraform -chdir=$BASE/network init
+terraform -chdir=$BASE/network apply -var="aws_account_name=lab-test-aws" -auto-approve
+
+# Layer 2: Clusters — parallel (~15 min)
+for env in prod nonprod; do
+  terraform -chdir=$BASE/clusters/$env init
+  terraform -chdir=$BASE/clusters/$env apply \
+    -var="aviatrix_aws_account_name=lab-test-aws" -auto-approve &
+done && wait
+
+# Layer 3: Nodes — parallel (~8 min)
+for env in prod nonprod; do
+  terraform -chdir=$BASE/nodes/$env init
+  terraform -chdir=$BASE/nodes/$env apply -auto-approve &
+done && wait
 
 # Layer 4: Namespaces + CRDs
-aws eks update-kubeconfig --name naas-shared-eks --region us-east-1
-kubectl apply -f k8s-apps/dcf-crd/namespace-setup.yaml
-kubectl apply -f k8s-apps/dcf-crd/firewallpolicy-team-a.yaml
-kubectl apply -f k8s-apps/dcf-crd/firewallpolicy-team-b.yaml
-kubectl apply -f k8s-apps/dcf-crd/webgrouppolicy-team-b.yaml
+PREFIX=$(terraform -chdir=$BASE/network output -raw name_prefix 2>/dev/null || echo "pc2")
+aws eks update-kubeconfig --name "${PREFIX}-prod" --alias pc2-prod --region us-east-2
+aws eks update-kubeconfig --name "${PREFIX}-nonprod" --alias pc2-nonprod --region us-east-2
+
+kubectl --context pc2-prod apply -f $BASE/k8s-apps/dcf-crd/prod-namespaces.yaml
+kubectl --context pc2-prod apply -f $BASE/k8s-apps/dcf-crd/firewallpolicy-prod.yaml
+kubectl --context pc2-nonprod apply -f $BASE/k8s-apps/dcf-crd/nonprod-namespaces.yaml
+kubectl --context pc2-nonprod apply -f $BASE/k8s-apps/dcf-crd/firewallpolicy-nonprod.yaml
 ```
 
-### Verify
+### Test
 
 ```bash
-aws eks update-kubeconfig --name naas-shared-eks --region us-east-1
-kubectl get nodes
-kubectl get ns
-kubectl get firewallpolicies -A  # Aviatrix CRDs
-kubectl get webgrouppolicies -A
+PROD_IP=$(kubectl --context pc2-prod -n default get pod nginx -o jsonpath='{.status.podIP}' 2>/dev/null)
+NONPROD_IP=$(kubectl --context pc2-nonprod -n default get pod nginx -o jsonpath='{.status.podIP}' 2>/dev/null)
 
-# Check CoPilot:
-#   Security > Distributed Cloud Firewall — verify namespace SmartGroups have members
-#   Cloud Assets > Kubernetes — verify cluster discovered
+# prod → nonprod: BLOCKED (DENY rule 10)
+kubectl --context pc2-prod exec netshoot -- curl -m10 http://$NONPROD_IP:80
+
+# nonprod → prod: BLOCKED (DENY rule 11)
+kubectl --context pc2-nonprod exec netshoot -- curl -m10 http://$PROD_IP:80
+
+# prod egress: PASS
+kubectl --context pc2-prod exec netshoot -- curl -m10 https://registry.k8s.io
 ```
 
-### Destroy (reverse order)
+### Destroy
 
 ```bash
-cd blueprints/namespace-aas/aws
-
-kubectl delete -f k8s-apps/dcf-crd/ --ignore-not-found
-cd nodes/shared && terraform destroy -auto-approve && cd ../..
-cd clusters/shared && terraform destroy -auto-approve && cd ../..
-cd network && terraform destroy -auto-approve && cd ..
-```
-
----
-
-## Pattern C: Prod/Non-Prod + NS-aaS (Recommended)
-
-**Region:** us-east-2
-**Architecture:** Separate prod + nonprod clusters, two-layer DCF (environment + namespace)
-
-### Deploy
-
-```bash
-cd blueprints/prod-nonprod-hybrid/aws
-
-# Layer 1: Network (~5-8 min)
-cd network
-terraform init
-terraform apply -auto-approve
-cd ..
-
-# Layer 2: Clusters (~10-15 min each, run in parallel)
-cd clusters/prod
-terraform init
-terraform apply -auto-approve &
-cd ../..
-cd clusters/nonprod
-terraform init
-terraform apply -auto-approve &
-cd ../..
-wait
-
-# Add IAM role for kubectl access
-ROLE_ARN=$(aws iam list-roles --query 'Roles[?contains(RoleName,`SubAccountAdmin`)].Arn' --output text)
-for cluster in pc2-prod pc2-nonprod; do
-  aws eks create-access-entry --cluster-name $cluster --region us-east-2 --principal-arn "$ROLE_ARN"
-  aws eks associate-access-policy --cluster-name $cluster --region us-east-2 \
-    --principal-arn "$ROLE_ARN" \
-    --policy-arn arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy \
-    --access-scope type=cluster
-done
-
-# Layer 3: Nodes (~5-8 min each, run in parallel)
-cd nodes/prod
-terraform init
-terraform apply -auto-approve &
-cd ../..
-cd nodes/nonprod
-terraform init
-terraform apply -auto-approve &
-cd ../..
-wait
-
-# Layer 4: Namespaces + CRDs
-aws eks update-kubeconfig --name pc2-prod --region us-east-2
-kubectl apply -f k8s-apps/dcf-crd/prod-namespaces.yaml
-kubectl apply -f k8s-apps/dcf-crd/firewallpolicy-prod.yaml
-
-aws eks update-kubeconfig --name pc2-nonprod --region us-east-2
-kubectl apply -f k8s-apps/dcf-crd/nonprod-namespaces.yaml
-kubectl apply -f k8s-apps/dcf-crd/firewallpolicy-nonprod.yaml
-```
-
-### Verify
-
-```bash
-# Prod cluster
-aws eks update-kubeconfig --name pc2-prod --region us-east-2
-kubectl get nodes
-kubectl get ns | grep -E "team|monitoring"
-
-# Non-prod cluster
-aws eks update-kubeconfig --name pc2-nonprod --region us-east-2
-kubectl get nodes
-kubectl get ns | grep -E "team|sandbox|monitoring"
-
-# Check CoPilot:
-#   Security > DCF — verify two-layer rules (env + namespace)
-#   Verify prod<->nonprod traffic is DENIED
-#   Verify nonprod cannot reach prod database spoke
-```
-
-### Destroy (reverse order)
-
-```bash
-cd blueprints/prod-nonprod-hybrid/aws
+kubectl --context pc2-prod delete -f $BASE/k8s-apps/dcf-crd/ --ignore-not-found
+kubectl --context pc2-nonprod delete -f $BASE/k8s-apps/dcf-crd/ --ignore-not-found
 
 for env in prod nonprod; do
-  cd nodes/$env && terraform destroy -auto-approve && cd ../..
-done
+  terraform -chdir=$BASE/nodes/$env destroy -auto-approve &
+done && wait
+
 for env in prod nonprod; do
-  cd clusters/$env && terraform destroy -auto-approve && cd ../..
-done
-cd network && terraform destroy -auto-approve && cd ..
+  terraform -chdir=$BASE/clusters/$env destroy \
+    -var="aviatrix_aws_account_name=lab-test-aws" -auto-approve &
+done && wait
+
+terraform -chdir=$BASE/network destroy -var="aws_account_name=lab-test-aws" -auto-approve
 ```
 
 ---
@@ -372,97 +293,46 @@ cd network && terraform destroy -auto-approve && cd ..
 ## Validation Checklist
 
 ### Network Layer
-- [ ] Transit Gateway visible in CoPilot
-- [ ] All Spoke Gateways attached to transit (green status)
-- [ ] SNAT policies active on spoke gateways
-- [ ] Route tables programmed (software-defined routing)
+- [ ] Transit Gateway visible in CoPilot Topology
+- [ ] All Spoke Gateways attached and green
+- [ ] SNAT policies active on each spoke
+- [ ] DCF enabled: `aviatrix_distributed_firewalling_config` applied
 
 ### DCF
-- [ ] "Enforcement on Kubernetes" shows Enabled in CoPilot
-- [ ] SmartGroups created and showing members
-- [ ] DCF ruleset active with correct priority ordering
-- [ ] WebGroups resolving (EKS required services)
-- [ ] Geo-blocking and ThreatIQ SmartGroups active
+- [ ] DCF policy group created (`aviatrix_dcf_policy_group`)
+- [ ] Ruleset attached with correct priorities
+- [ ] SmartGroups showing members (VPC-type or K8s namespace-type)
+- [ ] WebGroups resolving (EKS required services, docker.io)
+- [ ] Geo-blocking and ThreatIQ active
 
 ### Kubernetes
-- [ ] EKS clusters ACTIVE
-- [ ] Nodes in Ready state
-- [ ] k8s-firewall Helm chart installed (CRDs available)
+- [ ] EKS clusters ACTIVE, nodes Ready
+- [ ] Aviatrix controller can inventory cluster (check CoPilot > Kubernetes)
+- [ ] k8s-firewall Helm chart installed (`kubectl get crd | grep aviatrix`)
+- [ ] Calico running: `kubectl get pods -n calico-system`
 - [ ] Namespaces created (Pattern B and C)
-- [ ] FirewallPolicy CRDs applied
+- [ ] NetworkPolicies applied (Pattern B)
 
-### Recommendations (if enabled)
-- [ ] `enable_network_policy`: Calico pods running — `kubectl get pods -n tigera-operator`
-- [ ] `enable_gatekeeper`: Gatekeeper webhook active — `kubectl get pods -n gatekeeper-system`
-- [ ] `enable_external_secrets`: Operator running — `kubectl get pods -n external-secrets`
-- [ ] `enable_falco`: Falco daemonset running — `kubectl get pods -n falco`
-- [ ] `enable_prometheus_stack`: Prometheus + Grafana running — `kubectl get pods -n monitoring`
-- [ ] `enable_fluent_bit`: Fluent Bit daemonset running — `kubectl get pods -n logging`
-- [ ] `enable_node_termination_handler`: NTH running — `kubectl get pods -n kube-system -l app.kubernetes.io/name=aws-node-termination-handler`
-- [ ] `enable_cluster_autoscaler`: Autoscaler running — `kubectl get pods -n kube-system -l app.kubernetes.io/name=cluster-autoscaler`
-- [ ] `enable_velero`: Velero + daily backup schedule — `kubectl get pods -n velero && kubectl get schedules -n velero`
-- [ ] `enable_control_plane_logging`: CloudWatch log group exists — `aws logs describe-log-groups --log-group-name-prefix /aws/eks/`
-- [ ] `enable_state_locking`: DynamoDB table exists — `aws dynamodb describe-table --table-name <table>`
-
-### Connectivity Tests
-- [ ] Pod-to-pod within same cluster: works
-- [ ] Pod-to-service cross-cluster (permitted pair): works via transit
-- [ ] Pod-to-service cross-cluster (denied pair): blocked by DCF
-- [ ] Pod-to-internet (approved WebGroup): works
-- [ ] Pod-to-internet (unapproved): blocked
-- [ ] Pattern C: nonprod-to-prod: DENIED (both directions)
-- [ ] Pattern C: nonprod-to-prod-db: DENIED
+### Traffic Tests
+- [ ] Permitted cross-cluster/namespace flows: working
+- [ ] Denied flows: blocked (timeout, not refused)
+- [ ] Approved egress (registry.k8s.io): working
+- [ ] Default deny internet: blocked
+- [ ] Pattern C: nonprod → prod DENIED both directions
 
 ---
 
 ## Troubleshooting
 
-### Common Issues
-
 | Issue | Cause | Fix |
-|-------|-------|-----|
-| VPC/VNet name already exists | Orphaned resources from failed run | Delete via Aviatrix API or rename prefix |
-| DCF attachment point conflict | Multiple `aviatrix_dcf_ruleset` on same controller | Use `aviatrix_distributed_firewalling_policy_list` instead |
-| EKS CoreDNS DEGRADED | No nodes deployed yet | Deploy Layer 3 (nodes) — resolves automatically |
-| SmartGroups empty | K8s clusters not discovered | Enable "Enforcement on Kubernetes" + wait for discovery |
-| kubectl unauthorized | IAM role not in cluster access | Add via `aws eks create-access-entry` |
-| VPC limit exceeded | Default 5 per region | Request increase to 20 via Service Quotas |
-| EIP limit exceeded | Default 5 per region | Request increase to 20 via Service Quotas |
-| SNAT not working | Pod CIDR not excluded from transit | Add `excluded_advertised_spoke_routes` on transit |
-| `enable_segmentation` conflict | Can't use with `excluded_advertised_spoke_routes` | Remove `enable_segmentation` |
-
-### Aviatrix API Cleanup (orphaned resources)
-
-```bash
-# Login
-CID=$(curl -sk -X POST "https://$AVIATRIX_CONTROLLER_IP/v1/api" \
-  -d "action=login&username=$AVIATRIX_USERNAME&password=$AVIATRIX_PASSWORD" \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['CID'])")
-
-# Detach spoke from transit
-curl -sk -X POST "https://$AVIATRIX_CONTROLLER_IP/v2/api" \
-  -H "Content-Type: application/json" \
-  -d "{\"action\":\"detach_spoke_from_transit_gw\",\"CID\":\"$CID\",\"spoke_gw\":\"<spoke-name>\"}"
-
-# Delete gateway
-curl -sk -X POST "https://$AVIATRIX_CONTROLLER_IP/v2/api" \
-  -H "Content-Type: application/json" \
-  -d "{\"action\":\"delete_container\",\"CID\":\"$CID\",\"cloud_type\":1,\"gw_name\":\"<gw-name>\"}"
-
-# Delete VPC from controller
-curl -sk -X POST "https://$AVIATRIX_CONTROLLER_IP/v2/api" \
-  -H "Content-Type: application/json" \
-  -d "{\"action\":\"delete_custom_vpc\",\"CID\":\"$CID\",\"cloud_type\":1,\"account_name\":\"lab-test-aws\",\"pool_name\":\"<vpc-name>\"}"
-
-# Note: Transit GWs with FireNet need terraform import + destroy
-```
-
----
-
-## Current Deployment Status
-
-| Pattern | Region | Network | Clusters | Nodes | CRDs |
-|---------|--------|---------|----------|-------|------|
-| A: Cluster-aaS | us-west-2 | DONE | Deploying | - | - |
-| B: Namespace-aaS | us-east-1 | DONE | DONE | DONE | Pending |
-| C: Prod/Non-Prod | us-east-2 | DONE | DONE | Pending | Pending |
+|---|---|---|
+| `AVXERR-DFW-0043` attachment conflict | Multiple blueprints share one controller | Each blueprint uses its own `aviatrix_dcf_policy_group` — verify it's not sharing an attachment point |
+| `AVXERR-DFW-0025` ruleset not found | Ruleset deleted from controller (drift) | `terraform state rm aviatrix_dcf_ruleset.*` then re-apply |
+| EKS nodes `ImagePullBackOff` | docker.io/quay.io blocked by DCF egress | Add registries to `eks_required` or `approved_egress` WebGroup |
+| Calico `429 Too Many Requests` | Docker Hub rate limit on anonymous pulls | Create imagePullSecret or push to ECR |
+| SmartGroups empty | Cluster not inventoried by controller | Check `aviatrix_kubernetes_cluster` resource, verify `use_csp_credentials = true` and EKS access entry for `aviatrix-role-app` |
+| `Unauthorized` in CoPilot K8s | Missing EKS access entry | Add `access_entries` block with `AmazonEKSViewPolicy` for controller IAM role |
+| kubectl `Unauthorized` | IAM role not in cluster access entries | `aws eks create-access-entry` + associate `AmazonEKSClusterAdminPolicy` |
+| VPC limit exceeded | Default 5 per region | Request increase via AWS Service Quotas |
+| SNAT not working | Pod CIDR not excluded from transit advertisements | Add `excluded_advertised_spoke_routes = var.pod_cidr` on transit module |
+| `enable_segmentation` conflict | Incompatible with `excluded_advertised_spoke_routes` | Remove `enable_segmentation` |

--- a/DEPLOYMENT-WORKFLOW.md
+++ b/DEPLOYMENT-WORKFLOW.md
@@ -87,7 +87,7 @@ enable_velero                   = true  # Cluster backup to S3
 **Region:** us-west-2 · **Architecture:** 3 dedicated EKS clusters, VPC-level DCF isolation
 
 ```bash
-BASE=blueprints/blueprints/k8s-cluster-aas/aws
+BASE=blueprints/k8s-cluster-aas/aws
 ```
 
 ### Deploy
@@ -156,7 +156,7 @@ terraform -chdir=$BASE/network destroy -var="aviatrix_aws_account_name=lab-test-
 **Region:** us-east-1 · **Architecture:** 1 shared EKS cluster, namespace-level DCF + Calico isolation
 
 ```bash
-BASE=blueprints/blueprints/k8s-namespace-aas/aws
+BASE=blueprints/k8s-namespace-aas/aws
 ```
 
 ### Deploy
@@ -220,7 +220,7 @@ terraform -chdir=$BASE/network destroy -var="aviatrix_aws_account_name=lab-test-
 **Region:** us-east-2 · **Architecture:** 2 EKS clusters (prod/nonprod), two-layer DCF isolation
 
 ```bash
-BASE=blueprints/blueprints/k8s-prod-nonprod-hybrid/aws
+BASE=blueprints/k8s-prod-nonprod-hybrid/aws
 ```
 
 ### Deploy

--- a/README.md
+++ b/README.md
@@ -1,125 +1,117 @@
 # Aviatrix Kubernetes Multi-Cloud Blueprints
 
-Terraform blueprints for deploying multi-cluster Kubernetes environments with Aviatrix transit networking and Distributed Cloud Firewall (DCF).
+Production-ready Terraform blueprints for deploying Kubernetes environments with Aviatrix transit networking and Distributed Cloud Firewall (DCF).
 
-## Patterns
+## Kubernetes Patterns
 
-| Pattern | Directory | Description | Isolation Model |
-|---------|-----------|-------------|-----------------|
-| **A: Cluster-as-a-Service** | [`cluster-aas/`](cluster-aas/) | Dedicated cluster per team | VPC-level (hard boundary) |
-| **B: Namespace-as-a-Service** | [`namespace-aas/`](namespace-aas/) | Single shared cluster, namespace per team | Namespace-level (DCF + RBAC) |
-| **C: Prod/Non-Prod Hybrid** | [`prod-nonprod-hybrid/`](prod-nonprod-hybrid/) | Separate prod + nonprod clusters with NS-aaS | Two-layer (VPC + namespace) |
+Three patterns for different isolation requirements. Each supports AWS, Azure, and GCP.
 
-Each pattern supports AWS, Azure, and GCP. Standalone CSP-specific blueprints are also available:
+| Pattern | Directory | Isolation | Clusters | Best For |
+|---|---|---|---|---|
+| **k8s-cluster-aas** | [`blueprints/k8s-cluster-aas/`](blueprints/k8s-cluster-aas/) | VPC-level (hard boundary) | 1 per team | Strict isolation, compliance |
+| **k8s-namespace-aas** | [`blueprints/k8s-namespace-aas/`](blueprints/k8s-namespace-aas/) | Namespace (DCF + Calico) | 1 shared | Cost-conscious, trusted teams |
+| **k8s-prod-nonprod-hybrid** ⭐ | [`blueprints/k8s-prod-nonprod-hybrid/`](blueprints/k8s-prod-nonprod-hybrid/) | VPC + namespace (two-layer) | 2 (prod/nonprod) | Most organizations |
 
-| Blueprint | Directory | Description |
-|-----------|-----------|-------------|
-| Azure AKS Multi-Cluster | [`azure-aks-multicluster/`](azure-aks-multicluster/) | Frontend/backend AKS clusters with FireNet |
-| GCP GKE Multi-Cluster | [`gcp-gke-multicluster/`](gcp-gke-multicluster/) | Frontend/backend GKE clusters with Datapath v2 |
+## Standalone Blueprints
+
+| Blueprint | Directory | Description | Cloud |
+|---|---|---|---|
+| aws-eks-multicluster | [`blueprints/aws-eks-multicluster/`](blueprints/aws-eks-multicluster/) | DCF with EKS frontend/backend | AWS |
+| azure-aks-multicluster | [`azure-aks-multicluster/`](azure-aks-multicluster/) | AKS clusters with FireNet | Azure |
+| gcp-gke-multicluster | [`gcp-gke-multicluster/`](gcp-gke-multicluster/) | GKE clusters with Datapath v2 | GCP |
+| prevent-lateral-movement-vm-tags | [`blueprints/prevent-lateral-movement-vm-tags/`](blueprints/prevent-lateral-movement-vm-tags/) | Zero Trust DCF with VM tags | AWS |
+| zero-trust-segmentation | [`blueprints/zero-trust-segmentation/`](blueprints/zero-trust-segmentation/) | DCF with SmartGroups | AWS |
 
 ## 4-Layer Deployment Model
 
-All patterns follow the same sequential layer structure:
+All K8s patterns follow the same structure:
 
 ```
-Layer 1: Network    →  Transit GW, spoke GWs, VPCs/VNets, SNAT, DNS
-Layer 2: Clusters   →  EKS/AKS/GKE control planes, IRSA/Workload Identity
-Layer 3: Nodes      →  Node groups, Helm charts (k8s-firewall, ALB/Ingress, ExternalDNS)
-Layer 4: CRDs       →  Namespaces, FirewallPolicy, WebGroupPolicy manifests
+Layer 1: network/          ← Transit GW, Spoke GWs, VPCs, SNAT, DNS, DCF rules
+Layer 2: clusters/         ← EKS/AKS/GKE control planes, IRSA, access entries
+Layer 3: nodes/            ← Node groups, Calico, k8s-firewall, ALB, ExternalDNS
+Layer 4: k8s-apps/         ← Namespaces, FirewallPolicy, NetworkPolicy CRDs
 ```
-| Blueprint | Description | Cloud(s) | Tier | Status |
-|-----------|-------------|----------|------|--------|
-| [aws-eks-multicluster](blueprints/aws-eks-multicluster/) | Distributed Cloud Firewall with EKS | AWS | Community | 🚧 In Progress |
-| [prevent-lateral-movement-vm-tags](blueprints/prevent-lateral-movement-vm-tags/) | Zero Trust segmentation with DCF and VM tags to prevent lateral movement | AWS | Community | 🔄 In Review |
 
-## Manual Deployment
-
-### 1. Prerequisites
-
-Before deploying any blueprint, ensure you have:
-
-Layers must be deployed in order. Destruction is reverse order.
+Layers must be deployed in order. Layers at the same level (e.g., multiple clusters) can run in parallel.
 
 ## Quick Start
 
-### One-Time Setup (GitHub Actions)
-
-```bash
-cd .github
-python3 setup_gui.py   # Web GUI (opens browser)
-# or
-./setup.sh             # Interactive CLI
-```
-
-Configures S3 state bucket, GitHub secrets/variables, environments, and OIDC. See [WORKFLOW-GUIDE.md](WORKFLOW-GUIDE.md).
-
-### Manual Deploy
-
-Pick a pattern and one or more CSPs. Each `{pattern}/{csp}/` directory is a self-contained stack — deploy them independently or combine across clouds.
-
-```bash
-# Example: Pattern C on AWS
-cd prod-nonprod-hybrid/aws
-cd network   && terraform init && terraform apply -auto-approve && cd ..
-cd clusters/prod    && terraform init && terraform apply -auto-approve && cd ../..
-cd clusters/nonprod && terraform init && terraform apply -auto-approve && cd ../..
-cd nodes/prod       && terraform init && terraform apply -auto-approve && cd ../..
-cd nodes/nonprod    && terraform init && terraform apply -auto-approve && cd ../..
-kubectl apply -f k8s-apps/dcf-crd/
-
-# Example: Pattern A on Azure + GCP simultaneously
-cd cluster-aas/azure/network && terraform init && terraform apply -auto-approve &
-cd cluster-aas/gcp/network   && terraform init && terraform apply -auto-approve &
-wait
-```
-
-You can deploy the same pattern across multiple CSPs (e.g., `cluster-aas/aws` + `cluster-aas/azure` + `cluster-aas/gcp`) or mix patterns per cloud. The Aviatrix transit connects them all.
-
-## Shared Modules
-
-| Module | Path | Description |
-|--------|------|-------------|
-| Recommendations | [`modules/recommendations/`](modules/) | Optional production-hardening add-ons (Calico, Gatekeeper, Falco, Prometheus, Velero, etc.) |
-
-All recommendation toggles default to `false`. See [`modules/README.md`](modules/README.md) for profiles and usage.
-
-## Documentation
-
-| Document | Description |
-|----------|-------------|
-| [DEPLOYMENT-WORKFLOW.md](DEPLOYMENT-WORKFLOW.md) | Manual deployment guide for all patterns with verification checklists |
-| [WORKFLOW-GUIDE.md](WORKFLOW-GUIDE.md) | GitHub Actions CI/CD setup, usage, state management, and troubleshooting |
-
-## Prerequisites
+### Prerequisites
 
 - Aviatrix Controller with CoPilot
-- Aviatrix-onboarded cloud account(s)
-- Terraform >= 1.5
-- Cloud CLI (aws/az/gcloud) + kubectl >= 1.28
-- For CI/CD: GitHub repo with OIDC IAM role
+- Cloud account onboarded in Aviatrix
+- Terraform ≥ 1.5, AWS/Azure/GCP CLI, kubectl ≥ 1.28
+
+### Deploy (example: k8s-cluster-aas on AWS)
+
+```bash
+cd blueprints/k8s-cluster-aas/aws
+
+# Layer 1: Network
+cd network && terraform init && terraform apply -var="aviatrix_aws_account_name=<account>" && cd ..
+
+# Layer 2: Clusters (parallel)
+for team in team-a team-b team-c; do
+  terraform -chdir=clusters/$team init
+  terraform -chdir=clusters/$team apply -var="aviatrix_aws_account_name=<account>" -auto-approve &
+done && wait
+
+# Layer 3: Nodes (parallel)
+for team in team-a team-b team-c; do
+  terraform -chdir=nodes/$team init
+  terraform -chdir=nodes/$team apply -auto-approve &
+done && wait
+```
+
+See [DEPLOYMENT-WORKFLOW.md](DEPLOYMENT-WORKFLOW.md) for complete instructions, all patterns, and verification checklists.
+
+## Optional Hardening
+
+All patterns include opt-in toggles (all default `false`) via the shared recommendations module:
+
+```hcl
+# nodes/*/terraform.tfvars
+enable_network_policy           = true  # Calico NetworkPolicy
+enable_gatekeeper               = true  # OPA Gatekeeper admission control
+enable_external_secrets         = true  # AWS Secrets Manager sync
+enable_falco                    = true  # Runtime threat detection
+enable_prometheus_stack         = true  # Prometheus + Grafana
+enable_fluent_bit               = true  # CloudWatch log aggregation
+enable_node_termination_handler = true  # Required for SPOT instances
+enable_cluster_autoscaler       = true  # Dynamic scaling
+enable_velero                   = true  # Backup to S3
+```
+
+See [`modules/recommendations/`](modules/recommendations/) for full details.
 
 ## Repository Structure
 
 ```
 blueprints/
-├── .github/
-│   ├── setup.sh              # CLI setup script
-│   ├── setup_gui.py          # Web GUI setup
-│   └── bootstrap/            # S3 state bucket Terraform
-├── cluster-aas/              # Pattern A
-│   ├── aws/
-│   ├── azure/
-│   └── gcp/
-├── namespace-aas/            # Pattern B
-│   ├── aws/
-│   ├── azure/
-│   └── gcp/
-├── prod-nonprod-hybrid/      # Pattern C (recommended)
-│   ├── aws/
-│   ├── azure/
-│   └── gcp/
-├── azure-aks-multicluster/   # Standalone Azure blueprint
-├── gcp-gke-multicluster/     # Standalone GCP blueprint
-└── modules/
-    └── recommendations/      # Optional hardening add-ons
+├── blueprints/
+│   ├── k8s-cluster-aas/          # Pattern A: dedicated cluster per team
+│   │   ├── aws/ azure/ gcp/
+│   │   └── README.md
+│   ├── k8s-namespace-aas/        # Pattern B: shared cluster
+│   │   ├── aws/ azure/ gcp/
+│   │   └── README.md
+│   ├── k8s-prod-nonprod-hybrid/  # Pattern C: prod/nonprod (recommended)
+│   │   ├── aws/ azure/ gcp/
+│   │   └── README.md
+│   ├── aws-eks-multicluster/
+│   ├── zero-trust-segmentation/
+│   └── prevent-lateral-movement-vm-tags/
+├── azure-aks-multicluster/
+├── gcp-gke-multicluster/
+├── modules/
+│   └── recommendations/          # Optional hardening add-ons
+└── docs/
 ```
+
+## Documentation
+
+| Document | Description |
+|---|---|
+| [DEPLOYMENT-WORKFLOW.md](DEPLOYMENT-WORKFLOW.md) | Step-by-step deployment guide, verification checklists, troubleshooting |
+| [WORKFLOW-GUIDE.md](WORKFLOW-GUIDE.md) | GitHub Actions CI/CD setup and state management |

--- a/blueprints/k8s-cluster-aas/README.md
+++ b/blueprints/k8s-cluster-aas/README.md
@@ -1,137 +1,134 @@
-# Pattern A: Cluster-as-a-Service
+# k8s-cluster-aas — Cluster-as-a-Service
 
-Dedicated EKS/AKS/GKE cluster per team with VPC-level isolation enforced by Aviatrix Distributed Cloud Firewall (DCF).
+Each team gets a **dedicated EKS cluster in its own VPC**. Network isolation is enforced by Aviatrix DCF at the VPC boundary — no team can reach another team's cluster without an explicit PERMIT rule.
 
 ## Architecture
 
 ```
-                    ┌─────────────────┐
-                    │  Aviatrix Transit│
-                    │    Gateway (Hub) │
-                    └──┬──────┬──────┬┘
-                       │      │      │
-              ┌────────┘      │      └────────┐
-              ▼               ▼               ▼
-        ┌───────────┐  ┌───────────┐  ┌───────────┐
-        │  Team-A   │  │  Team-B   │  │  Team-C   │
-        │  VPC/VNet │  │  VPC/VNet │  │  VPC/VNet │
-        │  + Spoke  │  │  + Spoke  │  │  + Spoke  │
-        │  + EKS    │  │  + EKS    │  │  + EKS    │
-        └───────────┘  └───────────┘  └───────────┘
-                               │
-                        ┌──────┴──────┐
-                        │ Database    │
-                        │ Spoke VPC   │
-                        └─────────────┘
+Transit GW (10.2.0.0/20)
+├── Team-A Spoke (10.10.0.0/20) ──── EKS cluster-a  [pods: 100.64.0.0/18]
+├── Team-B Spoke (10.11.0.0/20) ──── EKS cluster-b  [pods: 100.64.64.0/18]
+├── Team-C Spoke (10.12.0.0/20) ──── EKS cluster-c  [pods: 100.64.128.0/18]
+└── DB Spoke     (10.5.0.0/22)  ──── Shared database
 ```
 
-Each team gets its own VPC, spoke gateway, and Kubernetes cluster. Inter-team traffic is routed through the Aviatrix transit and subject to DCF rules.
+**VPCs:** 5 (transit + 3 team + DB) · **Clusters:** 3 · **Kubernetes:** 1.35
 
-## Supported CSPs
+### Pod Networking
+Pods use RFC 6598 overlay CIDR (`100.64.0.0/16`). Aviatrix SNAT translates pod IPs to the spoke gateway IP before traffic hits DCF. **DCF sees POST-SNAT traffic** — use VPC SmartGroups for source, hostname SmartGroups for destination.
 
-| Directory | Cloud | Clusters | Region Default |
-|-----------|-------|----------|----------------|
-| `aws/` | AWS (EKS) | team-a, team-b, team-c | us-west-2 |
-| `azure/` | Azure (AKS) | team-a, team-b, team-c | — |
-| `gcp/` | GCP (GKE) | team-a, team-b, team-c | — |
+### DCF Policy Layout
 
-## Layers
+| Priority | Action | Rule |
+|---|---|---|
+| 100–101 | DENY | Geo-block (IR, KP, RU) + ThreatIQ feeds |
+| 110 | PERMIT | team-a → team-b on TCP/443 |
+| 111 | PERMIT | team-b → team-a on TCP/8080 |
+| 120–123 | DENY | team-a ↔ team-c, team-b ↔ team-c (both directions) |
+| 150 | PERMIT | All clusters → EKS required services (ECR, S3, STS, EKS API…) |
+| 200 | DENY | Default deny public internet (non-RFC1918) |
 
-Layers must be deployed in order. Each layer reads outputs from the previous via `terraform_remote_state`.
+## Deployment
 
-| Layer | Directory | What It Creates | ~Time |
-|-------|-----------|-----------------|-------|
-| 1. Network | `{csp}/network/` | Transit GW, 3 team VPCs + spoke GWs, database spoke, Route53/DNS zone, SNAT policies | 5-8 min |
-| 2. Clusters | `{csp}/clusters/{team}/` | EKS/AKS/GKE control plane, VPC CNI config, IRSA/Workload Identity roles, Aviatrix cluster onboarding | 10-15 min each |
-| 3. Nodes | `{csp}/nodes/{team}/` | Managed node group, ENIConfig (AWS), k8s-firewall Helm chart, ALB Controller, ExternalDNS | 5-8 min each |
+```
+Layer 1: aws/network/            ← Transit, VPCs, Spokes, DNS, DCF  (~8 min)
+Layer 2: aws/clusters/team-*/    ← EKS control planes (parallel)    (~15 min)
+Layer 3: aws/nodes/team-*/       ← Node groups, Helm charts (parallel) (~8 min)
+```
 
-No Layer 4 (CRDs) — teams own their clusters and manage their own workloads.
+### Prerequisites
+- Aviatrix Controller with AWS account onboarded
+- AWS credentials with sufficient permissions
+- Terraform ≥ 1.5, Aviatrix provider ~> 8.2
 
-## Key Design Decisions
-
-- **Pod CIDR overlay**: All clusters share `100.64.0.0/16` (RFC 6598). Non-routable; Aviatrix SNAT translates pod traffic to spoke gateway IPs before transit.
-- **Isolation model**: VPC boundaries provide primary isolation. DCF SmartGroups use VPC membership for policy matching.
-- **SNAT policies**: 3 rules per spoke — pod-to-transit (east-west), pod-to-internet (egress), node-to-internet (node egress).
-- **Team admin**: Each team gets cluster-admin on their own cluster only.
-
-## Deploy (AWS Example)
+### Layer 1 — Network
 
 ```bash
-cd cluster-aas/aws
-
-# Layer 1
-cd network && terraform init && terraform apply -auto-approve && cd ..
-
-# Layer 2 (parallel)
-for team in team-a team-b team-c; do
-  (cd clusters/$team && terraform init && terraform apply -auto-approve) &
-done
-wait
-
-# Layer 3 (parallel)
-for team in team-a team-b team-c; do
-  (cd nodes/$team && terraform init && terraform apply -auto-approve) &
-done
-wait
+cd aws/network
+terraform init
+terraform apply -var="aviatrix_aws_account_name=<account>"
 ```
 
-## Destroy (Reverse Order)
+| Variable | Default | Description |
+|---|---|---|
+| `aviatrix_aws_account_name` | required | Aviatrix access account name |
+| `aws_region` | `us-west-2` | AWS region |
+| `name_prefix` | `caas` | Resource name prefix |
+| `random_suffix` | `true` | Append random hex (e.g. `caas-4462`) |
+| `pod_cidr` | `100.64.0.0/16` | Pod overlay CIDR |
+| `private_dns_zone_name` | `aws.aviatrixdemo.local` | Route53 private zone |
+
+### Layer 2 — Clusters (parallel)
 
 ```bash
-cd cluster-aas/aws
-
 for team in team-a team-b team-c; do
-  (cd nodes/$team && terraform destroy -auto-approve) &
-done
-wait
-
-for team in team-a team-b team-c; do
-  (cd clusters/$team && terraform destroy -auto-approve) &
-done
-wait
-
-cd network && terraform destroy -auto-approve && cd ..
+  terraform -chdir=aws/clusters/$team init
+  terraform -chdir=aws/clusters/$team apply \
+    -var="aviatrix_aws_account_name=<account>" -auto-approve &
+done && wait
 ```
 
-## Variables
+| Variable | Default | Description |
+|---|---|---|
+| `kubernetes_version` | `1.35` | EKS version |
+| `enable_network_policy` | `true` | Calico (policy-only mode) |
 
-### Network Layer
+### Layer 3 — Nodes (parallel)
+
+```bash
+for team in team-a team-b team-c; do
+  terraform -chdir=aws/nodes/$team init
+  terraform -chdir=aws/nodes/$team apply -auto-approve &
+done && wait
+```
 
 | Variable | Default | Description |
-|----------|---------|-------------|
-| `name_prefix` | `caas` | Resource naming prefix |
-| `aviatrix_aws_account_name` | — | Aviatrix-onboarded AWS account name (required) |
-| `aws_region` | `us-west-2` | Target region |
-| `transit_cidr` | `10.2.0.0/20` | Transit VPC CIDR |
-| `team_a_vpc_cidr` | `10.10.0.0/20` | Team A VPC CIDR |
-| `team_b_vpc_cidr` | `10.11.0.0/20` | Team B VPC CIDR |
-| `team_c_vpc_cidr` | `10.12.0.0/20` | Team C VPC CIDR |
-| `db_vpc_cidr` | `10.5.0.0/22` | Database spoke CIDR |
-| `pod_cidr` | `100.64.0.0/16` | Shared pod overlay CIDR |
-
-### Cluster Layer
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `kubernetes_version` | `1.31` | EKS Kubernetes version |
-| `enable_private_endpoint` | `false` | Private-only API server (requires VPN/bastion) |
-| `enable_control_plane_logging` | `false` | Audit, API, authenticator logs to CloudWatch |
-
-### Nodes Layer
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `node_group_config.min_size` | `1` | Minimum nodes |
-| `node_group_config.max_size` | `3` | Maximum nodes |
-| `node_group_config.desired_size` | `2` | Desired node count |
+|---|---|---|
 | `node_group_config.instance_type` | `t3.large` | EC2 instance type |
-| `node_group_config.capacity_type` | `SPOT` | SPOT or ON_DEMAND |
+| `node_group_config.desired_size` | `2` | Node count |
+| `node_group_config.capacity_type` | `SPOT` | `SPOT` or `ON_DEMAND` |
 
-## Prerequisites
+## Traffic Tests
 
-- Aviatrix Controller with CoPilot
-- Aviatrix-onboarded cloud account
-- Terraform >= 1.5, AWS CLI >= 2.61, kubectl >= 1.28
-- Sufficient VPC/EIP quotas (6 VPCs, 12 EIPs per region)
+```bash
+# Configure kubectl contexts
+aws eks update-kubeconfig --name <cluster-name> --alias team-a --region us-west-2
 
-See [DEPLOYMENT-WORKFLOW.md](../DEPLOYMENT-WORKFLOW.md) for full details.
+# Deploy test containers
+for team in team-a team-b team-c; do
+  kubectl apply -f aws/k8s-apps/traffic-test/$team/
+done
+
+# Run automated tests
+cd aws/k8s-apps/traffic-test && ./run-tests.sh team-a team-b team-c
+```
+
+Expected: **8/8 pass**
+
+| Test | Expected | DCF Rule |
+|---|---|---|
+| team-a → team-b:443 | PASS | PERMIT 110 |
+| team-b → team-a:8080 | PASS | PERMIT 111 |
+| team-a ↔ team-c | BLOCKED | DENY 120/121 |
+| team-b ↔ team-c | BLOCKED | DENY 122/123 |
+| egress registry.k8s.io | PASS | PERMIT 150 |
+| egress example.com | BLOCKED | DEFAULT DENY 200 |
+
+## Destroy (reverse order)
+
+```bash
+for team in team-a team-b team-c; do terraform -chdir=aws/nodes/$team destroy -auto-approve & done && wait
+for team in team-a team-b team-c; do terraform -chdir=aws/clusters/$team destroy -var="aviatrix_aws_account_name=<account>" -auto-approve & done && wait
+terraform -chdir=aws/network destroy -var="aviatrix_aws_account_name=<account>" -auto-approve
+```
+
+## Key Design Notes
+
+- **excluded_advertised_spoke_routes goes on the TRANSIT**, not spokes — software-defined routing, not BGP
+- **Always deny BOTH directions** between isolated teams — asymmetric rules cause traffic asymmetry issues
+- **Do NOT use `0.0.0.0/0` for default deny** — blocks RFC1918 east-west traffic. Use the built-in Public Internet SmartGroup instead
+- **Calico in policy-only mode** — VPC CNI handles pod networking; Calico adds Kubernetes NetworkPolicy enforcement
+
+## When to Use
+
+Choose this pattern when teams need **full cluster autonomy**, different Kubernetes versions, or strict compliance isolation. For a cost-effective shared alternative, see [k8s-namespace-aas](../k8s-namespace-aas/). For the recommended balanced approach, see [k8s-prod-nonprod-hybrid](../k8s-prod-nonprod-hybrid/).

--- a/blueprints/k8s-namespace-aas/README.md
+++ b/blueprints/k8s-namespace-aas/README.md
@@ -1,144 +1,156 @@
-# Pattern B: Namespace-as-a-Service
+# k8s-namespace-aas — Namespace-as-a-Service
 
-Single shared Kubernetes cluster with namespace-level isolation enforced by Aviatrix DCF and Kubernetes RBAC.
+All teams share a **single EKS cluster** with namespace-level isolation enforced by Aviatrix DCF (transit-level) and Calico NetworkPolicy (intra-cluster). Kubernetes RBAC prevents accidental cross-namespace access but is **not a network security boundary** — DCF and NetworkPolicy are the enforcement mechanisms.
 
 ## Architecture
 
 ```
-                    ┌─────────────────┐
-                    │  Aviatrix Transit│
-                    │    Gateway (Hub) │
-                    └────────┬────────┘
-                             │
-                    ┌────────┴────────┐
-                    │   Shared VPC    │
-                    │   + Spoke GW    │
-                    │                 │
-                    │ ┌─────────────┐ │
-                    │ │ Shared EKS  │ │
-                    │ │             │ │
-                    │ │ ┌─────────┐ │ │
-                    │ │ │ team-a  │ │ │
-                    │ │ ├─────────┤ │ │
-                    │ │ │ team-b  │ │ │
-                    │ │ ├─────────┤ │ │
-                    │ │ │ team-c  │ │ │
-                    │ │ └─────────┘ │ │
-                    │ └─────────────┘ │
-                    └─────────────────┘
+Transit GW (10.2.0.0/20)
+└── Shared Spoke (10.10.0.0/16) ──── EKS shared-cluster
+                                          ├── namespace: team-a  [pods: 100.64.x.x]
+                                          ├── namespace: team-b  [pods: 100.64.x.x]
+                                          └── namespace: team-c  [pods: 100.64.x.x]
 ```
 
-All teams share one cluster. Isolation is provided by DCF SmartGroups (keyed on `k8s_namespace`) and RBAC RoleBindings that scope teams to their namespace.
+**VPCs:** 2 (transit + shared) · **Clusters:** 1 (shared) · **Kubernetes:** 1.35
 
-## Supported CSPs
+### Pod Networking
+Pods use RFC 6598 overlay CIDR (`100.64.0.0/16`). Aviatrix SNAT translates pod IPs to the spoke gateway IP for east-west and egress traffic. Intra-cluster east-west stays within the VPC fabric and is enforced by Calico NetworkPolicy.
 
-| Directory | Cloud | Clusters | Region Default |
-|-----------|-------|----------|----------------|
-| `aws/` | AWS (EKS) | shared | us-east-1 |
-| `azure/` | Azure (AKS) | shared | — |
-| `gcp/` | GCP (GKE) | shared | — |
+### Two-Layer Isolation
 
-## Layers
+| Layer | Mechanism | Scope |
+|---|---|---|
+| Cross-VPC | Aviatrix DCF at spoke gateway | Between clusters / external egress |
+| Intra-cluster | Calico NetworkPolicy (iptables) | Between namespaces, same cluster |
 
-| Layer | Directory | What It Creates | ~Time |
-|-------|-----------|-----------------|-------|
-| 1. Network | `{csp}/network/` | Transit GW, shared VPC + spoke GW, Route53/DNS zone, SNAT policies | 5-8 min |
-| 2. Cluster | `{csp}/clusters/shared/` | EKS/AKS/GKE control plane, VPC CNI custom networking, Aviatrix cluster onboarding | 10-15 min |
-| 3. Nodes | `{csp}/nodes/shared/` | Shared node group (m5.xlarge, SPOT), ENIConfig, k8s-firewall Helm chart | 5-8 min |
-| 4. CRDs | `{csp}/k8s-apps/dcf-crd/` | Namespaces, RBAC, FirewallPolicy CRDs, WebGroupPolicy CRDs | < 1 min |
+### DCF Policy Layout
 
-## Key Design Decisions
+| Priority | Action | Rule |
+|---|---|---|
+| 0–1 | DENY | Geo-block (IR, KP, RU) + ThreatIQ |
+| 5 | PERMIT | Monitoring namespace → all namespaces on TCP/9090 |
+| 10 | PERMIT | team-a → team-b on TCP/443 |
+| 50–55 | DENY | Namespace isolation (team-a ↔ team-c, team-b ↔ team-c) |
+| 60 | PERMIT | All namespaces → EKS required services egress |
 
-- **Single cluster, multi-tenant**: Lower cost and operational overhead vs. Pattern A. Trade-off: blast radius is larger.
-- **DCF as primary isolation**: SmartGroups match on `k8s_namespace` label. DCF sees post-SNAT traffic, so VPC SmartGroups match source IPs (spoke gateway).
-- **RBAC is NOT a network boundary**: Kubernetes RBAC prevents accidental cross-namespace access but does not enforce network isolation. DCF provides the hard boundary.
-- **Team self-service CRDs**: Teams can author FirewallPolicy CRDs (priority 70-99) to control their own egress destinations via WebGroups.
+### Calico NetworkPolicy (intra-cluster)
+Deployed via `aws/k8s-apps/dcf-crd/network-policies.yaml`:
+- **team-a**: allow same namespace, deny other namespaces
+- **team-b**: allow same namespace + team-a ingress (mirrors DCF rule 10)
+- **team-c**: allow same namespace only (fully isolated)
 
-## Layer 4: CRD Details
+## Deployment
 
-### Namespaces Created
+```
+Layer 1: aws/network/          ← Transit, VPC, Spoke, DNS, DCF  (~8 min)
+Layer 2: aws/clusters/shared/  ← Shared EKS control plane        (~15 min)
+Layer 3: aws/nodes/shared/     ← Node group, ENIConfig, Helm      (~8 min)
+Layer 4: aws/k8s-apps/         ← Namespaces, RBAC, NetworkPolicy  (<1 min)
+```
 
-| Namespace | Purpose | Labels |
-|-----------|---------|--------|
-| `team-a` | Team A workloads | `team: team-a` |
-| `team-b` | Team B workloads | `team: team-b` |
-| `team-c` | Team C workloads | `team: team-c` |
-| `monitoring` | Shared observability | — |
-| `istio-system` | Service mesh | — |
-| `cert-manager` | TLS automation | — |
+### Prerequisites
+- Aviatrix Controller with AWS account onboarded
+- AWS credentials with sufficient permissions
+- Terraform ≥ 1.5 · kubectl · helm
 
-### FirewallPolicy CRDs
-
-- **team-a**: Allows `app=api` pods to reach `api.stripe.com`, `api.sendgrid.com` on TCP 443
-- **team-b**: Allows `app=frontend` to CDN domains (CloudFront, Cloudflare, Akamai) and `app=analytics` to Segment/Mixpanel on TCP 443
-
-## Deploy (AWS Example)
+### Layer 1 — Network
 
 ```bash
-cd namespace-aas/aws
-
-# Layer 1
-cd network && terraform init && terraform apply -auto-approve && cd ..
-
-# Layer 2
-cd clusters/shared && terraform init && terraform apply -auto-approve && cd ../..
-
-# Layer 3
-cd nodes/shared && terraform init && terraform apply -auto-approve && cd ../..
-
-# Layer 4
-aws eks update-kubeconfig --name naas-shared-eks --region us-east-1
-kubectl apply -f k8s-apps/dcf-crd/namespace-setup.yaml
-kubectl apply -f k8s-apps/dcf-crd/firewallpolicy-team-a.yaml
-kubectl apply -f k8s-apps/dcf-crd/firewallpolicy-team-b.yaml
+cd aws/network
+terraform init
+terraform apply -var="aviatrix_aws_account_name=<account>"
 ```
-
-## Destroy (Reverse Order)
-
-```bash
-cd namespace-aas/aws
-
-kubectl delete -f k8s-apps/dcf-crd/ --ignore-not-found
-cd nodes/shared && terraform destroy -auto-approve && cd ../..
-cd clusters/shared && terraform destroy -auto-approve && cd ../..
-cd network && terraform destroy -auto-approve && cd ..
-```
-
-## Variables
-
-### Network Layer
 
 | Variable | Default | Description |
-|----------|---------|-------------|
-| `name_prefix` | `naas` | Resource naming prefix |
-| `aviatrix_aws_account_name` | — | Aviatrix-onboarded AWS account name (required) |
-| `aws_region` | `us-east-1` | Target region |
-| `shared_vpc_cidr` | `10.10.0.0/16` | Shared VPC CIDR |
-| `transit_cidr` | `10.2.0.0/20` | Transit VPC CIDR |
+|---|---|---|
+| `aviatrix_aws_account_name` | required | Aviatrix access account name |
+| `aws_region` | `us-east-1` | AWS region |
+| `name_prefix` | `naas` | Resource name prefix |
+| `random_suffix` | `true` | Append random hex (e.g. `naas-9d4c`) |
+| `shared_vpc_cidr` | `10.10.0.0/16` | Shared cluster VPC CIDR |
 | `pod_cidr` | `100.64.0.0/16` | Pod overlay CIDR |
-| `team_namespaces` | `[team-a, team-b, team-c]` | Namespace list for DCF SmartGroups |
+| `k8s_cluster_suffix` | `shared-eks` | Suffix for cluster name |
+| `team_namespaces` | `["team-a","team-b","team-c"]` | Teams to isolate |
+| `approved_web_domains` | `[*.amazonaws.com, ghcr.io, docker.io…]` | Approved egress domains |
 
-### Cluster Layer
+### Layer 2 — Cluster
+
+```bash
+cd aws/clusters/shared
+terraform init
+terraform apply -var="aviatrix_aws_account_name=<account>"
+```
 
 | Variable | Default | Description |
-|----------|---------|-------------|
-| `kubernetes_version` | `1.31` | EKS Kubernetes version |
-| `enable_private_endpoint` | `false` | Private-only API server |
-| `enable_control_plane_logging` | `false` | Control plane audit logging |
+|---|---|---|
+| `kubernetes_version` | `1.35` | EKS version |
 
-### Nodes Layer
+### Layer 3 — Nodes
+
+```bash
+cd aws/nodes/shared
+terraform init && terraform apply
+```
 
 | Variable | Default | Description |
-|----------|---------|-------------|
-| `node_group_config.desired_size` | `3` | Desired node count |
-| `node_group_config.instance_type` | `m5.xlarge` | EC2 instance type |
-| `node_group_config.capacity_type` | `SPOT` | SPOT or ON_DEMAND |
+|---|---|---|
+| `node_group_config.instance_type` | `t3.large` | EC2 instance type |
+| `node_group_config.desired_size` | `2` | Node count |
+| `node_group_config.capacity_type` | `SPOT` | `SPOT` or `ON_DEMAND` |
+| `enable_network_policy` | `true` | Calico (policy-only mode) |
 
-## Prerequisites
+### Layer 4 — K8s Apps
 
-- Aviatrix Controller with CoPilot
-- Aviatrix-onboarded cloud account
-- Terraform >= 1.5, AWS CLI >= 2.61, kubectl >= 1.28
-- Sufficient quotas (3 VPCs, 4 EIPs per region)
+```bash
+# Apply namespace isolation policies
+kubectl apply -f aws/k8s-apps/dcf-crd/network-policies.yaml
 
-See [DEPLOYMENT-WORKFLOW.md](../DEPLOYMENT-WORKFLOW.md) for full details.
+# Optional: team self-service egress policies
+kubectl apply -f aws/k8s-apps/dcf-crd/firewallpolicy-team-a.yaml
+kubectl apply -f aws/k8s-apps/dcf-crd/firewallpolicy-team-b.yaml
+```
+
+## Traffic Tests
+
+```bash
+aws eks update-kubeconfig --name <cluster-name> --alias naas-shared --region us-east-1
+
+# Create test pods per namespace
+for ns in team-a team-b team-c; do
+  kubectl -n $ns run nginx --image=nginx:alpine --port=80 --restart=Never
+  kubectl -n $ns run netshoot --image=nicolaka/netshoot --command -- sleep infinity --restart=Never
+  kubectl -n $ns expose pod nginx --port=443 --target-port=80 --name="${ns}-svc"
+done
+```
+
+Expected results:
+
+| Test | Expected | Enforced by |
+|---|---|---|
+| team-a → team-a (same ns) | PASS | — |
+| team-a → team-b | PASS | Calico PERMIT + DCF rule 10 |
+| team-a → team-c | BLOCKED | Calico DENY + DCF rule 50 |
+| team-c → team-a | BLOCKED | Calico DENY + DCF rule 51 |
+| team-b → team-c | BLOCKED | Calico DENY + DCF rule 52 |
+| team-c → team-b | BLOCKED | Calico DENY + DCF rule 55 |
+
+## Destroy (reverse order)
+
+```bash
+kubectl delete -f aws/k8s-apps/dcf-crd/
+terraform -chdir=aws/nodes/shared destroy -auto-approve
+terraform -chdir=aws/clusters/shared destroy -var="aviatrix_aws_account_name=<account>" -auto-approve
+terraform -chdir=aws/network destroy -var="aviatrix_aws_account_name=<account>" -auto-approve
+```
+
+## Key Design Notes
+
+- **RBAC is not a network boundary** — it prevents accidental access, DCF + NetworkPolicy enforce isolation
+- **Two enforcement layers required for intra-cluster isolation** — DCF only sees traffic that traverses the spoke gateway; Calico covers pod-to-pod within the same VPC
+- **`k8s_cluster_id` is required in K8s SmartGroups** — prevents cross-cluster namespace collisions when multiple clusters report to the same controller
+- **Approved egress domains include docker.io** — Calico images pull from docker.io; add this to avoid image pull failures behind DCF
+
+## When to Use
+
+Choose this pattern when **cost and operational simplicity** matter more than blast-radius isolation. Best for trusted teams with controlled workloads. For stricter isolation, see [k8s-cluster-aas](../k8s-cluster-aas/). For the recommended balanced approach, see [k8s-prod-nonprod-hybrid](../k8s-prod-nonprod-hybrid/).

--- a/blueprints/k8s-prod-nonprod-hybrid/README.md
+++ b/blueprints/k8s-prod-nonprod-hybrid/README.md
@@ -1,181 +1,188 @@
-# Pattern C: Prod/Non-Prod Hybrid (Recommended)
+# k8s-prod-nonprod-hybrid — Prod/Non-Prod Hybrid (Recommended)
 
-Separate production and non-production clusters with two-layer DCF isolation: environment-level (VPC) and namespace-level (CRDs). Combines the strong isolation of Pattern A with the team self-service of Pattern B.
+Separate production and non-production EKS clusters with **two-layer DCF isolation**: environment-level (VPC SmartGroups) and namespace-level (K8s SmartGroups). Combines the strong isolation of cluster-aas with the team self-service of namespace-aas. HA enabled by default.
 
 ## Architecture
 
 ```
-                    ┌─────────────────┐
-                    │  Aviatrix Transit│
-                    │    Gateway (Hub) │
-                    │       (HA)       │
-                    └──┬──────┬──────┬┘
-                       │      │      │
-              ┌────────┘      │      └────────┐
-              ▼               ▼               ▼
-        ┌───────────┐  ┌───────────┐  ┌───────────┐
-        │Production │  │Non-Prod   │  │ Database  │
-        │  VPC      │  │  VPC      │  │  Spoke    │
-        │  + Spoke  │  │  + Spoke  │  │(prod-only)│
-        │           │  │           │  └───────────┘
-        │ ┌───────┐ │  │ ┌───────┐ │
-        │ │pc2-   │ │  │ │pc2-   │ │
-        │ │prod   │ │  │ │nonprod│ │
-        │ │       │ │  │ │       │ │
-        │ │team-a │ │  │ │team-a │ │
-        │ │team-b │ │  │ │team-b │ │
-        │ └───────┘ │  │ │sandbox│ │
-        └───────────┘  │ └───────┘ │
-                       └───────────┘
+Transit GW (10.2.0.0/20, HA)
+├── Prod Spoke    (10.10.0.0/20) ──── EKS prod-cluster
+│                                         ├── namespace: team-a-prod
+│                                         ├── namespace: team-b-prod
+│                                         └── namespace: monitoring
+├── NonProd Spoke (10.20.0.0/20) ──── EKS nonprod-cluster
+│                                         ├── namespace: team-a-dev
+│                                         ├── namespace: team-b-staging
+│                                         ├── namespace: sandbox
+│                                         └── namespace: monitoring
+└── DB Spoke      (10.5.0.0/22)  ──── Database (prod-only)
 ```
 
-Production and non-production are hard-isolated at the VPC/spoke level. Within each cluster, teams get their own namespaces with DCF-enforced egress policies. The database spoke is only reachable from production.
+**VPCs:** 4 (transit + prod + nonprod + DB) · **Clusters:** 2 · **Kubernetes:** 1.35
 
-## Supported CSPs
+### Two-Layer DCF Isolation
 
-| Directory | Cloud | Clusters | Region Default |
-|-----------|-------|----------|----------------|
-| `aws/` | AWS (EKS) | prod, nonprod | us-east-2 |
-| `azure/` | Azure (AKS) | prod, nonprod | — |
-| `gcp/` | GCP (GKE) | prod, nonprod | — |
+**Layer 1 — Environment boundary (VPC SmartGroups)**
+- Prod VPC ↔ NonProd VPC: bidirectionally denied
+- Database spoke: prod-only (transit routing + DCF rules)
 
-## Layers
+**Layer 2 — Team namespace boundary (K8s SmartGroups)**
+- Per-namespace SmartGroups (`k8s_namespace` + `k8s_cluster_id`)
+- Teams define egress policies via FirewallPolicy CRDs (priority 70–99)
 
-| Layer | Directory | What It Creates | ~Time |
-|-------|-----------|-----------------|-------|
-| 1. Network | `{csp}/network/` | Transit GW (HA), prod VPC + spoke, nonprod VPC + spoke, database spoke, Route53/DNS zone, SNAT policies | 5-8 min |
-| 2. Clusters | `{csp}/clusters/{env}/` | EKS/AKS/GKE control plane per environment, VPC CNI, managed node groups, Aviatrix cluster onboarding | 10-15 min each |
-| 3. Nodes | `{csp}/nodes/{env}/` | k8s-firewall Helm chart (DCF CRD engine) | 5-8 min each |
-| 4. CRDs | `{csp}/k8s-apps/dcf-crd/` | Namespaces, FirewallPolicy CRDs (strict for prod, relaxed for nonprod) | < 1 min |
+### DCF Policy Layout
 
-## Key Design Decisions
+| Priority | Action | Rule |
+|---|---|---|
+| 0–1 | DENY | Geo-block + ThreatIQ |
+| 10 | DENY | prod-vpc → nonprod-vpc |
+| 11 | DENY | nonprod-vpc → prod-vpc |
+| 20–21 | DENY | monitoring-nonprod ↔ prod namespaces |
+| 30 | DENY | nonprod → DB spoke |
+| 31 | PERMIT | prod → DB spoke |
+| 32 | PERMIT | monitoring-prod → prod namespaces (TCP/9090) |
+| 50–51 | PERMIT | prod/nonprod egress → EKS required services |
+| 70–99 | — | Team self-service via FirewallPolicy CRDs |
 
-- **Two-layer isolation**: VPC boundaries block prod/nonprod cross-traffic at Layer 1. DCF CRDs enforce per-team egress at Layer 4.
-- **Database spoke is prod-only**: Transit routing ensures nonprod cannot reach the database spoke, regardless of DCF rules.
-- **Stricter prod policies**: Production FirewallPolicies allow only pre-approved API endpoints. Nonprod policies are more relaxed; sandbox allows all HTTPS egress.
-- **HA by default**: Transit and spoke gateways deploy with HA enabled (`enable_ha = true`).
+## Deployment
 
-## Layer 4: CRD Details
+```
+Layer 1: aws/network/              ← Transit(HA), VPCs, Spokes, DNS, DCF  (~8 min)
+Layer 2: aws/clusters/prod|nonprod  ← EKS control planes (parallel)         (~15 min)
+Layer 3: aws/nodes/prod|nonprod     ← Node groups, Helm charts (parallel)    (~8 min)
+Layer 4: aws/k8s-apps/             ← Namespaces, RBAC, FirewallPolicy CRDs  (<1 min)
+```
 
-### Production Namespaces
+### Prerequisites
+- Aviatrix Controller with AWS account onboarded
+- AWS credentials with sufficient permissions
+- Terraform ≥ 1.5 · kubectl · helm
 
-| Namespace | Egress Policy |
-|-----------|--------------|
-| `team-a-prod` | TCP 443 to Stripe, Datadog, AWS APIs only |
-| `team-b-prod` | TCP 443 to CloudFront, Akamai only |
-| `monitoring` | Observability stack |
-
-### Non-Production Namespaces
-
-| Namespace | Egress Policy |
-|-----------|--------------|
-| `team-a-dev` | TCP 443 to npm, GitHub, AWS APIs, Stripe |
-| `team-b-staging` | TCP 443 to staging CDN and build tools |
-| `sandbox` | TCP 80/443 to any destination (relaxed) |
-| `monitoring` | Observability stack |
-
-## Deploy (AWS Example)
+### Layer 1 — Network
 
 ```bash
-cd prod-nonprod-hybrid/aws
-
-# Layer 1
-cd network && terraform init && terraform apply -auto-approve && cd ..
-
-# Layer 2 (parallel)
-cd clusters/prod && terraform init && terraform apply -auto-approve &
-cd clusters/nonprod && terraform init && terraform apply -auto-approve &
-wait
-
-# Layer 3 (parallel)
-cd nodes/prod && terraform init && terraform apply -auto-approve &
-cd nodes/nonprod && terraform init && terraform apply -auto-approve &
-wait
-
-# Layer 4
-aws eks update-kubeconfig --name pc2-prod --region us-east-2
-kubectl apply -f k8s-apps/dcf-crd/prod-namespaces.yaml
-kubectl apply -f k8s-apps/dcf-crd/firewallpolicy-prod.yaml
-
-aws eks update-kubeconfig --name pc2-nonprod --region us-east-2
-kubectl apply -f k8s-apps/dcf-crd/nonprod-namespaces.yaml
-kubectl apply -f k8s-apps/dcf-crd/firewallpolicy-nonprod.yaml
+cd aws/network
+terraform init
+terraform apply -var="aws_account_name=<account>"
 ```
-
-## Destroy (Reverse Order)
-
-```bash
-cd prod-nonprod-hybrid/aws
-
-for env in prod nonprod; do
-  (cd nodes/$env && terraform destroy -auto-approve) &
-done
-wait
-
-for env in prod nonprod; do
-  (cd clusters/$env && terraform destroy -auto-approve) &
-done
-wait
-
-cd network && terraform destroy -auto-approve && cd ..
-```
-
-## Variables
-
-### Network Layer
 
 | Variable | Default | Description |
-|----------|---------|-------------|
-| `aws_account_name` | — | Aviatrix-onboarded AWS account name (required) |
-| `aws_region` | `us-east-2` | Target region |
-| `transit_cidr` | `10.2.0.0/20` | Transit VPC CIDR |
+|---|---|---|
+| `aws_account_name` | required | Aviatrix access account name |
+| `aws_region` | `us-east-2` | AWS region |
+| `environment_prefix` | `pc2` | Resource name prefix |
+| `random_suffix` | `true` | Append random hex (e.g. `pc2-7160`) |
 | `prod_vpc_cidr` | `10.10.0.0/20` | Production VPC CIDR |
 | `nonprod_vpc_cidr` | `10.20.0.0/20` | Non-production VPC CIDR |
-| `db_vpc_cidr` | `10.5.0.0/22` | Database spoke CIDR |
-| `pod_cidr` | `100.64.0.0/16` | Shared pod overlay CIDR |
-| `enable_ha` | `true` | HA for transit and spoke gateways |
-| `teams` | map | Team namespace definitions |
+| `db_spoke_cidr` | `10.5.0.0/22` | Database spoke CIDR |
+| `pod_cidr` | `100.64.0.0/16` | Pod overlay CIDR |
+| `enable_ha` | `true` | Enable gateway HA |
 
-### Cluster Layer
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `cluster_version` | `1.31` | EKS Kubernetes version |
-| `enable_private_endpoint` | `false` | Private-only API server |
-| `enable_control_plane_logging` | `false` | Control plane audit logging |
-
-### Nodes Layer
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| Prod: `desired_size` | `2` | Prod node count |
-| Nonprod: `desired_size` | `2` | Nonprod node count |
-| `instance_type` | `t3.large` | EC2 instance type |
-
-## Verification
+### Layer 2 — Clusters (parallel)
 
 ```bash
-# Prod cluster
-aws eks update-kubeconfig --name pc2-prod --region us-east-2
-kubectl get nodes
-kubectl get firewallpolicies -A
+terraform -chdir=aws/clusters/prod init
+terraform -chdir=aws/clusters/prod apply -var="aviatrix_aws_account_name=<account>" -auto-approve &
 
-# Nonprod cluster
-aws eks update-kubeconfig --name pc2-nonprod --region us-east-2
-kubectl get nodes
-kubectl get firewallpolicies -A
-
-# Verify in CoPilot:
-#   Security > DCF — two-layer rules (env + namespace)
-#   nonprod → prod traffic: DENIED
-#   nonprod → database spoke: DENIED
+terraform -chdir=aws/clusters/nonprod init
+terraform -chdir=aws/clusters/nonprod apply -var="aviatrix_aws_account_name=<account>" -auto-approve &
+wait
 ```
 
-## Prerequisites
+| Variable | Default | Description |
+|---|---|---|
+| `kubernetes_version` | `1.35` | EKS version |
 
-- Aviatrix Controller with CoPilot
-- Aviatrix-onboarded cloud account
-- Terraform >= 1.5, AWS CLI >= 2.61, kubectl >= 1.28
-- Sufficient quotas (5 VPCs, 10 EIPs per region)
+### Layer 3 — Nodes (parallel)
 
-See [DEPLOYMENT-WORKFLOW.md](../DEPLOYMENT-WORKFLOW.md) for full details.
+```bash
+terraform -chdir=aws/nodes/prod apply -auto-approve &
+terraform -chdir=aws/nodes/nonprod apply -auto-approve &
+wait
+```
+
+| Variable | Default | Description |
+|---|---|---|
+| `node_group_config.instance_type` | `t3.large` | EC2 instance type |
+| `node_group_config.desired_size` | `2` | Node count |
+| `enable_network_policy` | `true` | Calico (policy-only mode) |
+
+### Layer 4 — K8s Apps (both clusters)
+
+```bash
+# Production cluster
+aws eks update-kubeconfig --name <prod-cluster> --alias pc2-prod --region us-east-2
+kubectl --context pc2-prod apply -f aws/k8s-apps/dcf-crd/prod-namespaces.yaml
+kubectl --context pc2-prod apply -f aws/k8s-apps/dcf-crd/firewallpolicy-prod.yaml
+
+# Non-production cluster
+aws eks update-kubeconfig --name <nonprod-cluster> --alias pc2-nonprod --region us-east-2
+kubectl --context pc2-nonprod apply -f aws/k8s-apps/dcf-crd/nonprod-namespaces.yaml
+kubectl --context pc2-nonprod apply -f aws/k8s-apps/dcf-crd/firewallpolicy-nonprod.yaml
+```
+
+## Traffic Tests
+
+```bash
+# Deploy test pods in both clusters
+for ctx in pc2-prod pc2-nonprod; do
+  kubectl --context $ctx -n default run nginx --image=nginx:alpine --port=80 --restart=Never
+  kubectl --context $ctx -n default run netshoot --image=nicolaka/netshoot --command -- sleep infinity --restart=Never
+done
+```
+
+Expected results:
+
+| Test | Expected | DCF Rule |
+|---|---|---|
+| prod → nonprod VPC | BLOCKED | DENY 10 |
+| nonprod → prod VPC | BLOCKED | DENY 11 |
+| nonprod → DB spoke | BLOCKED | DENY 30 |
+| prod → DB spoke | PASS | PERMIT 31 |
+| prod egress registry.k8s.io | PASS | PERMIT 50 |
+| nonprod egress registry.k8s.io | PASS | PERMIT 51 |
+
+## Destroy (reverse order)
+
+```bash
+# Layer 4
+kubectl --context pc2-prod delete -f aws/k8s-apps/dcf-crd/
+kubectl --context pc2-nonprod delete -f aws/k8s-apps/dcf-crd/
+
+# Layer 3
+terraform -chdir=aws/nodes/prod destroy -auto-approve &
+terraform -chdir=aws/nodes/nonprod destroy -auto-approve &
+wait
+
+# Layer 2
+terraform -chdir=aws/clusters/prod destroy -var="aviatrix_aws_account_name=<account>" -auto-approve &
+terraform -chdir=aws/clusters/nonprod destroy -var="aviatrix_aws_account_name=<account>" -auto-approve &
+wait
+
+# Layer 1
+terraform -chdir=aws/network destroy -var="aws_account_name=<account>" -auto-approve
+```
+
+## Key Design Notes
+
+- **Two-layer isolation is the key differentiator** — environment boundary (VPC) prevents gross misconfiguration; namespace boundary enforces team segmentation within each environment
+- **Database spoke is prod-only via transit routing + DCF** — dual enforcement means a misconfigured DCF rule alone can't expose the DB to nonprod
+- **`k8s_cluster_id` differs for prod vs nonprod SmartGroups** — without this, namespace names collide between clusters
+- **Sandbox namespace has relaxed egress** — suitable for developer experimentation without compromising prod or nonprod
+- **HA enabled by default** — recommended for production-grade deployments
+
+## Environment Policies
+
+| Namespace | Egress Allowed | Rationale |
+|---|---|---|
+| team-a-prod | Stripe, Datadog, AWS APIs | Production: strict allowlist |
+| team-b-prod | CloudFront, Akamai | Production: CDN only |
+| team-a-dev | npm, GitHub, AWS, Stripe | Dev: includes build tools |
+| team-b-staging | Staging CDN, build tools | Staging: mirrors prod with extras |
+| sandbox | All HTTPS | Developer experimentation |
+
+## When to Use
+
+**Recommended for most organizations.** Choose this pattern when you need environment-level isolation (prod cannot talk to nonprod) combined with team self-service egress policies. Balances security, cost, and operational overhead.
+
+For the strongest isolation, see [k8s-cluster-aas](../k8s-cluster-aas/). For the lowest cost, see [k8s-namespace-aas](../k8s-namespace-aas/).


### PR DESCRIPTION
## Summary

Documentation updates across all K8s blueprint patterns:

- **Root README.md** — updated pattern table with correct `k8s-*` directory links, added all blueprints, cleaned structure
- **DEPLOYMENT-WORKFLOW.md** — correct paths (`blueprints/k8s-*`), random suffix cluster names, Pattern C variable fix (`aws_account_name`), updated DCF troubleshooting (policy group approach), added docker.io/Calico rate limit issue
- **k8s-cluster-aas/README.md** — full rewrite: architecture diagram, DCF policy table (including default deny 200), deploy commands, 8/8 test matrix, destroy instructions, design notes
- **k8s-namespace-aas/README.md** — full rewrite: two-layer isolation explained (DCF + Calico), deploy commands, test cases, Calico note
- **k8s-prod-nonprod-hybrid/README.md** — full rewrite: two-layer DCF, environment policies table, namespace summary, deploy/destroy commands

All documentation is aligned to the repo structure (paths relative to repo root, `k8s-` prefix preserved).

## Test plan
- [ ] Verify links in README.md resolve correctly in GitHub
- [ ] Verify DEPLOYMENT-WORKFLOW commands match actual repo paths
- [ ] Verify blueprint READMEs match deployed architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)