### PR TITLE
azure-aks-multicluster: clean destroy via K8s SmartGroup toggle

### DIFF
--- a/blueprints/azure-aks-multicluster/README.md
+++ b/blueprints/azure-aks-multicluster/README.md
@@ -761,20 +761,28 @@ az network private-dns record-set a add-record \
 
 ## Destroy Instructions
 
-Always destroy in **reverse order**. Kubernetes resources (ingresses, services) must be deleted first so that ExternalDNS can clean up Private DNS records before Terraform removes the DNS zone.
+Always destroy in **reverse order**. Two cross-layer dependencies need explicit cleanup that Terraform doesn't handle automatically:
 
-### Step 1: Delete Kubernetes Resources
+1. **K8s-firewall CRDs orphan controller-side state when the Helm release goes away.** Delete the FirewallPolicy/WebGroupPolicy CRs *before* destroying the nodes layer so the in-cluster controller can run finalizers and clean its controller-side SmartGroups + policy lists.
+2. **K8s SmartGroups in the network layer pin the cluster registrations.** The `aviatrix_kubernetes_cluster` resource cannot be deleted while any SmartGroup references its cluster_id. Toggle them off before destroying clusters via `enable_k8s_smartgroup_demo = false`.
+
+### Step 1: Delete Kubernetes Resources (ingresses, LB services, DCF CRs)
 
 ```bash
 # Frontend cluster
 kubectl delete ingress --all -A --context frontend
 kubectl delete svc -A --field-selector spec.type=LoadBalancer --context frontend
+kubectl delete firewallpolicies.networking.aviatrix.com --all -A --context frontend 2>/dev/null || true
+kubectl delete webgrouppolicies.networking.aviatrix.com --all -A --context frontend 2>/dev/null || true
 
 # Backend cluster
 kubectl delete ingress --all -A --context backend
 kubectl delete svc -A --field-selector spec.type=LoadBalancer --context backend
+kubectl delete firewallpolicies.networking.aviatrix.com --all -A --context backend 2>/dev/null || true
+kubectl delete webgrouppolicies.networking.aviatrix.com --all -A --context backend 2>/dev/null || true
 
-# Wait ~60s for ExternalDNS to remove DNS records
+# Wait ~60s for ExternalDNS to remove DNS records and the k8s-firewall controller
+# to process its CR finalizers (removes controller-side SmartGroups + policy lists).
 sleep 60
 
 # Verify DNS records are cleaned up (only db.* should remain as a Terraform-managed record)
@@ -783,6 +791,8 @@ az network private-dns record-set list \
   --zone-name azure.aviatrixdemo.local \
   --output table
 ```
+
+If you skip the CR cleanup, the k8s-firewall Helm release will be torn down before its controller can finalize its CRs. The controller-side SmartGroups + policy lists become orphans that block the cluster destroy in step 4 with `[AVXERR-SMARTGROUP-0003] ... present in one or more dfw policies`. The recovery procedure (after the fact) is at the end of this section.
 
 ### Step 2: Destroy Node Pools (Parallel)
 
@@ -794,9 +804,21 @@ cd nodes/frontend/ && terraform destroy
 cd nodes/backend/ && terraform destroy
 ```
 
-### Step 3: Destroy AKS Clusters (Parallel)
+### Step 3: Disable K8s SmartGroup Demo
 
-`terraform destroy` removes the `aviatrix_kubernetes_cluster` registration from the controller as well as the AKS cluster itself. After destroy, confirm the registrations are gone (the Aviatrix provider has historically left stale records for some resource types):
+The K8s SmartGroups in `network/dcf-k8s.tf` and the priority-50 demo rule reference the AKS cluster IDs. The Aviatrix Controller refuses to delete the `aviatrix_kubernetes_cluster` registration while any SmartGroup still references it. Disable both via the gating variable:
+
+```bash
+cd network/
+
+# Apply with the demo disabled — destroys the 4 K8s SmartGroups and removes the
+# priority-50 rule from the DCF ruleset. ~10s.
+terraform apply -auto-approve -var enable_k8s_smartgroup_demo=false
+```
+
+### Step 4: Destroy AKS Clusters (Parallel)
+
+`terraform destroy` removes the `aviatrix_kubernetes_cluster` registration from the controller as well as the AKS cluster itself.
 
 ```bash
 # Terminal 1
@@ -814,19 +836,55 @@ curl -sk -H "Authorization: cid ${CID}" \
 # Expected: []  (or no entries for aks-demo-*)
 ```
 
-### Step 4: Destroy Network Layer
+### Step 5: Destroy Network Layer
 
 ```bash
-cd network/ && terraform destroy
+cd network/ && terraform destroy -var enable_k8s_smartgroup_demo=false
 ```
 
-This destroys the K8s SmartGroups (`network/dcf-k8s.tf`) along with the rest of the DCF resources. Their cluster_id selectors point at AKS resources that no longer exist by this stage; the controller deletes them cleanly because they're regular Aviatrix resources, not Azure-side state.
+The `-var` is needed so the destroy plan matches the live state from Step 3 (otherwise Terraform will plan to recreate the K8s SmartGroups before destroying everything).
 
-### Step 5: Clean Up kubectl Contexts (Optional)
+### Step 6: Clean Up kubectl Contexts (Optional)
 
 ```bash
 kubectl config delete-context frontend
 kubectl config delete-context backend
+```
+
+### Recovery: orphaned k8s-firewall controller state
+
+If you skipped Step 1's CR cleanup, the cluster destroy in Step 4 fails with
+`failed to delete kubernetes cluster: HTTP DELETE ... cluster is still used in smart groups: ..., firewallpolicysource--..., webgrouppolicy-target-...`.
+
+These orphans are controller-side records the k8s-firewall controller didn't get a chance to clean up. Remove them via the Controller API:
+
+```bash
+CID=$(curl -sk -X POST "https://${AVIATRIX_CONTROLLER_IP}/v1/api" \
+  -d "action=login&username=${AVIATRIX_USERNAME}&password=${AVIATRIX_PASSWORD}" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['CID'])")
+
+# 1. Find K8s-injected policy lists (metadata.k8s set):
+curl -sk -H "Authorization: cid ${CID}" \
+  "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/microseg/policy-list3" \
+  | jq '.dcf_policies[] | select(.metadata.k8s) | {uuid, name}'
+
+# 2. For each non-system list (UUID NOT starting with "defa11a1-"), DELETE:
+curl -sk -X DELETE -H "Authorization: cid ${CID}" \
+  "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/microseg/policy-list3/<uuid>"
+
+# 3. For SYSTEM lists like "K8s Policy List" (defa11a1-3000-6000-4000-...), PUT
+#    with empty policies array to clear injected rules without deleting the list itself:
+curl -sk -X PUT -H "Authorization: cid ${CID}" -H "Content-Type: application/json" \
+  -d '{"name":"K8s Policy List","attach_to":"defa11a1-3000-6000-5000-000000000000","policies":[],"metadata":{"k8s":{"resource-type":"k8s-policylist"}}}' \
+  "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/microseg/policy-list3/defa11a1-3000-6000-4000-000000000000"
+
+# 4. Now the orphan SmartGroups can be deleted:
+curl -sk -H "Authorization: cid ${CID}" \
+  "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/app-domains" \
+  | jq '.app_domains[] | select(.name | startswith("firewallpolicysource") or startswith("webgrouppolicy-")) | .uuid'
+# DELETE each via /v2.5/api/app-domains/<uuid>
+
+# 5. Resume Step 4 (cluster destroy).
 ```
 
 ---

--- a/blueprints/azure-aks-multicluster/network/dcf-k8s.tf
+++ b/blueprints/azure-aks-multicluster/network/dcf-k8s.tf
@@ -31,7 +31,8 @@ locals {
 #####################
 
 resource "aviatrix_smart_group" "frontend_cluster" {
-  name = "${var.name_prefix}-sg-frontend-cluster"
+  count = var.enable_k8s_smartgroup_demo ? 1 : 0
+  name  = "${var.name_prefix}-sg-frontend-cluster"
   selector {
     match_expressions {
       type           = "k8s"
@@ -41,7 +42,8 @@ resource "aviatrix_smart_group" "frontend_cluster" {
 }
 
 resource "aviatrix_smart_group" "backend_cluster" {
-  name = "${var.name_prefix}-sg-backend-cluster"
+  count = var.enable_k8s_smartgroup_demo ? 1 : 0
+  name  = "${var.name_prefix}-sg-backend-cluster"
   selector {
     match_expressions {
       type           = "k8s"
@@ -56,7 +58,8 @@ resource "aviatrix_smart_group" "backend_cluster" {
 #####################
 
 resource "aviatrix_smart_group" "frontend_gatus_ns" {
-  name = "${var.name_prefix}-sg-frontend-gatus-ns"
+  count = var.enable_k8s_smartgroup_demo ? 1 : 0
+  name  = "${var.name_prefix}-sg-frontend-gatus-ns"
   selector {
     match_expressions {
       type           = "k8s"
@@ -67,7 +70,8 @@ resource "aviatrix_smart_group" "frontend_gatus_ns" {
 }
 
 resource "aviatrix_smart_group" "backend_gatus_ns" {
-  name = "${var.name_prefix}-sg-backend-gatus-ns"
+  count = var.enable_k8s_smartgroup_demo ? 1 : 0
+  name  = "${var.name_prefix}-sg-backend-gatus-ns"
   selector {
     match_expressions {
       type           = "k8s"
@@ -92,11 +96,11 @@ output "backend_aks_cluster_id" {
 }
 
 output "smartgroup_frontend_gatus_ns_uuid" {
-  description = "UUID of the K8s namespace SmartGroup for the frontend gatus namespace"
-  value       = aviatrix_smart_group.frontend_gatus_ns.uuid
+  description = "UUID of the K8s namespace SmartGroup for the frontend gatus namespace (null when enable_k8s_smartgroup_demo=false)"
+  value       = try(aviatrix_smart_group.frontend_gatus_ns[0].uuid, null)
 }
 
 output "smartgroup_backend_gatus_ns_uuid" {
-  description = "UUID of the K8s namespace SmartGroup for the backend gatus namespace"
-  value       = aviatrix_smart_group.backend_gatus_ns.uuid
+  description = "UUID of the K8s namespace SmartGroup for the backend gatus namespace (null when enable_k8s_smartgroup_demo=false)"
+  value       = try(aviatrix_smart_group.backend_gatus_ns[0].uuid, null)
 }

--- a/blueprints/azure-aks-multicluster/network/dcf.tf
+++ b/blueprints/azure-aks-multicluster/network/dcf.tf
@@ -476,18 +476,26 @@ resource "aviatrix_dcf_ruleset" "aks_demo" {
   # namespaces directly. Membership of these SmartGroups (defined in
   # dcf-k8s.tf) is resolved by the controller from the cluster API.
   # Empty until enable_aviatrix_onboarding completes in clusters/*.
+  #
+  # Gated by var.enable_k8s_smartgroup_demo so the rule + the SmartGroups
+  # it references can be removed in a single apply before destroying the
+  # clusters layer (the cluster registration cannot be deleted while a
+  # SmartGroup references its cluster_id).
   #############################
 
-  rules {
-    name             = "Frontend Gatus to Backend Gatus k8s ns selector"
-    action           = "PERMIT"
-    priority         = 50
-    protocol         = "TCP"
-    logging          = true
-    src_smart_groups = [aviatrix_smart_group.frontend_gatus_ns.uuid]
-    dst_smart_groups = [aviatrix_smart_group.backend_gatus_ns.uuid]
-    port_ranges {
-      lo = 8080
+  dynamic "rules" {
+    for_each = var.enable_k8s_smartgroup_demo ? [1] : []
+    content {
+      name             = "Frontend Gatus to Backend Gatus k8s ns selector"
+      action           = "PERMIT"
+      priority         = 50
+      protocol         = "TCP"
+      logging          = true
+      src_smart_groups = [aviatrix_smart_group.frontend_gatus_ns[0].uuid]
+      dst_smart_groups = [aviatrix_smart_group.backend_gatus_ns[0].uuid]
+      port_ranges {
+        lo = 8080
+      }
     }
   }
 

--- a/blueprints/azure-aks-multicluster/network/variables.tf
+++ b/blueprints/azure-aks-multicluster/network/variables.tf
@@ -96,3 +96,16 @@ variable "private_dns_zone_name" {
   type        = string
   default     = "azure.aviatrixdemo.local"
 }
+
+variable "enable_k8s_smartgroup_demo" {
+  description = <<-EOT
+    Create K8s-typed SmartGroups (per-cluster + per-cluster gatus namespace)
+    and the priority-50 demo DCF rule that references them.
+
+    DESTROY WORKFLOW: set this to false and `terraform apply` BEFORE destroying
+    clusters/{frontend,backend}. The aviatrix_kubernetes_cluster registration
+    cannot be deleted while these SmartGroups reference its cluster_id.
+  EOT
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Summary

End-to-end teardown surfaced two cross-layer dependencies the previous destroy steps didn't handle. This PR fixes both.

## Changes

- **`network/variables.tf`** — new `enable_k8s_smartgroup_demo` (default `true`) gating the K8s-typed SmartGroups + the priority-50 demo rule.
- **`network/dcf-k8s.tf`** — `count = var.enable_k8s_smartgroup_demo ? 1 : 0` on all 4 SmartGroups; outputs use `try(...[0].uuid, null)`.
- **`network/dcf.tf`** — priority-50 rule wrapped in a `dynamic "rules"` block driven by the same flag.
- **`README.md`** — destroy section rewritten:
  - Step 1 now also deletes `firewallpolicies` / `webgrouppolicies` CRs **before** the nodes/* destroy so the k8s-firewall controller can finalize its CRs.
  - New Step 3: `terraform apply -var enable_k8s_smartgroup_demo=false` in `network/` to release the cluster references.
  - Network destroy in Step 5 carries the same var.
  - New Recovery subsection for cleaning up orphaned k8s-firewall controller state via the Aviatrix API.

## Why

Without these:

- **CRD-orphan**: destroying `nodes/*` first kills the in-cluster k8s-firewall controller before it can finalize its `FirewallPolicy` / `WebGroupPolicy` CRs. The controller-side SmartGroups + policy lists become orphans referencing the cluster, blocking step 4 with `[AVXERR-SMARTGROUP-0003] ... present in one or more dfw policies`.
- **Cluster-pin**: the K8s SmartGroups in `network/dcf-k8s.tf` reference the AKS `cluster_id`s. The Aviatrix Controller refuses to delete the `aviatrix_kubernetes_cluster` resource while any SmartGroup still references it, so `clusters/*` destroy fails with `cluster is still used in smart groups: aks-demo-sg-frontend-cluster, ...`.

## Test plan

- [x] Full lab destroy following the new Steps 1–6 — completed cleanly with no orphan resources
- [x] Controller post-destroy: `GET /v2.5/api/k8s/clusters` → `[]`
- [x] Controller post-destroy: no `aks-demo-*` / `firewallpolicy*` / `webgrouppolicy*` SmartGroups remain
- [x] Azure post-destroy: no `aks-demo-*` resource groups remain
- [x] `terraform validate` on `network/` passes with the dynamic block + count

🤖 Generated with [Claude Code](https://claude.com/claude-code)