### PR TITLE
azure-aks-multicluster: AKS cluster onboarding with Aviatrix Controller

### DIFF
--- a/blueprints/azure-aks-multicluster/README.md
+++ b/blueprints/azure-aks-multicluster/README.md
@@ -228,6 +228,9 @@ export ARM_CLIENT_SECRET="<client-secret>"
 az account show
 ```
 
+> [!IMPORTANT]
+> When the cluster layers run with `enable_aviatrix_onboarding = true` (default), the Aviatrix Controller calls each AKS API server directly after fetching the kubeconfig from ARM. Set `aviatrix_controller_public_ip` in `clusters/*/terraform.tfvars` (typically the same as `AVIATRIX_CONTROLLER_IP`) so it's appended to `authorized_ip_ranges`. Without this, the controller will be blocked from the API server even though registration succeeds.
+
 ### Step 2: Deploy Network Infrastructure
 
 The network layer creates the Aviatrix transit/spoke topology, VNets with subnets and UDRs, Application Gateways, Azure Private DNS zone, and the DB test VM.
@@ -275,12 +278,15 @@ cd ../clusters/frontend/
 # Initialize Terraform
 terraform init
 
-# Create variable file (copy from network, same values apply)
-cp ../../terraform.tfvars.example terraform.tfvars
+# Create variable file from the example
+cp terraform.tfvars.example terraform.tfvars
 # Verify or adjust:
-#   azure_region        (default: eastus2)
-#   kubernetes_version  (default: 1.32)
-#   authorized_ip_ranges (add your IP: run "curl -s ifconfig.me")
+#   azure_region                  (default: eastus2)
+#   kubernetes_version            (default: 1.33)
+#   authorized_ip_ranges          (add your IP: run "curl -s ifconfig.me")
+#   enable_aviatrix_onboarding    (default: true — registers cluster with the Controller)
+#   aviatrix_controller_public_ip (set to ${AVIATRIX_CONTROLLER_IP} so the controller
+#                                  reaches the AKS API server)
 vim terraform.tfvars
 
 # Deploy cluster (~10-15 minutes)
@@ -295,6 +301,7 @@ terraform apply
 - Federated credential for ExternalDNS Workload Identity
 - Role assignments: Network Contributor on frontend VNet, route table write access
 - OIDC issuer enabled for Workload Identity
+- `aviatrix_kubernetes_cluster` registration with the Aviatrix Controller (when `enable_aviatrix_onboarding = true`)
 
 ### Step 4: Deploy Backend AKS Cluster (Parallel with Step 3)
 
@@ -304,11 +311,15 @@ cd ../backend/
 # Initialize Terraform
 terraform init
 
+# Same tfvars pattern as frontend — including aviatrix_controller_public_ip
+cp terraform.tfvars.example terraform.tfvars
+vim terraform.tfvars
+
 # Deploy cluster (~10-15 minutes)
 terraform apply
 ```
 
-**What's created:** Same as the frontend cluster, scoped to the backend VNet.
+**What's created:** Same as the frontend cluster, scoped to the backend VNet, including the `aviatrix_kubernetes_cluster` registration when `enable_aviatrix_onboarding = true`.
 
 Steps 3 and 4 can run in parallel in separate terminals.
 
@@ -497,7 +508,32 @@ Gatus monitors two threat endpoints that **should be blocked** by DCF. They appe
 
 > **Note:** The threat IP `102.130.117.167` must be present in your active Aviatrix ThreatGuard feed for blocking to work. If your feed differs, verify and update the IP in `k8s-apps/frontend/gatus.yaml` and `k8s-apps/backend/gatus.yaml`.
 
-### Scenario 5: DCF CRD-Based Policies
+### Scenario 5: K8s-Typed SmartGroup Membership
+
+Verify that the K8s-typed SmartGroups created in `network/dcf-k8s.tf` resolve membership from the cluster API once onboarding completes.
+
+```bash
+# In CoPilot:
+#   Cloud Workloads → Kubernetes Clusters
+#   Both clusters should show "Onboarded: Yes" with namespace and pod counts populated.
+#
+#   Security → SmartGroups → aks-demo-sg-frontend-gatus-ns
+#   Members tab should list the gatus pod IPs (100.64.x.x range, dynamically resolved).
+
+# From the Controller API (alternative):
+CID=$(curl -sk -X POST "https://${AVIATRIX_CONTROLLER_IP}/v1/api" \
+  -d "action=login&username=${AVIATRIX_USERNAME}&password=${AVIATRIX_PASSWORD}" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['CID'])")
+
+curl -sk -H "Authorization: cid ${CID}" \
+  "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/k8s/clusters" \
+  | python3 -m json.tool
+# Expected: both aks-demo-frontend and aks-demo-backend listed with use_csp_credentials=true
+```
+
+The priority-50 DCF rule ("Frontend Gatus to Backend Gatus k8s ns selector") references these SmartGroups. Once members populate, you can confirm enforcement in **CoPilot → Diagnostics → FlowIQ** by filtering for source/destination matching the gatus pod IPs.
+
+### Scenario 6: DCF CRD-Based Policies
 
 Apply example CRD policies to test Kubernetes-native policy management:
 
@@ -513,7 +549,7 @@ kubectl get firewallpolicies -n gatus --context frontend
 kubectl get webgrouppolicies -n dev --context frontend
 ```
 
-### Scenario 6: Private DNS Resolution
+### Scenario 7: Private DNS Resolution
 
 ExternalDNS creates Private DNS records for Gatus Services and Ingresses. Verify DNS resolution works across clusters:
 
@@ -591,11 +627,17 @@ The network layer provisions a complete DCF policy ruleset. Policies are enforce
 | `backend-vnet` | CIDR | `10.20.0.0/23` |
 | `db-vnet` | CIDR | `10.5.0.0/22` |
 | `all-aks-clusters` | CIDR union | Both AKS VNets |
+| `frontend-cluster` | K8s | All workloads in the frontend AKS cluster |
+| `backend-cluster` | K8s | All workloads in the backend AKS cluster |
+| `frontend-gatus-ns` | K8s | `gatus` namespace, frontend cluster |
+| `backend-gatus-ns` | K8s | `gatus` namespace, backend cluster |
 | `frontend-service` | Hostname | `frontend.azure.aviatrixdemo.local` |
 | `backend-service` | Hostname | `backend.azure.aviatrixdemo.local` |
 | `database` | Hostname | `db.azure.aviatrixdemo.local` |
 | `geo-blocked` | Geo feed | Country: Iran |
 | `threat-intel` | Threat feed | Aviatrix ThreatGuard |
+
+The K8s-typed SmartGroups require both clusters to be onboarded with the Aviatrix Controller (see [AKS Cluster Onboarding](#aks-cluster-onboarding) below). Until onboarded, the K8s SmartGroups exist but have zero members, and any rules referencing them are no-ops — safe to keep deployed.
 
 **WebGroups (domain-based egress filtering):**
 
@@ -617,7 +659,39 @@ The network layer provisions a complete DCF policy ruleset. Policies are enforce
 | 20 | AKS-required HTTPS egress (azure-required + kubernetes-io + docker-hub) | Permit |
 | 21 | AKS-required HTTP egress (Ubuntu/Debian apt repos) | Permit |
 | 30–33 | Additional egress: npm, GitHub Aviatrix paths | Permit |
-| 50–99 | Reserved for Aviatrix k8s-firewall CRD-injected rules | Dynamic |
+| 50 | Frontend `gatus` namespace → backend `gatus` namespace (TCP 8080) — K8s SmartGroup demo | Permit |
+| 51–99 | Reserved for Aviatrix k8s-firewall CRD-injected rules | Dynamic |
+
+### AKS Cluster Onboarding
+
+Each AKS cluster is registered with the Aviatrix Controller via the `aviatrix_kubernetes_cluster` resource in `clusters/{frontend,backend}/onboarding.tf`. Once onboarded, DCF SmartGroups can target Kubernetes-typed selectors (`k8s_cluster_id`, `k8s_namespace`, `k8s_pod`, `k8s_service`) and the controller resolves membership dynamically from the cluster API.
+
+**Authentication flow** (per the [Aviatrix DCF docs for K8s onboarding](https://docs.aviatrix.com/docs/enterprise/8.2/guides/security/dcf/kubernetes-onboard#azure-aks)):
+
+1. Controller calls Azure ARM `Microsoft.ContainerService/managedClusters/listClusterUserCredential/action` via the Aviatrix Azure access account's service principal (`aviatrix_azure_account_name`).
+2. ARM returns a local-account kubeconfig.
+3. Controller connects to the AKS API server FQDN with that kubeconfig.
+
+**Key differences from the AWS/EKS pattern:**
+
+| Concern | EKS | AKS |
+|---|---|---|
+| Cluster auth model | IAM access entry → AAD-style RBAC | **Kubernetes RBAC with local accounts only.** Entra-ID-only auth is *not supported* — the kubeconfig from ARM contains `exec` entries the controller cannot process. |
+| In-cluster RBAC | `view-nodes` ClusterRole + binding required | Not required — the kubeconfig from `listClusterUserCredential` is admin-equivalent. |
+| Per-cluster role assignment | EKS access entry + `AmazonEKSViewPolicy` | None per-cluster — subscription-scoped Contributor on the access account SP covers it. |
+
+**Required Azure RBAC actions on the access account SP** (subscription scope, all included in `Contributor`):
+
+- `Microsoft.ResourceGraph/resources/read`
+- `Microsoft.ContainerService/managedClusters/read`
+- `Microsoft.ContainerService/managedClusters/listClusterUserCredential/action`
+- `Microsoft.Compute/virtualMachines/read`
+- `Microsoft.Network/networkInterfaces/read`
+- `Microsoft.Network/networkSecurityGroups/read`
+
+**API server allowlist:** The controller's public egress IP must be in the AKS API server's `authorized_ip_ranges`. Set `aviatrix_controller_public_ip` in `clusters/*/terraform.tfvars` and the cluster will append it automatically (alongside the spoke gateway public IP for AKS-node egress).
+
+**Toggle:** Set `enable_aviatrix_onboarding = false` in `clusters/*/terraform.tfvars` to skip onboarding. The cluster still deploys; only VNet-typed SmartGroup selectors will resolve for it.
 
 ### Kubernetes CRD-Based Firewall Policies
 
@@ -722,12 +796,22 @@ cd nodes/backend/ && terraform destroy
 
 ### Step 3: Destroy AKS Clusters (Parallel)
 
+`terraform destroy` removes the `aviatrix_kubernetes_cluster` registration from the controller as well as the AKS cluster itself. After destroy, confirm the registrations are gone (the Aviatrix provider has historically left stale records for some resource types):
+
 ```bash
 # Terminal 1
 cd clusters/frontend/ && terraform destroy
 
 # Terminal 2
 cd clusters/backend/ && terraform destroy
+
+# Verify no stale K8s cluster registrations remain on the controller
+CID=$(curl -sk -X POST "https://${AVIATRIX_CONTROLLER_IP}/v1/api" \
+  -d "action=login&username=${AVIATRIX_USERNAME}&password=${AVIATRIX_PASSWORD}" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['CID'])")
+curl -sk -H "Authorization: cid ${CID}" \
+  "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/k8s/clusters"
+# Expected: []  (or no entries for aks-demo-*)
 ```
 
 ### Step 4: Destroy Network Layer
@@ -735,6 +819,8 @@ cd clusters/backend/ && terraform destroy
 ```bash
 cd network/ && terraform destroy
 ```
+
+This destroys the K8s SmartGroups (`network/dcf-k8s.tf`) along with the rest of the DCF resources. Their cluster_id selectors point at AKS resources that no longer exist by this stage; the controller deletes them cleanly because they're regular Aviatrix resources, not Azure-side state.
 
 ### Step 5: Clean Up kubectl Contexts (Optional)
 
@@ -843,6 +929,54 @@ If the NGINX ingress controller Service shows `<pending>` for EXTERNAL-IP instea
    ```bash
    kubectl get secret -n kube-system --context frontend | grep azure
    ```
+
+### AKS Cluster Shows "Onboarded: No" in CoPilot
+
+After `clusters/*` apply succeeds, the cluster shows under CoPilot → Cloud Workloads → Kubernetes Clusters but with **Onboarded: No**, or the K8s SmartGroups have zero members:
+
+1. **Check that the controller's egress IP is in the AKS API server allowlist.** The controller calls ARM (no IP gating there) to fetch the kubeconfig, then connects to the AKS API server FQDN — the second hop is what fails when the allowlist is wrong.
+   ```bash
+   az aks show -g <cluster-rg> -n <cluster-name> \
+     --query 'apiServerAccessProfile.authorizedIpRanges' -o tsv
+   # Expect to see: <controller_public_ip>/32, <spoke_gw_public_ip>/32, your IP
+   ```
+   If the controller IP is missing, set `aviatrix_controller_public_ip` in the cluster's `terraform.tfvars` and re-apply.
+
+2. **Verify the access account SP has the right Azure RBAC actions.** Subscription-scoped Contributor is sufficient. If it's narrower:
+   ```bash
+   az role assignment list --assignee <arm_ad_client_id> --all \
+     --query '[].{role:roleDefinitionName,scope:scope}' -o tsv
+   # Required actions (covered by Contributor):
+   #   Microsoft.ContainerService/managedClusters/listClusterUserCredential/action
+   #   Microsoft.ContainerService/managedClusters/read
+   #   Microsoft.ResourceGraph/resources/read
+   ```
+
+3. **Check the cluster isn't Entra-ID-only.** The Aviatrix Controller cannot process `exec`-based kubeconfigs. AKS must use Kubernetes RBAC with local accounts:
+   ```bash
+   az aks show -g <cluster-rg> -n <cluster-name> \
+     --query '{aad:aadProfile, localAccount:disableLocalAccounts}'
+   # aadProfile should be null OR have managed:true with azureRbac:true (NOT azureRbac alone)
+   # disableLocalAccounts must be false
+   ```
+
+4. **Confirm the registration exists on the controller** via the API:
+   ```bash
+   CID=$(curl -sk -X POST "https://${AVIATRIX_CONTROLLER_IP}/v1/api" \
+     -d "action=login&username=${AVIATRIX_USERNAME}&password=${AVIATRIX_PASSWORD}" \
+     | python3 -c "import sys,json; print(json.load(sys.stdin)['CID'])")
+   curl -sk -H "Authorization: cid ${CID}" \
+     "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/k8s/clusters" | python3 -m json.tool
+   ```
+   `resource: null` in this response is **expected** when `use_csp_credentials = true` — that field only populates for custom/self-managed registrations. The presence of the cluster in the list with the right `cluster_id` is the registration confirmation.
+
+### AKS API Update Fails: "NetworkPolicy cilium requires NetworkDataplane cilium"
+
+If `terraform apply` on a cluster layer fails with this error during a cluster modify, the cluster was created before AKS added the cross-validation but the provider now flags drift on `network_data_plane`. The blueprint sets `network_data_plane = "cilium"` explicitly to satisfy the check; if you've stripped it, restore it. The change requires a control-plane update (~10–15 minutes).
+
+### AKS Cluster Plan Errors: "cannot change `node_count` when `auto_scaling_enabled` is set to `true`"
+
+The default node pool is autoscaled (`min_count = 1`, `max_count = 3`), so the live `node_count` drifts from the seed value in tfvars. The blueprint already includes `lifecycle { ignore_changes = [default_node_pool[0].node_count] }` to suppress this. If you've removed it, restore it; otherwise plan-time errors block legitimate changes to other cluster attributes.
 
 ### AppGW Provisioning Fails or Times Out
 
@@ -1086,6 +1220,7 @@ Each layer publishes outputs that the next layer (or operators) consume.
 | `db_vm_private_ip`, `db_vm_name` | string | DB target IP for east-west tests |
 | `pod_cidr`, `service_cidr`, `dns_service_ip` | string | Cluster network plumbing |
 | `dcf_ruleset_uuid`, `smartgroup_*_uuid`, `webgroup_*_uuid` | string | DCF references for K8s CRD policies |
+| `frontend_aks_cluster_id`, `backend_aks_cluster_id` | string | Pre-computed lowercased AKS resource IDs used as `k8s_cluster_id` in K8s SmartGroups (matches what the clusters layer onboards with) |
 
 ### `clusters/{frontend,backend}/`
 
@@ -1097,6 +1232,7 @@ Each layer publishes outputs that the next layer (or operators) consume.
 | `kubelet_identity_object_id`, `aks_identity_principal_id`, `external_dns_client_id` | no | Role assignment + Workload Identity binding |
 | `resource_group_name`, `node_resource_group` | no | The `MC_*` group AKS auto-creates |
 | `kubectl_config_command` | no | Copy/paste-friendly `az aks get-credentials …` |
+| `aviatrix_cluster_id`, `aviatrix_onboarded` | no | Lowercased cluster ID used by `aviatrix_kubernetes_cluster` and onboarding-on toggle |
 
 ### `nodes/{frontend,backend}/`
 
@@ -1107,7 +1243,8 @@ No outputs — this layer only installs Helm releases.
 These are intentional behaviors a deployer should be aware of:
 
 - **DCF egress allowlist is descriptive, not enforcing.** The DCF default action on this controller is PERMIT and the ruleset has no final DENY rule, so destinations not listed in any WebGroup (e.g., `example.com`, `iana.org`) still reach the internet. The blueprint's WebGroup-based PERMIT rules show the intended pattern; converting the allowlist to enforcement requires either changing the default action to DENY or adding a final low-priority DENY. If you do that, also add explicit allows for UDP/53 (DNS) and UDP/123 (NTP) so AKS itself keeps working.
-- **Hostname-based SmartGroups for private FQDNs are not active.** `enable_vpc_dns_server = true` consistently fails the controller's DNS check on Controller 9.0.10 with the modules' default GW DNS configuration, so the blueprint disables it on every gateway. Hostname SmartGroups for the public Internet still work (controller resolves externally), but `frontend.azure.aviatrixdemo.local` / `backend.azure.aviatrixdemo.local` / `db.azure.aviatrixdemo.local` SmartGroups won't resolve targets — east-west enforcement falls through to the VNet-based SmartGroups, which is sufficient for the demonstrated traffic flows.
+- **Hostname-based SmartGroups for private FQDNs are not active.** `enable_vpc_dns_server = true` consistently fails the controller's DNS check on Controller 9.0.10 with the modules' default GW DNS configuration, so the blueprint disables it on every gateway. Hostname SmartGroups for the public Internet still work (controller resolves externally), but `frontend.azure.aviatrixdemo.local` / `backend.azure.aviatrixdemo.local` / `db.azure.aviatrixdemo.local` SmartGroups won't resolve targets — east-west enforcement falls through to the VNet-based SmartGroups, which is sufficient for the demonstrated traffic flows. The K8s-typed SmartGroups (`frontend-cluster`, `backend-cluster`, `frontend-gatus-ns`, `backend-gatus-ns`) sidestep this entirely since they target by cluster/namespace identity rather than by FQDN.
+- **AKS pod-name SmartGroups would match by name, not labels.** Provider 8.2's `k8s_pod` selector takes a pod *name*, so it won't match Deployment-generated names with hashes (e.g., `frontend-7d4c89-xyz12`). Use `k8s_namespace` (and `k8s_service` for services exposed via a Service object) instead. Label-selector matching is not supported in this provider version.
 - **Threat-feed test IP rotates.** Aviatrix ThreatIQ ingests the [ET Open compromised-ips feed](https://rules.emergingthreats.net/blockrules/compromised-ips.txt), which rotates roughly daily. The IP referenced in `k8s-apps/{frontend,backend}/gatus.yaml` is a snapshot from one run and will eventually fall out of the feed. When that happens, pick a current IP from the feed and update both YAMLs:
   ```bash
   curl -s https://rules.emergingthreats.net/blockrules/compromised-ips.txt | grep -vE '^(#|$)' | head -1

--- a/blueprints/azure-aks-multicluster/clusters/backend/main.tf
+++ b/blueprints/azure-aks-multicluster/clusters/backend/main.tf
@@ -6,11 +6,22 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 8.2"
+    }
   }
 }
 
 provider "azurerm" {
   features {}
+}
+
+provider "aviatrix" {
+  controller_ip           = var.aviatrix_controller_ip
+  username                = var.aviatrix_username
+  password                = var.aviatrix_password
+  skip_version_validation = true
 }
 
 locals {
@@ -100,6 +111,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     network_plugin      = "azure"
     network_plugin_mode = "overlay"
     network_policy      = "cilium" # Activates Azure CNI Powered by Cilium (replaces kube-proxy with eBPF)
+    network_data_plane  = "cilium" # Required by AKS API alongside network_policy=cilium
 
     pod_cidr = data.terraform_remote_state.network.outputs.pod_cidr
 
@@ -112,10 +124,15 @@ resource "azurerm_kubernetes_cluster" "aks" {
   # The spoke GW's public IP is auto-included because AKS nodes egress through
   # it (UDR 0.0.0.0/0 → spoke GW → SNAT → public IP). Without this the kubelet
   # CSE step fails with VMExtensionError_K8SAPIServerConnFail.
+  # The Aviatrix Controller's egress IP is appended when onboarding is enabled
+  # so the controller can reach the API server after fetching the kubeconfig.
   api_server_access_profile {
     authorized_ip_ranges = concat(
       var.authorized_ip_ranges,
       ["${data.terraform_remote_state.network.outputs.backend_spoke_gateway_public_ip}/32"],
+      var.enable_aviatrix_onboarding && var.aviatrix_controller_public_ip != null
+      ? ["${var.aviatrix_controller_public_ip}/32"]
+      : [],
     )
   }
 
@@ -123,6 +140,12 @@ resource "azurerm_kubernetes_cluster" "aks" {
     azurerm_role_assignment.aks_vnet_contributor,
     azurerm_role_assignment.aks_route_table,
   ]
+
+  # node_count in the default_node_pool is autoscaled — ignore drift between
+  # the tfvars seed value and the live count to keep terraform plan idempotent.
+  lifecycle {
+    ignore_changes = [default_node_pool[0].node_count]
+  }
 }
 
 resource "azurerm_federated_identity_credential" "external_dns" {

--- a/blueprints/azure-aks-multicluster/clusters/backend/onboarding.tf
+++ b/blueprints/azure-aks-multicluster/clusters/backend/onboarding.tf
@@ -1,0 +1,34 @@
+#####################
+# Aviatrix Controller Onboarding
+#
+# Registers the AKS cluster with the Aviatrix Controller so DCF SmartGroups
+# can target Kubernetes-typed selectors (cluster, namespace, service, pod)
+# instead of just VNet selectors.
+#
+# Auth flow (per docs.aviatrix.com/docs/enterprise/8.2/guides/security/dcf/kubernetes-onboard):
+#   1. Controller calls ARM listClusterUserCredential/action via the Aviatrix
+#      Azure access account's service principal to fetch a local-account
+#      kubeconfig from the AKS cluster.
+#   2. Controller connects to the AKS API server FQDN with that kubeconfig.
+#
+# Requirements (NOT enforced by Terraform — pre-checks for the operator):
+#   - Aviatrix Azure access account onboarded (see network/main.tf, var.aviatrix_azure_account_name).
+#   - That account's SP has Microsoft.ContainerService/managedClusters/listClusterUserCredential/action
+#     at subscription scope. Contributor includes it.
+#   - AKS cluster uses Kubernetes RBAC with local accounts. Entra-ID-only
+#     auth is NOT supported — the kubeconfig returned would contain `exec`
+#     entries the controller cannot process.
+#   - Controller's public egress IP is in the AKS API server's authorized_ip_ranges
+#     (see var.aviatrix_controller_public_ip).
+#####################
+
+resource "aviatrix_kubernetes_cluster" "this" {
+  count = var.enable_aviatrix_onboarding ? 1 : 0
+
+  # Docs require lowercased cluster_id. azurerm_kubernetes_cluster.id is
+  # mixed-case ("/subscriptions/.../Microsoft.ContainerService/managedClusters/...").
+  cluster_id          = lower(azurerm_kubernetes_cluster.aks.id)
+  use_csp_credentials = true
+
+  depends_on = [azurerm_kubernetes_cluster.aks]
+}

--- a/blueprints/azure-aks-multicluster/clusters/backend/outputs.tf
+++ b/blueprints/azure-aks-multicluster/clusters/backend/outputs.tf
@@ -77,3 +77,13 @@ output "kubectl_config_command" {
   description = "Command to configure kubectl for this cluster"
   value       = "az aks get-credentials --resource-group ${azurerm_kubernetes_cluster.aks.resource_group_name} --name ${azurerm_kubernetes_cluster.aks.name} --overwrite-existing"
 }
+
+output "aviatrix_cluster_id" {
+  description = "Lowercased cluster_id used for Aviatrix onboarding (also the SmartGroup k8s_cluster_id selector value)"
+  value       = lower(azurerm_kubernetes_cluster.aks.id)
+}
+
+output "aviatrix_onboarded" {
+  description = "Whether this cluster is registered with the Aviatrix Controller"
+  value       = var.enable_aviatrix_onboarding
+}

--- a/blueprints/azure-aks-multicluster/clusters/backend/terraform.tfvars.example
+++ b/blueprints/azure-aks-multicluster/clusters/backend/terraform.tfvars.example
@@ -15,3 +15,16 @@ node_pool_config = {
 # Restrict API server access to your IP for security (recommended)
 # authorized_ip_ranges = ["<YOUR_IP>/32"]
 authorized_ip_ranges = ["0.0.0.0/0"]
+
+# Aviatrix Controller onboarding (so DCF can use K8s-typed SmartGroups).
+enable_aviatrix_onboarding = true
+
+# Controller credentials. Leave unset and export AVIATRIX_CONTROLLER_IP /
+# AVIATRIX_USERNAME / AVIATRIX_PASSWORD env vars (recommended), or set here.
+# aviatrix_controller_ip = "1.2.3.4"
+# aviatrix_username      = "admin"
+# aviatrix_password      = "..."
+
+# Controller public egress IP — appended to authorized_ip_ranges so the
+# controller can reach the AKS API server after fetching the kubeconfig.
+# aviatrix_controller_public_ip = "1.2.3.4"

--- a/blueprints/azure-aks-multicluster/clusters/backend/variables.tf
+++ b/blueprints/azure-aks-multicluster/clusters/backend/variables.tf
@@ -34,7 +34,57 @@ variable "authorized_ip_ranges" {
     IP ranges authorized to access the AKS API server.
     Add your current public IP (e.g., ["1.2.3.4/32"]).
     Use ["0.0.0.0/0"] to allow all (not recommended for production).
+    NOTE: when enable_aviatrix_onboarding = true, the Aviatrix Controller's
+    public egress IP must also be in this list, OR set
+    aviatrix_controller_public_ip and it will be appended automatically.
   EOT
   type        = list(string)
   default     = ["0.0.0.0/0"]
+}
+
+#####################
+# Aviatrix Cluster Onboarding
+#####################
+
+variable "enable_aviatrix_onboarding" {
+  description = <<-EOT
+    Register this AKS cluster with the Aviatrix Controller so DCF SmartGroups
+    can target k8s clusters, namespaces, services, and pods.
+    When true, requires the Aviatrix Azure access account to have the
+    Microsoft.ContainerService/managedClusters/listClusterUserCredential/action
+    permission at subscription scope (Contributor includes it).
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "aviatrix_controller_ip" {
+  description = "Aviatrix Controller IP/hostname (or set AVIATRIX_CONTROLLER_IP env var)"
+  type        = string
+  default     = null
+}
+
+variable "aviatrix_username" {
+  description = "Aviatrix Controller username (or set AVIATRIX_USERNAME env var)"
+  type        = string
+  default     = null
+}
+
+variable "aviatrix_password" {
+  description = "Aviatrix Controller password (or set AVIATRIX_PASSWORD env var)"
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "aviatrix_controller_public_ip" {
+  description = <<-EOT
+    Public IP of the Aviatrix Controller, appended to AKS authorized_ip_ranges
+    when enable_aviatrix_onboarding = true. The controller fetches the AKS
+    kubeconfig via ARM, then connects to the AKS API server FQDN — that
+    second hop must clear the API server allowlist. Leave null if your
+    authorized_ip_ranges already covers the controller (e.g., 0.0.0.0/0).
+  EOT
+  type        = string
+  default     = null
 }

--- a/blueprints/azure-aks-multicluster/clusters/frontend/main.tf
+++ b/blueprints/azure-aks-multicluster/clusters/frontend/main.tf
@@ -6,11 +6,22 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 8.2"
+    }
   }
 }
 
 provider "azurerm" {
   features {}
+}
+
+provider "aviatrix" {
+  controller_ip           = var.aviatrix_controller_ip
+  username                = var.aviatrix_username
+  password                = var.aviatrix_password
+  skip_version_validation = true
 }
 
 locals {
@@ -105,6 +116,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     network_plugin      = "azure"
     network_plugin_mode = "overlay" # Cilium overlay — pod IPs in 100.64.0.0/16 are NOT in the VNet
     network_policy      = "cilium"  # Activates Azure CNI Powered by Cilium (replaces kube-proxy with eBPF)
+    network_data_plane  = "cilium"  # Required by AKS API alongside network_policy=cilium
 
     # Pod CIDR: same across both clusters (overlapping by design).
     # Aviatrix spoke gateway SNATs 100.64.x.x → spoke GW IP for transit routing.
@@ -123,10 +135,15 @@ resource "azurerm_kubernetes_cluster" "aks" {
   # The spoke GW's public IP is auto-included because AKS nodes egress through
   # it (UDR 0.0.0.0/0 → spoke GW → SNAT → public IP). Without this the kubelet
   # CSE step fails with VMExtensionError_K8SAPIServerConnFail.
+  # The Aviatrix Controller's egress IP is appended when onboarding is enabled
+  # so the controller can reach the API server after fetching the kubeconfig.
   api_server_access_profile {
     authorized_ip_ranges = concat(
       var.authorized_ip_ranges,
       ["${data.terraform_remote_state.network.outputs.frontend_spoke_gateway_public_ip}/32"],
+      var.enable_aviatrix_onboarding && var.aviatrix_controller_public_ip != null
+      ? ["${var.aviatrix_controller_public_ip}/32"]
+      : [],
     )
   }
 
@@ -134,6 +151,12 @@ resource "azurerm_kubernetes_cluster" "aks" {
     azurerm_role_assignment.aks_vnet_contributor,
     azurerm_role_assignment.aks_route_table,
   ]
+
+  # node_count in the default_node_pool is autoscaled — ignore drift between
+  # the tfvars seed value and the live count to keep terraform plan idempotent.
+  lifecycle {
+    ignore_changes = [default_node_pool[0].node_count]
+  }
 }
 
 #####################

--- a/blueprints/azure-aks-multicluster/clusters/frontend/onboarding.tf
+++ b/blueprints/azure-aks-multicluster/clusters/frontend/onboarding.tf
@@ -1,0 +1,34 @@
+#####################
+# Aviatrix Controller Onboarding
+#
+# Registers the AKS cluster with the Aviatrix Controller so DCF SmartGroups
+# can target Kubernetes-typed selectors (cluster, namespace, service, pod)
+# instead of just VNet selectors.
+#
+# Auth flow (per docs.aviatrix.com/docs/enterprise/8.2/guides/security/dcf/kubernetes-onboard):
+#   1. Controller calls ARM listClusterUserCredential/action via the Aviatrix
+#      Azure access account's service principal to fetch a local-account
+#      kubeconfig from the AKS cluster.
+#   2. Controller connects to the AKS API server FQDN with that kubeconfig.
+#
+# Requirements (NOT enforced by Terraform — pre-checks for the operator):
+#   - Aviatrix Azure access account onboarded (see network/main.tf, var.aviatrix_azure_account_name).
+#   - That account's SP has Microsoft.ContainerService/managedClusters/listClusterUserCredential/action
+#     at subscription scope. Contributor includes it.
+#   - AKS cluster uses Kubernetes RBAC with local accounts. Entra-ID-only
+#     auth is NOT supported — the kubeconfig returned would contain `exec`
+#     entries the controller cannot process.
+#   - Controller's public egress IP is in the AKS API server's authorized_ip_ranges
+#     (see var.aviatrix_controller_public_ip).
+#####################
+
+resource "aviatrix_kubernetes_cluster" "this" {
+  count = var.enable_aviatrix_onboarding ? 1 : 0
+
+  # Docs require lowercased cluster_id. azurerm_kubernetes_cluster.id is
+  # mixed-case ("/subscriptions/.../Microsoft.ContainerService/managedClusters/...").
+  cluster_id          = lower(azurerm_kubernetes_cluster.aks.id)
+  use_csp_credentials = true
+
+  depends_on = [azurerm_kubernetes_cluster.aks]
+}

--- a/blueprints/azure-aks-multicluster/clusters/frontend/outputs.tf
+++ b/blueprints/azure-aks-multicluster/clusters/frontend/outputs.tf
@@ -77,3 +77,13 @@ output "kubectl_config_command" {
   description = "Command to configure kubectl for this cluster"
   value       = "az aks get-credentials --resource-group ${azurerm_kubernetes_cluster.aks.resource_group_name} --name ${azurerm_kubernetes_cluster.aks.name} --overwrite-existing"
 }
+
+output "aviatrix_cluster_id" {
+  description = "Lowercased cluster_id used for Aviatrix onboarding (also the SmartGroup k8s_cluster_id selector value)"
+  value       = lower(azurerm_kubernetes_cluster.aks.id)
+}
+
+output "aviatrix_onboarded" {
+  description = "Whether this cluster is registered with the Aviatrix Controller"
+  value       = var.enable_aviatrix_onboarding
+}

--- a/blueprints/azure-aks-multicluster/clusters/frontend/terraform.tfvars.example
+++ b/blueprints/azure-aks-multicluster/clusters/frontend/terraform.tfvars.example
@@ -16,3 +16,19 @@ node_pool_config = {
 # Run: curl ifconfig.me  to get your current IP
 # authorized_ip_ranges = ["<YOUR_IP>/32"]
 authorized_ip_ranges = ["0.0.0.0/0"]
+
+# Aviatrix Controller onboarding (so DCF can use K8s-typed SmartGroups).
+# Set to false to skip onboarding (cluster still deploys, but only VNet
+# SmartGroup selectors will work for it).
+enable_aviatrix_onboarding = true
+
+# Controller credentials. Leave unset and export AVIATRIX_CONTROLLER_IP /
+# AVIATRIX_USERNAME / AVIATRIX_PASSWORD env vars (recommended), or set here.
+# aviatrix_controller_ip = "1.2.3.4"
+# aviatrix_username      = "admin"
+# aviatrix_password      = "..."
+
+# Controller public egress IP — appended to authorized_ip_ranges so the
+# controller can reach the AKS API server after fetching the kubeconfig.
+# Leave unset if authorized_ip_ranges already covers the controller (e.g., 0.0.0.0/0).
+# aviatrix_controller_public_ip = "1.2.3.4"

--- a/blueprints/azure-aks-multicluster/clusters/frontend/variables.tf
+++ b/blueprints/azure-aks-multicluster/clusters/frontend/variables.tf
@@ -34,7 +34,57 @@ variable "authorized_ip_ranges" {
     IP ranges authorized to access the AKS API server.
     Add your current public IP (e.g., ["1.2.3.4/32"]).
     Use ["0.0.0.0/0"] to allow all (not recommended for production).
+    NOTE: when enable_aviatrix_onboarding = true, the Aviatrix Controller's
+    public egress IP must also be in this list, OR set
+    aviatrix_controller_public_ip and it will be appended automatically.
   EOT
   type        = list(string)
   default     = ["0.0.0.0/0"]
+}
+
+#####################
+# Aviatrix Cluster Onboarding
+#####################
+
+variable "enable_aviatrix_onboarding" {
+  description = <<-EOT
+    Register this AKS cluster with the Aviatrix Controller so DCF SmartGroups
+    can target k8s clusters, namespaces, services, and pods.
+    When true, requires the Aviatrix Azure access account to have the
+    Microsoft.ContainerService/managedClusters/listClusterUserCredential/action
+    permission at subscription scope (Contributor includes it).
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "aviatrix_controller_ip" {
+  description = "Aviatrix Controller IP/hostname (or set AVIATRIX_CONTROLLER_IP env var)"
+  type        = string
+  default     = null
+}
+
+variable "aviatrix_username" {
+  description = "Aviatrix Controller username (or set AVIATRIX_USERNAME env var)"
+  type        = string
+  default     = null
+}
+
+variable "aviatrix_password" {
+  description = "Aviatrix Controller password (or set AVIATRIX_PASSWORD env var)"
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "aviatrix_controller_public_ip" {
+  description = <<-EOT
+    Public IP of the Aviatrix Controller, appended to AKS authorized_ip_ranges
+    when enable_aviatrix_onboarding = true. The controller fetches the AKS
+    kubeconfig via ARM, then connects to the AKS API server FQDN — that
+    second hop must clear the API server allowlist. Leave null if your
+    authorized_ip_ranges already covers the controller (e.g., 0.0.0.0/0).
+  EOT
+  type        = string
+  default     = null
 }

--- a/blueprints/azure-aks-multicluster/docs/feature-cluster-onboarding.md
+++ b/blueprints/azure-aks-multicluster/docs/feature-cluster-onboarding.md
@@ -1,0 +1,232 @@
+# Feature: Onboard AKS Clusters with the Aviatrix Controller
+
+> Status: **Spec / not yet implemented.** This document captures the scope and the open questions so the implementation work can happen in a separate session.
+
+## Background
+
+After deploying the blueprint, **CoPilot → Cloud Workloads → Kubernetes Clusters** lists `aks-demo-frontend` and `aks-demo-backend` as **Onboarded: No**. They're discovered (because the VNets are managed by Aviatrix) but the controller isn't reading the cluster API. Consequence: all SmartGroups in `network/dcf.tf` use **VPC/VNet** selectors instead of the richer Kubernetes-typed selectors (`k8s_cluster_id`, `k8s_namespace`, `k8s_pod`, `k8s_service`). The k8s-firewall Helm chart we install handles **CRD-side** policy (FirewallPolicy, WebgroupPolicy authored as Kubernetes manifests), but it does **not** onboard the cluster as a Smart-Group source — that's a separate `aviatrix_kubernetes_cluster` registration with credentials the controller can use to call the AKS API.
+
+The AWS analog (`blueprints/aws-eks-multicluster`) already does this. Once onboarded:
+
+- DCF rules can target individual pods, namespaces, or services
+- SmartGroup membership becomes dynamic — pods come and go and the controller updates the data plane
+- The Gatus internal probes can use namespace/pod selectors instead of CIDR
+
+## Reference: how AWS-EKS does it (template to adapt)
+
+Two pieces of code in `aws-eks-multicluster/modules/eks-cluster/main.tf`:
+
+```hcl
+resource "aviatrix_kubernetes_cluster" "this" {
+  count = var.enable_aviatrix_onboarding ? 1 : 0
+
+  cluster_id          = module.eks.cluster_arn
+  use_csp_credentials = true
+
+  depends_on = [module.eks]
+}
+```
+
+…plus an EKS access entry granting the **Aviatrix Controller IAM role** (`var.aviatrix_controller_role_arn`) cluster access, and an in-cluster `view-nodes` ClusterRole + binding so the controller can list pods/services/nodes.
+
+```hcl
+resource "aws_eks_access_entry" "aviatrix_controller" {
+  cluster_name      = module.eks.cluster_name
+  principal_arn     = var.aviatrix_controller_role_arn
+  kubernetes_groups = ["view-nodes"]
+  type              = "STANDARD"
+}
+
+resource "aws_eks_access_policy_association" "aviatrix_controller" {
+  cluster_name  = module.eks.cluster_name
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
+  principal_arn = var.aviatrix_controller_role_arn
+  access_scope { type = "cluster" }
+}
+
+resource "kubernetes_cluster_role" "view_nodes" { ... }
+resource "kubernetes_cluster_role_binding" "view_nodes" { ... }
+```
+
+EKS uses **IAM Roles for Service Accounts (IRSA)**: the Aviatrix Controller has an IAM role, that role is added as an EKS access entry with the `AmazonEKSViewPolicy`, and the access entry is bound to a Kubernetes group that has a custom `view-nodes` ClusterRole.
+
+## What's different on Azure
+
+Azure has no equivalent of EKS access entries. The integration models are:
+
+| Mechanism | How it works | Suitability |
+|---|---|---|
+| **Service principal + kubeconfig** | Azure SP authenticates against AKS API via `az aks get-credentials`, kubeconfig holds the token | What the controller likely uses today |
+| **Workload Identity / federated credentials** | Federated identity bound to the Aviatrix Controller's principal | More secure but requires the controller to be running in Azure (it's not — it's in AWS) |
+| **AKS-managed AAD with RBAC** | Cluster has AAD integration enabled; AAD principal granted Kubernetes Cluster Reader role | Closest analog to the AWS access entry pattern; works regardless of where the controller runs |
+
+Cleanest path for this blueprint: **AAD-integrated AKS + Azure RBAC role assignment** giving the Aviatrix Controller's principal `Azure Kubernetes Service RBAC Reader` (or `Cluster Admin` if pod listing requires it) on each cluster. This avoids managing kubeconfigs as Terraform-managed credentials.
+
+**Open question for implementation:** what credential does the controller's `aviatrix_kubernetes_cluster` resource consume on Azure? The Terraform provider documentation needs a careful read — the AWS path uses `use_csp_credentials = true` which leans on the onboarded Azure account. If the same flag works on Azure (controller picks up the SP from the onboarded account and uses it to reach AKS), the Terraform side is much simpler than EKS. Otherwise, an explicit `kube_config` argument may be required.
+
+## Reference docs to consult
+
+The implementer should read these before writing code:
+
+1. **Aviatrix DCF for Kubernetes — Onboard Cluster (Azure section)** — the live docs at https://docs.aviatrix.com under DCF → Kubernetes Clusters. Specifically what the controller needs to authenticate against AKS, and whether managed-identity or SP credentials are stored on the controller.
+2. **Aviatrix Terraform provider — `aviatrix_kubernetes_cluster`** — argument schema, particularly the difference between `use_csp_credentials` and explicit credential args.
+3. **AKS AAD integration / Azure RBAC for Kubernetes Authorization** — Microsoft Learn:
+   - https://learn.microsoft.com/azure/aks/azure-ad-integration-cli
+   - https://learn.microsoft.com/azure/aks/manage-azure-rbac
+4. **Aviatrix Controller's Azure access account** — what subscription/RG scope it has on `var.aviatrix_azure_account_name`. Onboarding an AKS cluster inside that subscription should reuse those credentials, not require new ones.
+
+## Proposed scope (what the implementation work covers)
+
+### 1. Network layer — no change
+
+Cluster onboarding is a per-cluster concern. Network layer stays as-is.
+
+### 2. `clusters/{frontend,backend}/main.tf`
+
+Add (toggleable via a variable, default `true`):
+
+```hcl
+variable "enable_aviatrix_onboarding" {
+  description = "Register this AKS cluster with the Aviatrix Controller so DCF SmartGroups can target k8s namespaces, pods, and services"
+  type        = bool
+  default     = true
+}
+```
+
+Enable AAD integration on the cluster:
+
+```hcl
+resource "azurerm_kubernetes_cluster" "aks" {
+  # ...existing config...
+
+  # Enable AAD integration so the controller can authenticate as an AAD principal
+  azure_active_directory_role_based_access_control {
+    azure_rbac_enabled = true
+    # admin_group_object_ids can stay empty for lab; cluster-admin is granted via RBAC
+  }
+}
+```
+
+Grant the Aviatrix Controller's SP a read role on the cluster:
+
+```hcl
+data "azurerm_client_config" "current" {}
+
+# Aviatrix Controller's SP object ID — sourced from the Aviatrix Azure access account.
+# Likely needs a new variable on the network layer to expose this.
+variable "aviatrix_controller_principal_id" {
+  description = "Object ID of the AAD principal the Aviatrix Controller uses to call Azure APIs"
+  type        = string
+}
+
+resource "azurerm_role_assignment" "aviatrix_controller_aks_reader" {
+  count                = var.enable_aviatrix_onboarding ? 1 : 0
+  scope                = azurerm_kubernetes_cluster.aks.id
+  role_definition_name = "Azure Kubernetes Service RBAC Reader"
+  principal_id         = var.aviatrix_controller_principal_id
+}
+```
+
+If a custom RBAC role is needed for pod/node visibility analogous to the AWS `view-nodes` ClusterRole, add it as a `kubernetes_cluster_role` + binding.
+
+Register the cluster:
+
+```hcl
+resource "aviatrix_kubernetes_cluster" "this" {
+  count = var.enable_aviatrix_onboarding ? 1 : 0
+
+  cluster_id          = azurerm_kubernetes_cluster.aks.id
+  use_csp_credentials = true   # confirm this path works for Azure; otherwise pass kube_config
+
+  depends_on = [
+    azurerm_kubernetes_cluster.aks,
+    azurerm_role_assignment.aviatrix_controller_aks_reader,
+  ]
+}
+```
+
+### 3. New input: controller principal ID
+
+Two options:
+
+- **Variable input** — operator pastes the controller's SP/managed identity object ID into `terraform.tfvars`. Simple, explicit, but a manual step.
+- **Data source** — query the Aviatrix Controller API for the access account's `arm_ad_client_id`, then look up the SP object ID via `azuread_service_principal`. Fully derived but requires the `azuread` provider and login as someone who can read AAD.
+
+Recommend variable input for v1; revisit derivation later.
+
+### 4. Convert SmartGroups to K8s selectors
+
+Once clusters are onboarded, replace VPC selectors in `network/dcf.tf`:
+
+```hcl
+# Before
+resource "aviatrix_smart_group" "frontend_vnet" {
+  name = "${var.name_prefix}-sg-frontend-vnet"
+  selector {
+    match_expressions {
+      type = "vpc"
+      name = "${var.name_prefix}-frontend-vnet"
+    }
+  }
+}
+
+# After
+resource "aviatrix_smart_group" "frontend_cluster" {
+  name = "${var.name_prefix}-sg-frontend-cluster"
+  selector {
+    match_expressions {
+      k8s_cluster_id = "${var.name_prefix}-frontend"   # or the AKS resource ID
+    }
+  }
+}
+```
+
+Optionally add finer SmartGroups demonstrating the new capability:
+
+```hcl
+resource "aviatrix_smart_group" "gatus_pods" {
+  name = "${var.name_prefix}-sg-gatus-pods"
+  selector {
+    match_expressions {
+      k8s_namespace = "gatus"
+      k8s_pod       = "app=frontend"   # or app=backend
+    }
+  }
+}
+```
+
+DCF rules would then target `gatus_pods` instead of the whole VNet — much closer to a production Zero-Trust posture.
+
+### 5. README updates
+
+- Add an "AKS Cluster Onboarding" section under "How It Works" explaining the Azure-vs-AWS difference and the AAD/RBAC flow
+- Update the variables table with the new `aviatrix_controller_principal_id`
+- Update test scenarios to use the K8s-typed SmartGroups
+- Mention this in the architecture diagram (controller now has a read path into the cluster)
+
+## Acceptance criteria
+
+- [ ] CoPilot → Cloud Workloads → Kubernetes Clusters shows both clusters as **Onboarded: Yes** with namespace/service/pod counts populated
+- [ ] At least one DCF rule in the ruleset targets a `k8s_namespace` or `k8s_pod` SmartGroup and is observed enforcing in FlowIQ
+- [ ] `terraform destroy` cleanly removes the role assignment and the `aviatrix_kubernetes_cluster` resource (no orphaned controller-side records)
+- [ ] Toggle still works: setting `enable_aviatrix_onboarding = false` skips all the new resources without breaking the cluster apply
+- [ ] CI `validate-blueprint` still verdicts READY FOR QA
+
+## Risks / unknowns to investigate first
+
+1. **Does `use_csp_credentials = true` work for Azure?** If not, the implementer needs to thread a kubeconfig through to the `aviatrix_kubernetes_cluster` resource. The provider doc has the answer.
+2. **What principal does the controller actually use to call AKS?** The onboarded Azure access account has `arm_ad_client_id = 5d078f14-e51e-42f8-9fa9-4b84b72ddd1e` (visible via the Aviatrix `list_accounts` API). That's the principal that needs the RBAC role — but confirm before granting.
+3. **Is AAD integration disruptive on an existing cluster?** Enabling `azure_rbac_enabled` on a live cluster may require a control-plane update. Plan the apply order: onboarding additions go in last so any roll happens after the cluster is otherwise stable.
+4. **Does the AKS API authorized_ip_ranges allowlist need to include the controller's egress IP?** The current allowlist is the operator's IP plus the spoke GW public IP. The controller (running in AWS on a different egress) will get blocked unless its IP is added.
+5. **Private DCF SmartGroups for hostnames** — currently "doesn't resolve private FQDNs" is a known limitation because `enable_vpc_dns_server` is OFF. K8s-service SmartGroups would side-step that limitation by referencing the K8s service name directly. Worth noting in the README.
+
+## Out of scope for this feature
+
+- Changing the spoke GW SNAT mode
+- Re-enabling `enable_vpc_dns_server`
+- Migrating from `single_ip_snat` to per-pod-CIDR `customized_snat`
+- Adding pod-level NetworkPolicy (Calico/Cilium-native) — different layer
+
+## Branching
+
+A starter branch is already created and pushed: **`feat/azure-aks-cluster-onboarding`** (off the post-#35 main). The implementation work can pick this up directly.

--- a/blueprints/azure-aks-multicluster/docs/feature-cluster-onboarding.md
+++ b/blueprints/azure-aks-multicluster/docs/feature-cluster-onboarding.md
@@ -1,6 +1,11 @@
 # Feature: Onboard AKS Clusters with the Aviatrix Controller
 
-> Status: **Spec / not yet implemented.** This document captures the scope and the open questions so the implementation work can happen in a separate session.
+> Status: **Implemented.** See `clusters/{frontend,backend}/onboarding.tf`, `network/dcf-k8s.tf`, and the README's "AKS Cluster Onboarding" section under *How It Works*. This document is preserved as the original design discussion; **the README is the source of truth for the deployed behavior**, including a few corrections to the spec below.
+>
+> Spec deltas (corrected during implementation):
+> - **No AAD/Entra integration.** The Aviatrix DCF docs ([8.2 K8s onboarding](https://docs.aviatrix.com/docs/enterprise/8.2/guides/security/dcf/kubernetes-onboard#azure-aks)) require Kubernetes RBAC with local accounts; Entra-only auth is unsupported because the kubeconfig returned by ARM contains `exec` entries the controller can't process.
+> - **No in-cluster `view-nodes` ClusterRole.** The kubeconfig from `listClusterUserCredential/action` is admin-equivalent; the AWS-EKS in-cluster RBAC pattern is not needed on Azure.
+> - **No per-cluster role assignment.** Subscription-scoped Contributor on the Aviatrix Azure access account already covers the required ARM action.
 
 ## Background
 

--- a/blueprints/azure-aks-multicluster/network/dcf-k8s.tf
+++ b/blueprints/azure-aks-multicluster/network/dcf-k8s.tf
@@ -1,0 +1,102 @@
+#####################
+# K8s-Typed SmartGroups
+#
+# Once the AKS clusters are onboarded with the Aviatrix Controller (via the
+# clusters/{frontend,backend} layers), the controller resolves K8s-typed
+# selectors dynamically: pod IPs are listed from the cluster API and added
+# to the SmartGroup as members.
+#
+# Cluster IDs are constructed here (not read from the clusters layer) because
+# the network layer is applied first. The construction must match the format
+# produced by lower(azurerm_kubernetes_cluster.aks.id) in the clusters layer:
+#   /subscriptions/{sub}/resourcegroups/{rg}/providers/microsoft.containerservice/managedclusters/{name}
+#
+# Until the clusters are onboarded these SmartGroups have zero members and
+# any DCF rules referencing them are no-ops — safe to deploy in either order.
+#####################
+
+data "azurerm_client_config" "current" {}
+
+locals {
+  subscription_id = data.azurerm_client_config.current.subscription_id
+
+  # Must match lower(azurerm_kubernetes_cluster.aks.id) in clusters/* layers.
+  frontend_aks_cluster_id = lower("/subscriptions/${local.subscription_id}/resourcegroups/${var.name_prefix}-frontend-rg/providers/microsoft.containerservice/managedclusters/${var.name_prefix}-frontend")
+  backend_aks_cluster_id  = lower("/subscriptions/${local.subscription_id}/resourcegroups/${var.name_prefix}-backend-rg/providers/microsoft.containerservice/managedclusters/${var.name_prefix}-backend")
+}
+
+#####################
+# Cluster-scoped (analog of the VNet SmartGroup, but membership is pods+nodes
+# resolved from the cluster API instead of from VNet/IP)
+#####################
+
+resource "aviatrix_smart_group" "frontend_cluster" {
+  name = "${var.name_prefix}-sg-frontend-cluster"
+  selector {
+    match_expressions {
+      type           = "k8s"
+      k8s_cluster_id = local.frontend_aks_cluster_id
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "backend_cluster" {
+  name = "${var.name_prefix}-sg-backend-cluster"
+  selector {
+    match_expressions {
+      type           = "k8s"
+      k8s_cluster_id = local.backend_aks_cluster_id
+    }
+  }
+}
+
+#####################
+# Namespace-scoped — Gatus pods only
+# Demonstrates finer-grained policy than VNet selectors allow.
+#####################
+
+resource "aviatrix_smart_group" "frontend_gatus_ns" {
+  name = "${var.name_prefix}-sg-frontend-gatus-ns"
+  selector {
+    match_expressions {
+      type           = "k8s"
+      k8s_cluster_id = local.frontend_aks_cluster_id
+      k8s_namespace  = "gatus"
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "backend_gatus_ns" {
+  name = "${var.name_prefix}-sg-backend-gatus-ns"
+  selector {
+    match_expressions {
+      type           = "k8s"
+      k8s_cluster_id = local.backend_aks_cluster_id
+      k8s_namespace  = "gatus"
+    }
+  }
+}
+
+#####################
+# Outputs (referenced by clusters/* docs and validation)
+#####################
+
+output "frontend_aks_cluster_id" {
+  description = "Constructed AKS cluster_id used as the K8s SmartGroup selector value (matches what clusters/frontend onboards)"
+  value       = local.frontend_aks_cluster_id
+}
+
+output "backend_aks_cluster_id" {
+  description = "Constructed AKS cluster_id used as the K8s SmartGroup selector value (matches what clusters/backend onboards)"
+  value       = local.backend_aks_cluster_id
+}
+
+output "smartgroup_frontend_gatus_ns_uuid" {
+  description = "UUID of the K8s namespace SmartGroup for the frontend gatus namespace"
+  value       = aviatrix_smart_group.frontend_gatus_ns.uuid
+}
+
+output "smartgroup_backend_gatus_ns_uuid" {
+  description = "UUID of the K8s namespace SmartGroup for the backend gatus namespace"
+  value       = aviatrix_smart_group.backend_gatus_ns.uuid
+}

--- a/blueprints/azure-aks-multicluster/network/dcf.tf
+++ b/blueprints/azure-aks-multicluster/network/dcf.tf
@@ -471,7 +471,28 @@ resource "aviatrix_dcf_ruleset" "aks_demo" {
   }
 
   #############################
-  # PLACEHOLDER: K8s CRD POLICIES (Priority 50-99)
+  # K8s-TYPED DEMO (Priority 50)
+  # Demonstrates that, once clusters are onboarded, DCF can target K8s
+  # namespaces directly. Membership of these SmartGroups (defined in
+  # dcf-k8s.tf) is resolved by the controller from the cluster API.
+  # Empty until enable_aviatrix_onboarding completes in clusters/*.
+  #############################
+
+  rules {
+    name             = "Frontend Gatus to Backend Gatus k8s ns selector"
+    action           = "PERMIT"
+    priority         = 50
+    protocol         = "TCP"
+    logging          = true
+    src_smart_groups = [aviatrix_smart_group.frontend_gatus_ns.uuid]
+    dst_smart_groups = [aviatrix_smart_group.backend_gatus_ns.uuid]
+    port_ranges {
+      lo = 8080
+    }
+  }
+
+  #############################
+  # PLACEHOLDER: K8s CRD POLICIES (Priority 51-99)
   # Inserted programmatically by Aviatrix k8s-firewall controller.
   # See k8s-apps/dcf-crd/ for FirewallPolicy / WebGroupPolicy CRD examples.
   #############################


### PR DESCRIPTION
## Summary

- Registers the two AKS clusters with the Aviatrix Controller via `aviatrix_kubernetes_cluster` (use_csp_credentials=true) so DCF can target K8s-typed selectors (`k8s_cluster_id`, `k8s_namespace`) instead of just VNet selectors.
- Adds 4 K8s SmartGroups in `network/dcf-k8s.tf` (per-cluster + per-cluster gatus namespace) and a priority-50 demo rule wiring frontend gatus → backend gatus.
- Updates README with an "AKS Cluster Onboarding" section, Azure-vs-EKS auth-flow comparison, RBAC actions list, controller-IP-allowlist guidance, new test scenario, and three new troubleshooting entries (Onboarded:No, network_data_plane drift, autoscaler node_count drift).

## Spec corrections (vs. `docs/feature-cluster-onboarding.md`)

The original spec proposed enabling AAD on AKS, granting per-cluster RBAC, and adding a `view-nodes` ClusterRole. Per the [8.2 K8s onboarding docs](https://docs.aviatrix.com/docs/enterprise/8.2/guides/security/dcf/kubernetes-onboard#azure-aks), all three are wrong on Azure:

- **No AAD/Entra integration.** AKS must use Kubernetes RBAC with local accounts. Entra-only kubeconfigs contain `exec` entries the controller cannot process.
- **No in-cluster RBAC.** The kubeconfig the controller fetches via `listClusterUserCredential/action` is admin-equivalent.
- **No per-cluster role assignment.** Subscription-scoped Contributor on the Aviatrix Azure access account already covers the required ARM action.

Spec doc preserved as a historical design record with a corrections preamble.

## Side fixes (pre-existing drift surfaced during testing)

- `network_data_plane = "cilium"` added to AKS — Azure API now cross-validates this against `network_policy = "cilium"`.
- `lifecycle { ignore_changes = [default_node_pool[0].node_count] }` added — autoscaler-driven drift was blocking unrelated cluster updates.

## Test plan

- [x] `terraform init -backend=false` + `terraform validate` pass on all 5 leaves
- [x] `terraform apply` succeeds on `clusters/frontend` (registration `id: 69f106fe…`)
- [x] `terraform apply` succeeds on `clusters/backend` (registration `id: 69f10b88…`)
- [x] Both clusters present in `GET /v2.5/api/k8s/clusters` with `use_csp_credentials: true`
- [x] All 4 K8s SmartGroups created in `app-domains` with the documented selector schema
- [x] Priority-50 DCF rule applied in the `aks_demo` ruleset
- [x] Controller IP `3.131.22.171/32` is in each AKS API server's `authorized_ip_ranges`
- [x] `validate-blueprint` → READY FOR QA
- [x] CoPilot UI → Cloud Workloads → Kubernetes Clusters shows both **Onboarded: Yes** with namespace/pod counts populated *(manual UI verification — not driveable from CLI)*
- [x] FlowIQ shows the priority-50 rule enforcing on traffic from a frontend gatus pod to a backend gatus pod *(manual)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)