### PR TITLE
Restore catalog-style root README, add k8s-* + validate-blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ Blueprints are **complete, deployable lab environments** that demonstrate Aviatr
 | [k8s-namespace-aas](blueprints/k8s-namespace-aas/) | Pattern B — single shared cluster, namespace per team (DCF + RBAC isolation) | AWS, Azure, GCP | — | 🚧 Work in progress |
 | [k8s-prod-nonprod-hybrid](blueprints/k8s-prod-nonprod-hybrid/) | Pattern C — separate prod and nonprod clusters, namespace-as-a-service inside each | AWS, Azure, GCP | — | 🚧 Work in progress |
 | [agentcore-aws](blueprints/agentcore-aws/) | AWS Bedrock AgentCore Runtime fronted by Aviatrix DCF | AWS | — | 🚧 Work in progress |
-| [azure-centralized-ingress](blueprints/azure-centralized-ingress/) | Centralized public ingress in Azure via Aviatrix spoke (DNAT + AppGW WAF) | Azure | — | 🚧 Work in progress |
-| [secure-enterprise-ai-chat-aws](blueprints/secure-enterprise-ai-chat-aws/) | Secured enterprise AI chat (LibreChat) on EKS with DCF egress controls | AWS | — | 🚧 Work in progress |
 
 ## Manual Deployment
 

--- a/README.md
+++ b/README.md
@@ -1,117 +1,167 @@
-# Aviatrix Kubernetes Multi-Cloud Blueprints
+# Aviatrix Blueprints
 
-Production-ready Terraform blueprints for deploying Kubernetes environments with Aviatrix transit networking and Distributed Cloud Firewall (DCF).
+Production-ready Terraform lab environments for learning, demonstrating, and testing Aviatrix cloud networking solutions.
 
-## Kubernetes Patterns
+![Aviatrix Blueprints](aviatrix_blueprints_logo.png)
 
-Three patterns for different isolation requirements. Each supports AWS, Azure, and GCP.
+> [!TIP]
+> **🤖 Aviatrix Blueprints are Optimized for Claude Code**
+>
+> Get AI-assisted deployment with prerequisite checks, cost estimates, and automated orchestration.
+>
+> | Skill | Description |
+> |-------|-------------|
+> | `/deploy-blueprint` | Guided deployment with prerequisite validation |
+> | `/analyze-blueprint` | Resource inventory and cost estimates |
+> | `/validate-blueprint` | Pre-QA quality gate (Tier 1/2/3 checks) |
+>
+> [Get Claude Code](https://claude.ai/code)
 
-| Pattern | Directory | Isolation | Clusters | Best For |
-|---|---|---|---|---|
-| **k8s-cluster-aas** | [`blueprints/k8s-cluster-aas/`](blueprints/k8s-cluster-aas/) | VPC-level (hard boundary) | 1 per team | Strict isolation, compliance |
-| **k8s-namespace-aas** | [`blueprints/k8s-namespace-aas/`](blueprints/k8s-namespace-aas/) | Namespace (DCF + Calico) | 1 shared | Cost-conscious, trusted teams |
-| **k8s-prod-nonprod-hybrid** ⭐ | [`blueprints/k8s-prod-nonprod-hybrid/`](blueprints/k8s-prod-nonprod-hybrid/) | VPC + namespace (two-layer) | 2 (prod/nonprod) | Most organizations |
-
-## Standalone Blueprints
-
-| Blueprint | Directory | Description | Cloud |
-|---|---|---|---|
-| aws-eks-multicluster | [`blueprints/aws-eks-multicluster/`](blueprints/aws-eks-multicluster/) | DCF with EKS frontend/backend | AWS |
-| azure-aks-multicluster | [`azure-aks-multicluster/`](azure-aks-multicluster/) | AKS clusters with FireNet | Azure |
-| gcp-gke-multicluster | [`gcp-gke-multicluster/`](gcp-gke-multicluster/) | GKE clusters with Datapath v2 | GCP |
-| prevent-lateral-movement-vm-tags | [`blueprints/prevent-lateral-movement-vm-tags/`](blueprints/prevent-lateral-movement-vm-tags/) | Zero Trust DCF with VM tags | AWS |
-| zero-trust-segmentation | [`blueprints/zero-trust-segmentation/`](blueprints/zero-trust-segmentation/) | DCF with SmartGroups | AWS |
-
-## 4-Layer Deployment Model
-
-All K8s patterns follow the same structure:
-
-```
-Layer 1: network/          ← Transit GW, Spoke GWs, VPCs, SNAT, DNS, DCF rules
-Layer 2: clusters/         ← EKS/AKS/GKE control planes, IRSA, access entries
-Layer 3: nodes/            ← Node groups, Calico, k8s-firewall, ALB, ExternalDNS
-Layer 4: k8s-apps/         ← Namespaces, FirewallPolicy, NetworkPolicy CRDs
-```
-
-Layers must be deployed in order. Layers at the same level (e.g., multiple clusters) can run in parallel.
-
-## Quick Start
-
-### Prerequisites
-
-- Aviatrix Controller with CoPilot
-- Cloud account onboarded in Aviatrix
-- Terraform ≥ 1.5, AWS/Azure/GCP CLI, kubectl ≥ 1.28
-
-### Deploy (example: k8s-cluster-aas on AWS)
+## Quick Start with Claude Code
 
 ```bash
-cd blueprints/k8s-cluster-aas/aws
-
-# Layer 1: Network
-cd network && terraform init && terraform apply -var="aviatrix_aws_account_name=<account>" && cd ..
-
-# Layer 2: Clusters (parallel)
-for team in team-a team-b team-c; do
-  terraform -chdir=clusters/$team init
-  terraform -chdir=clusters/$team apply -var="aviatrix_aws_account_name=<account>" -auto-approve &
-done && wait
-
-# Layer 3: Nodes (parallel)
-for team in team-a team-b team-c; do
-  terraform -chdir=nodes/$team init
-  terraform -chdir=nodes/$team apply -auto-approve &
-done && wait
+# Clone and open with Claude Code
+git clone https://github.com/AviatrixSystems/aviatrix-blueprints.git
+cd aviatrix-blueprints
+claude
 ```
 
-See [DEPLOYMENT-WORKFLOW.md](DEPLOYMENT-WORKFLOW.md) for complete instructions, all patterns, and verification checklists.
+Inside Claude Code:
+- `/deploy-blueprint aws-eks-multicluster` — Deploy with guided assistance
+- `/analyze-blueprint aws-eks-multicluster` — Preview resources and costs before deploying
+- `/validate-blueprint aws-eks-multicluster` — Run the pre-QA validation gate locally
 
-## Optional Hardening
+## What are Blueprints?
 
-All patterns include opt-in toggles (all default `false`) via the shared recommendations module:
+Blueprints are **complete, deployable lab environments** that demonstrate Aviatrix capabilities in real-world scenarios. Unlike reusable Terraform modules, blueprints are designed to be:
 
-```hcl
-# nodes/*/terraform.tfvars
-enable_network_policy           = true  # Calico NetworkPolicy
-enable_gatekeeper               = true  # OPA Gatekeeper admission control
-enable_external_secrets         = true  # AWS Secrets Manager sync
-enable_falco                    = true  # Runtime threat detection
-enable_prometheus_stack         = true  # Prometheus + Grafana
-enable_fluent_bit               = true  # CloudWatch log aggregation
-enable_node_termination_handler = true  # Required for SPOT instances
-enable_cluster_autoscaler       = true  # Dynamic scaling
-enable_velero                   = true  # Backup to S3
+- **Self-contained**: Everything needed to deploy a working environment
+- **Educational**: Clear documentation explaining what's being built and why
+- **Demonstrable**: Built-in test scenarios for showcasing functionality
+- **Ephemeral**: Designed for temporary use with easy cleanup
+
+## Blueprint Tiers
+
+| Tier | Description | Requirements |
+|------|-------------|--------------|
+| **Verified** | Validated by Aviatrix QA team, tested against specific controller versions | Full QA and SE review, version compatibility matrix |
+| **Community** | Contributed by the community, functional but not officially validated | Validated by an Aviatrix SE or Professional Services |
+
+## Blueprint Catalog
+
+| Blueprint | Description | Cloud(s) | Tier | Status |
+|-----------|-------------|----------|------|--------|
+| [aws-eks-multicluster](blueprints/aws-eks-multicluster/) | Multi-cluster EKS with Aviatrix transit and Distributed Cloud Firewall | AWS | Community | ✅ Available |
+| [azure-aks-multicluster](blueprints/azure-aks-multicluster/) | Multi-cluster AKS with Aviatrix transit and DCF (Cilium overlay, AppGW + NGINX two-tier ingress) | Azure | Community | ✅ Available |
+| [prevent-lateral-movement-vm-tags](blueprints/prevent-lateral-movement-vm-tags/) | Zero Trust segmentation using DCF and VM tags to prevent lateral movement | AWS | Community | ✅ Available |
+| [zero-trust-segmentation](blueprints/zero-trust-segmentation/) | Zero Trust workload segmentation with DCF SmartGroups | AWS | Community | ✅ Available |
+| [k8s-cluster-aas](blueprints/k8s-cluster-aas/) | Pattern A — dedicated cluster per team (VPC-level isolation) | AWS, Azure, GCP | — | 🚧 Work in progress |
+| [k8s-namespace-aas](blueprints/k8s-namespace-aas/) | Pattern B — single shared cluster, namespace per team (DCF + RBAC isolation) | AWS, Azure, GCP | — | 🚧 Work in progress |
+| [k8s-prod-nonprod-hybrid](blueprints/k8s-prod-nonprod-hybrid/) | Pattern C — separate prod and nonprod clusters, namespace-as-a-service inside each | AWS, Azure, GCP | — | 🚧 Work in progress |
+| [agentcore-aws](blueprints/agentcore-aws/) | AWS Bedrock AgentCore Runtime fronted by Aviatrix DCF | AWS | — | 🚧 Work in progress |
+| [azure-centralized-ingress](blueprints/azure-centralized-ingress/) | Centralized public ingress in Azure via Aviatrix spoke (DNAT + AppGW WAF) | Azure | — | 🚧 Work in progress |
+| [secure-enterprise-ai-chat-aws](blueprints/secure-enterprise-ai-chat-aws/) | Secured enterprise AI chat (LibreChat) on EKS with DCF egress controls | AWS | — | 🚧 Work in progress |
+
+## Manual Deployment
+
+### 1. Prerequisites
+
+Before deploying any blueprint, ensure you have:
+
+- An [Aviatrix Enterprise or Aviatrix Cloud Control Plane](docs/prerequisites/aviatrix-controller.md) deployed and accessible
+- [Terraform](docs/prerequisites/terraform.md) installed (v1.5+)
+- Cloud provider CLI configured for your target cloud:
+  - [AWS CLI](docs/prerequisites/aws-cli.md)
+  - [Azure CLI](docs/prerequisites/azure-cli.md)
+  - [Google Cloud CLI](docs/prerequisites/gcloud-cli.md)
+- Additional tools as required by specific blueprints (e.g., [kubectl](docs/prerequisites/kubectl.md))
+
+See the [Prerequisites Overview](docs/prerequisites/README.md) for detailed setup instructions.
+
+### 2. Deploy a Blueprint
+
+```bash
+# Clone the repository
+git clone https://github.com/AviatrixSystems/aviatrix-blueprints.git
+cd aviatrix-blueprints
+
+# Navigate to your chosen blueprint
+cd blueprints/aws-eks-multicluster
+
+# Review the README for specific requirements
+cat README.md
+
+# Copy and configure variables
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your values
+
+# Deploy
+terraform init
+terraform plan
+terraform apply
 ```
 
-See [`modules/recommendations/`](modules/recommendations/) for full details.
+Multi-layer blueprints (the `k8s-*` patterns and the `*-multicluster` blueprints) document their per-layer deploy and destroy order in the blueprint's own `README.md`.
+
+### 3. Explore and Learn
+
+Each blueprint includes:
+- Architecture diagrams
+- Step-by-step deployment instructions
+- Test scenarios to validate functionality
+- Demo walkthroughs for presentations
+
+### 4. Clean Up
+
+```bash
+# Destroy all resources when done
+terraform destroy
+```
 
 ## Repository Structure
 
 ```
-blueprints/
-├── blueprints/
-│   ├── k8s-cluster-aas/          # Pattern A: dedicated cluster per team
-│   │   ├── aws/ azure/ gcp/
-│   │   └── README.md
-│   ├── k8s-namespace-aas/        # Pattern B: shared cluster
-│   │   ├── aws/ azure/ gcp/
-│   │   └── README.md
-│   ├── k8s-prod-nonprod-hybrid/  # Pattern C: prod/nonprod (recommended)
-│   │   ├── aws/ azure/ gcp/
-│   │   └── README.md
+aviatrix-blueprints/
+├── docs/                    # Documentation and guides
+│   ├── prerequisites/       # Setup guides for required tools
+│   ├── getting-started.md   # Quick start guide
+│   └── blueprint-standards.md
+├── modules/                 # Shared Terraform modules
+├── blueprints/              # Deployable lab environments
+│   ├── _template/           # Template for new blueprints
 │   ├── aws-eks-multicluster/
-│   ├── zero-trust-segmentation/
-│   └── prevent-lateral-movement-vm-tags/
-├── azure-aks-multicluster/
-├── gcp-gke-multicluster/
-├── modules/
-│   └── recommendations/          # Optional hardening add-ons
-└── docs/
+│   ├── azure-aks-multicluster/
+│   ├── k8s-cluster-aas/         # Multi-cloud Pattern A
+│   ├── k8s-namespace-aas/       # Multi-cloud Pattern B
+│   ├── k8s-prod-nonprod-hybrid/ # Multi-cloud Pattern C
+│   └── ...                  # Additional blueprints
+└── .github/                 # CI/CD and templates
 ```
 
 ## Documentation
 
-| Document | Description |
-|---|---|
-| [DEPLOYMENT-WORKFLOW.md](DEPLOYMENT-WORKFLOW.md) | Step-by-step deployment guide, verification checklists, troubleshooting |
-| [WORKFLOW-GUIDE.md](WORKFLOW-GUIDE.md) | GitHub Actions CI/CD setup and state management |
+- [Getting Started Guide](docs/getting-started.md)
+- [Blueprint Standards](docs/blueprint-standards.md)
+- [Contributing Guide](CONTRIBUTING.md)
+- [Prerequisites](docs/prerequisites/README.md)
+
+## Contributing
+
+We welcome contributions! Whether you're fixing a bug, improving documentation, or adding a new blueprint, please see our [Contributing Guide](CONTRIBUTING.md).
+
+### Adding a New Blueprint
+
+1. Copy the [blueprint template](blueprints/_template/)
+2. Follow the [Blueprint Standards](docs/blueprint-standards.md)
+3. Run `/validate-blueprint <name>` (or `.github/scripts/validate-blueprint.sh blueprints/<name>`) to confirm Tier 1/2 checks pass
+4. Submit a PR for review
+
+## Support
+
+- **Issues**: [GitHub Issues](https://github.com/AviatrixSystems/aviatrix-blueprints/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/AviatrixSystems/aviatrix-blueprints/discussions)
+- **Aviatrix Documentation**: [docs.aviatrix.com](https://docs.aviatrix.com)
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary

The K8s-pattern-focused rewrite of the root README in `5be60e6` replaced the original catalog with a deployment guide. This PR restores the catalog structure (modeled on `5596162`, before that rewrite) — \"What are Blueprints\", Tier definitions, a full blueprint catalog with status emojis, and a generic single-blueprint deploy walkthrough — and updates it for the current blueprint set.

The detailed K8s pattern guidance and 4-layer deploy walkthrough remain in `DEPLOYMENT-WORKFLOW.md`.

## Changes

**Catalog updated** to reflect every blueprint currently in `blueprints/`:

| Blueprint | Cloud(s) | Tier | Status |
|---|---|---|---|
| aws-eks-multicluster | AWS | Community | ✅ Available |
| azure-aks-multicluster | Azure | Community | ✅ Available |
| prevent-lateral-movement-vm-tags | AWS | Community | ✅ Available |
| zero-trust-segmentation | AWS | Community | ✅ Available |
| k8s-cluster-aas | AWS / Azure / GCP | — | 🚧 Work in progress |
| k8s-namespace-aas | AWS / Azure / GCP | — | 🚧 Work in progress |
| k8s-prod-nonprod-hybrid | AWS / Azure / GCP | — | 🚧 Work in progress |
| agentcore-aws | AWS | — | 🚧 Work in progress |
| azure-centralized-ingress | Azure | — | 🚧 Work in progress |
| secure-enterprise-ai-chat-aws | AWS | — | 🚧 Work in progress |

**New `/validate-blueprint` skill** added to the Claude Code skills callout box and to the \"Adding a New Blueprint\" steps:

```bash
/validate-blueprint <name>
# or
.github/scripts/validate-blueprint.sh blueprints/<name>
```

## Test plan

- [x] All blueprint links resolve to existing directories
- [x] Status emojis match what's documented in each blueprint's own README
- [x] DEPLOYMENT-WORKFLOW.md is unchanged (kept as the K8s patterns deep-dive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)