### PR TITLE
gatus: refresh stale threat-feed test IP

### DIFF
--- a/blueprints/azure-aks-multicluster/README.md
+++ b/blueprints/azure-aks-multicluster/README.md
@@ -1108,7 +1108,10 @@ These are intentional behaviors a deployer should be aware of:
 
 - **DCF egress allowlist is descriptive, not enforcing.** The DCF default action on this controller is PERMIT and the ruleset has no final DENY rule, so destinations not listed in any WebGroup (e.g., `example.com`, `iana.org`) still reach the internet. The blueprint's WebGroup-based PERMIT rules show the intended pattern; converting the allowlist to enforcement requires either changing the default action to DENY or adding a final low-priority DENY. If you do that, also add explicit allows for UDP/53 (DNS) and UDP/123 (NTP) so AKS itself keeps working.
 - **Hostname-based SmartGroups for private FQDNs are not active.** `enable_vpc_dns_server = true` consistently fails the controller's DNS check on Controller 9.0.10 with the modules' default GW DNS configuration, so the blueprint disables it on every gateway. Hostname SmartGroups for the public Internet still work (controller resolves externally), but `frontend.azure.aviatrixdemo.local` / `backend.azure.aviatrixdemo.local` / `db.azure.aviatrixdemo.local` SmartGroups won't resolve targets — east-west enforcement falls through to the VNet-based SmartGroups, which is sufficient for the demonstrated traffic flows.
-- **ThreatGuard test IP may be stale.** `102.130.117.167` was an active ThreatGuard feed IP at the time the blueprint was authored. Replace it in `k8s-apps/{frontend,backend}/gatus.yaml` if your controller's current feed differs (CoPilot → Security → ThreatIQ).
+- **Threat-feed test IP rotates.** Aviatrix ThreatIQ ingests the [ET Open compromised-ips feed](https://rules.emergingthreats.net/blockrules/compromised-ips.txt), which rotates roughly daily. The IP referenced in `k8s-apps/{frontend,backend}/gatus.yaml` is a snapshot from one run and will eventually fall out of the feed. When that happens, pick a current IP from the feed and update both YAMLs:
+  ```bash
+  curl -s https://rules.emergingthreats.net/blockrules/compromised-ips.txt | grep -vE '^(#|$)' | head -1
+  ```
 
 ## Additional Resources
 

--- a/blueprints/azure-aks-multicluster/k8s-apps/backend/gatus.yaml
+++ b/blueprints/azure-aks-multicluster/k8s-apps/backend/gatus.yaml
@@ -75,11 +75,14 @@ data:
         interval: 60s
         conditions: ["[CONNECTED] == true"]
 
-      # NOTE: This IP must appear in your Aviatrix ThreatGuard feed to be blocked.
-      # Verify against your current threat intelligence feed and replace if needed.
+      # NOTE: Aviatrix ThreatIQ pulls from the ET Open compromised-ips feed,
+      # which rotates daily. The IP below was verified present in the feed at
+      # the time this blueprint was last tested. If your run shows this as
+      # CONNECTED (i.e. NOT blocked), pick a current IP from the live feed:
+      #   curl -s https://rules.emergingthreats.net/blockrules/compromised-ips.txt | grep -vE '^(#|$)' | head -1
       - name: "Threat Feed - Malicious IP"
         group: "Threats"
-        url: "icmp://102.130.117.167"
+        url: "icmp://185.38.148.2"
         interval: 60s
         conditions: ["[CONNECTED] == true"]
 

--- a/blueprints/azure-aks-multicluster/k8s-apps/frontend/gatus.yaml
+++ b/blueprints/azure-aks-multicluster/k8s-apps/frontend/gatus.yaml
@@ -75,11 +75,14 @@ data:
         interval: 60s
         conditions: ["[CONNECTED] == true"]
 
-      # NOTE: This IP must appear in your Aviatrix ThreatGuard feed to be blocked.
-      # Verify against your current threat intelligence feed and replace if needed.
+      # NOTE: Aviatrix ThreatIQ pulls from the ET Open compromised-ips feed,
+      # which rotates daily. The IP below was verified present in the feed at
+      # the time this blueprint was last tested. If your run shows this as
+      # CONNECTED (i.e. NOT blocked), pick a current IP from the live feed:
+      #   curl -s https://rules.emergingthreats.net/blockrules/compromised-ips.txt | grep -vE '^(#|$)' | head -1
       - name: "Threat Feed - Malicious IP"
         group: "Threats"
-        url: "icmp://102.130.117.167"
+        url: "icmp://185.38.148.2"
         interval: 60s
         conditions: ["[CONNECTED] == true"]
 


### PR DESCRIPTION
## Summary

The Gatus dashboards' Threat group includes a probe of a known-malicious IP that should be blocked by the DCF \`threat_intel\` SmartGroup (which sources from Aviatrix ThreatIQ → ET Open compromised-ips feed). The hardcoded IP \`102.130.117.167\` was current when the blueprint was authored, but the feed rotates roughly daily, so by the time we re-ran the lab it had aged out and the probe came back PASS (= reached, NOT blocked).

## Verification

Pulled the live ET Open feed inside the cluster's spoke and tested ICMP:

| IP | Source | Result |
|---|---|---|
| 8.8.8.8 | Google | 0% packet loss (control) |
| 1.1.1.1 | Cloudflare | 0% packet loss (control) |
| 102.130.117.167 | stale blueprint IP | 0% packet loss (NOT in current feed) |
| 185.38.148.2 | current ET Open feed | **100% packet loss** (DCF blocked) |
| 116.110.212.137 | current ET Open feed | 100% packet loss (DCF blocked) |
| 193.32.162.82 | current ET Open feed | 100% packet loss (DCF blocked) |

Threats group Gatus probes after the change:

```
[FAIL] Threats/GeoBlock - Iran          (= blocked, correct)
[FAIL] Threats/Threat Feed - Malicious IP   (= blocked, correct)
```

## Changes

- \`k8s-apps/{frontend,backend}/gatus.yaml\`: \`icmp://102.130.117.167\` → \`icmp://185.38.148.2\` and an inline comment with the curl command to refresh against the live feed if needed.
- \`README.md\` \"Known Limitations\": replaced generic \"may be stale / verify against your feed\" wording with an explicit pointer to https://rules.emergingthreats.net/blockrules/compromised-ips.txt and a one-liner to grab a fresh IP.

## Test plan

- [x] ET Open feed retrieved successfully
- [x] Replacement IP (185.38.148.2) confirmed present in the feed
- [x] Replacement IP confirmed blocked from inside the cluster (100% packet loss)
- [x] Control IPs (8.8.8.8, 1.1.1.1) confirmed reachable, ruling out general egress breakage
- [x] Updated configmap applied + Gatus deployments restarted on both clusters
- [x] Both clusters' \`Threats/Threat Feed - Malicious IP\` now reports FAIL = blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)