### PR TITLE
gcp-gke-multicluster: blueprint + QA pass

### DIFF
--- a/blueprints/gcp-gke-multicluster/README.md
+++ b/blueprints/gcp-gke-multicluster/README.md
@@ -1,0 +1,264 @@
+# Multi-Cluster GKE with Aviatrix Transit Architecture
+
+Two GKE clusters on dedicated GCP VPCs, fronted by an Aviatrix transit fabric, demonstrating Distributed Cloud Firewall (DCF) for Kubernetes — the GCP counterpart to `aws-eks-multicluster` and `azure-aks-multicluster`.
+
+> **Aviatrix Controller 9.0+ is required.** The blueprint relies on the controller programming a `0.0.0.0/0` route into each spoke VPC's routing table automatically; pre-9.0 controllers don't.
+
+---
+
+## Prerequisites
+
+### Aviatrix infrastructure
+
+| Component | Requirement | Notes |
+|-----------|-------------|-------|
+| Aviatrix Controller | 9.0+ | Default-route propagation into the spoke VPC requires controller 9.0. |
+| Aviatrix CoPilot | Recommended | Used for DCF visualization and SmartGroup browsing. |
+| Aviatrix GCP access account | Onboarded in Controller | Default name in this blueprint: `Google`. The service account JSON loaded into the controller needs at minimum `roles/compute.networkAdmin` (VPC + spoke gateway management) and `roles/container.clusterViewer` (GKE onboarding via `aviatrix_kubernetes_cluster`). |
+
+### Local tools
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| Terraform | >= 1.5 | Infrastructure provisioning |
+| `gcloud` CLI | latest | GCP authentication and `kubectl` plugin |
+| `kubectl` | latest | GKE cluster interaction |
+| `gke-gcloud-auth-plugin` | latest | Required by `kubectl` for GKE access tokens (`gcloud components install gke-gcloud-auth-plugin`) |
+
+### GCP authentication
+
+```bash
+gcloud auth login
+gcloud auth application-default login   # ADC for Terraform google provider
+gcloud config set project cmchenry-01
+```
+
+### GCP APIs to enable (one-time, project-level)
+
+```bash
+gcloud services enable \
+  compute.googleapis.com \
+  container.googleapis.com \
+  dns.googleapis.com \
+  iam.googleapis.com \
+  iamcredentials.googleapis.com
+```
+
+### GCP quotas
+
+This blueprint deploys 3 Aviatrix gateways (n1-standard-1) + 2 GKE node pools (e2-standard-2 × ~2 nodes each) + 1 Apache test VM (e2-small). Default project quotas in `us-central1` are usually enough — the typical pinch points:
+
+| Quota | Need | Default |
+|-------|------|---------|
+| `CPUS` (per region) | ~13 vCPU | 24+ |
+| `IN_USE_ADDRESSES` (per region) | ~6 (gateways + ALBs) | 8+ |
+| Backend services / URL maps (per project) | 2 each | high |
+
+Check with `gcloud compute project-info describe --project cmchenry-01 --format="json(quotas)"`.
+
+---
+
+## Architecture
+
+```
+                        Internet
+                           │
+            ┌──────────────┴──────────────┐
+            ▼                              ▼
+   Frontend Gateway              Backend Gateway
+   (Global External ALB)         (Global External ALB)
+   reserved IP from network/     reserved IP from network/
+            │                              │
+   ┌────────▼───────────┐         ┌────────▼───────────┐
+   │  Frontend VPC       │         │  Backend VPC        │
+   │  10.10.0.0/20       │         │  10.20.0.0/20       │
+   │                     │         │                     │
+   │  GKE frontend       │         │  GKE backend        │
+   │  (Dataplane V2 /    │         │  (Dataplane V2 /    │
+   │   Cilium eBPF)      │         │   Cilium eBPF)      │
+   │  pods 100.64.0.0/16 │         │  pods 100.64.0.0/16 │
+   │                     │         │                     │
+   │  Aviatrix Spoke GW  │         │  Aviatrix Spoke GW  │
+   └─────────┬───────────┘         └─────────┬───────────┘
+             │   Aviatrix Transit Fabric     │
+             └────────────┬──────────────────┘
+                          │
+                ┌─────────▼──────────┐
+                │ Aviatrix Transit   │
+                │ Transit VPC        │
+                │ 10.2.0.0/24        │
+                └─────────┬──────────┘
+                          │
+                ┌─────────▼──────────┐
+                │ DB VPC 10.5.0.0/22 │
+                │ Apache test VM    │
+                │ db.gcp.aviatrixdemo.local │
+                └────────────────────┘
+```
+
+### Why GKE Gateway API instead of an internal NGINX
+
+The AKS variant of this blueprint uses **Azure App Gateway → internal NGINX LB** because Azure's L4 public LB combined with a `0/0 → spoke GW` UDR causes asymmetric routing on response traffic. **GCP doesn't have that trap with Google-managed L7 LBs** — return traffic flows back through Google's LB plane, not the VPC's `0/0` route. So we use **GKE Gateway API** (`gatewayClassName: gke-l7-global-external-managed`) which provisions a native Google global external Application Load Balancer, attaches the Gatus Service via container-native NEGs, and avoids the NGINX hop entirely.
+
+### Pod networking (GKE Dataplane V2)
+
+Both clusters use **GKE Dataplane V2** (Cilium-based eBPF, replaces kube-proxy). Pod IPs come from the alias secondary range `100.64.0.0/16` — **the same in both clusters, overlapping by design**. Aviatrix spoke gateways SNAT pod source IPs to the spoke GW's private IP before transit, so the overlap is invisible east-west. The cluster's `default_snat_status.disabled = true` ensures pod IPs reach the spoke GW unmasqueraded — equivalent to `enableIPv4Masquerade=false` in the AKS variant.
+
+---
+
+## Directory structure
+
+```
+gcp-gke-multicluster/
+├── network/                # Layer 1: VPCs, transit, spokes, DCF, Cloud DNS
+│   ├── main.tf             # Transit + 3 spokes + DB VM + global IPs + DNS zone
+│   ├── dcf.tf              # SmartGroups, WebGroups, ruleset
+│   ├── dcf-k8s.tf          # K8s-typed SmartGroups (gated by enable_k8s_smartgroup_demo)
+│   ├── variables.tf
+│   ├── outputs.tf
+│   └── modules/
+│       ├── gke-vpc/        # VPC + node subnet (with pod/service alias ranges)
+│       │                   #   + Aviatrix GW subnet + proxy-only subnet + firewall rules
+│       └── linux-vm/       # Ubuntu Apache test VM
+│
+├── clusters/
+│   ├── frontend/           # Layer 2: GKE control plane + node pool + GSAs
+│   └── backend/            #          (parallel)
+│
+├── nodes/
+│   ├── frontend/           # Layer 3: Helm — ExternalDNS (Cloud DNS) + k8s-firewall
+│   └── backend/            #          (parallel)
+│
+└── k8s-apps/               # Layer 4: Kubernetes manifests (kubectl apply)
+    ├── frontend/gatus.yaml     # Gatus + internal-LB Service + Gateway + HTTPRoute
+    ├── backend/gatus.yaml
+    └── dcf-crd/                # FirewallPolicy / WebGroupPolicy CRD examples
+```
+
+---
+
+## Deployment
+
+> Total wall-clock: ~40–55 min when running same-level layers in parallel (network ~10–15m → clusters ~10m parallel → nodes ~3m parallel → kubectl ~3m).
+
+### Step 0 — credentials
+
+```bash
+# Aviatrix
+source ~/Documents/Scripting/chris-avx-lab/controller_env_ga.sh   # or set AVIATRIX_* manually
+
+# GCP
+gcloud auth application-default login
+gcloud config set project cmchenry-01
+```
+
+### Step 1 — network
+
+```bash
+cd network/
+cp terraform.tfvars.example terraform.tfvars
+# Edit gcp_project_id / aviatrix_gcp_account_name if your defaults differ.
+terraform init
+terraform apply
+```
+
+Creates:
+- Aviatrix transit GW + 3 spoke GWs (frontend, backend, db) — all zonal in `us-central1-a`
+- 3 GCP VPCs with custom subnets (nodes + Aviatrix GW + proxy-only)
+- Cloud DNS private zone bound to all 3 VPCs
+- Static A record `db.gcp.aviatrixdemo.local` → DB VM IP
+- 2 reserved global external IPv4 addresses for the GKE Gateways
+- DCF SmartGroups, WebGroups, ruleset
+
+### Step 2 — GKE clusters (parallel)
+
+```bash
+cd ../clusters/frontend && cp terraform.tfvars.example terraform.tfvars
+terraform init && terraform apply &
+
+cd ../backend && cp terraform.tfvars.example terraform.tfvars
+terraform init && terraform apply &
+wait
+```
+
+Each layer creates: GKE cluster (Dataplane V2 / Cilium), primary node pool, node service account, ExternalDNS service account with Workload Identity Federation, and `aviatrix_kubernetes_cluster` registration.
+
+If you set `master_authorized_cidr_blocks` to anything other than `["0.0.0.0/0"]`, also set `aviatrix_controller_public_ip` so the controller's egress IP is appended to the GKE master allowlist for the onboarding handshake.
+
+### Step 3 — Helm add-ons (parallel)
+
+```bash
+cd ../../nodes/frontend && terraform init && terraform apply &
+cd ../backend && terraform init && terraform apply &
+wait
+```
+
+Installs ExternalDNS (Cloud DNS provider, Workload Identity) and Aviatrix k8s-firewall.
+
+### Step 4 — Kubernetes apps
+
+Connect kubectl to each cluster, then apply Gatus + Gateway:
+
+```bash
+gcloud container clusters get-credentials gke-demo-frontend --zone us-central1-a
+kubectl apply -f k8s-apps/frontend/gatus.yaml
+
+gcloud container clusters get-credentials gke-demo-backend --zone us-central1-a
+kubectl apply -f k8s-apps/backend/gatus.yaml
+
+# Optional DCF CRD examples (install in either cluster)
+kubectl apply -f k8s-apps/dcf-crd/
+```
+
+### Verify
+
+```bash
+# Reserved Gateway IPs (printed by network/)
+terraform -chdir=network output frontend_gateway_global_ip_address
+terraform -chdir=network output backend_gateway_global_ip_address
+
+# Open in browser — Gatus UI shows:
+#   Internal Services: green (east-west via Aviatrix transit + DCF allow rules)
+#   Egress: green for kubernetes.io / npmjs.org / github (DCF WebGroup allow)
+#   Threats: blocked (DCF deny rules — geo + ThreatIQ)
+```
+
+---
+
+## Destroy
+
+**Order matters** — reverse of deploy:
+
+```bash
+# 0. Remove K8s resources first
+kubectl delete -f k8s-apps/frontend/gatus.yaml
+kubectl delete -f k8s-apps/backend/gatus.yaml
+kubectl delete -f k8s-apps/dcf-crd/ --ignore-not-found
+
+# 1. (CRITICAL) flip enable_k8s_smartgroup_demo before destroying clusters
+cd network/
+terraform apply -var enable_k8s_smartgroup_demo=false
+
+# 2. nodes (parallel)
+cd ../nodes/frontend && terraform destroy &
+cd ../backend && terraform destroy &
+wait
+
+# 3. clusters (parallel)
+cd ../../clusters/frontend && terraform destroy &
+cd ../backend && terraform destroy &
+wait
+
+# 4. network (last)
+cd ../../network && terraform destroy
+```
+
+---
+
+## GCP-specific gotchas
+
+- **Aviatrix `vpc_id` for GCP** has the form `<vpc_name>~-~<project_id>` — composed locally in `gke-vpc/outputs.tf`. Not the GCP self_link.
+- **Aviatrix GW `region`** for GCP is a **zone** (`us-central1-a`), not a region. Aviatrix gateways on GCP are zonal.
+- **`single_ip_snat = true` is accepted on GCP** despite the doc claim, but it only covers **internet egress (eth0)**. East-west traffic through the Aviatrix transit is *not* SNATed by `single_ip_snat`. With overlapping pod CIDRs across two GKE clusters (`100.64.0.0/16` in both), un-SNATed pod IPs arriving at the destination spoke route back into the wrong cluster's pod range and replies fail. This blueprint uses `aviatrix_gateway_snat` with `customized_snat` mode and explicit policies for both the transit connection and `eth0` — same pattern as `aws-eks-multicluster`.
+- **Default 0/0 propagation** is a controller-9.0 feature. If running 9.0 and the spoke VPC's routing still doesn't have a `0.0.0.0/0` route after `terraform apply`, fall back to a manual `google_compute_route` per VPC pointing at the spoke GW's NIC.
+- **GKE master authorized networks** must include the Aviatrix spoke GW egress IP. The clusters layer appends it automatically. When `enable_aviatrix_onboarding=true` and your `master_authorized_cidr_blocks` is restrictive, also set `aviatrix_controller_public_ip` so the controller can reach the master endpoint during onboarding.

--- a/blueprints/gcp-gke-multicluster/README.md
+++ b/blueprints/gcp-gke-multicluster/README.md
@@ -19,7 +19,7 @@ Before deploying this infrastructure, ensure you have the following prerequisite
 |-----------|-------------|-------|
 | **Aviatrix Controller** | 9.0.10 or newer | Default-route propagation into the spoke VPC requires Controller 9.0. K8s SmartGroup membership requires CoPilot 9.0+. |
 | **Aviatrix CoPilot** | Recommended | Required for DCF visualization, SmartGroup browsing, K8s cluster pod-IP membership, and FlowIQ flow inspection. |
-| **Aviatrix GCP access account** | Onboarded in Controller | Default name in this blueprint: `Google`. The service account JSON loaded into the Controller needs at minimum `roles/compute.networkAdmin` (VPC + spoke gateway management) and `roles/container.clusterViewer` (GKE onboarding via `aviatrix_kubernetes_cluster`). The built-in `Kubernetes Engine Admin` role is the simplest one-stop. |
+| **Aviatrix GCP access account** | Onboarded in Controller | Default name in this blueprint: `Google`. The service account JSON loaded into the Controller needs `roles/compute.networkAdmin` (VPC + spoke gateway management) **plus** `roles/container.admin` or `roles/container.clusterAdmin` (GKE onboarding **and** the watch loop that reconciles DCF CRs into Controller-side SmartGroups — both need `container.clusters.getCredentials`). `roles/container.clusterViewer` alone is **not** sufficient: it satisfies onboarding but the watch loop silently fails to reconcile, so `FirewallPolicy`/`WebGroupPolicy` CRs you apply in Step 8 won't appear in CoPilot. See [Troubleshooting › GKE Cluster Shows "Onboarded: No"](#gke-cluster-shows-onboarded-no-in-copilot-or-dcf-crs-arent-reconciled) if symptoms appear. |
 
 ### Local Tools
 
@@ -69,9 +69,10 @@ This blueprint deploys 4 Aviatrix gateways, 4 GKE nodes, and 1 Apache test VM in
 
 Check current usage:
 ```bash
-gcloud compute project-info describe \
+gcloud compute regions describe us-central1 \
   --project=<YOUR_PROJECT_ID> \
-  --format="json(quotas[?metric=='CPUS' || metric=='IN_USE_ADDRESSES'])"
+  --format="value(quotas.metric,quotas.usage,quotas.limit)" \
+  | tr ';' '\n' | paste -d'|' - - - | grep -E "^(CPUS|IN_USE_ADDRESSES)\b"
 ```
 
 If you need an increase, file the request via Console → IAM & Admin → Quotas. Up to ~50 vCPUs is generally auto-approved.
@@ -412,9 +413,9 @@ gke-gke-demo-frontend-primary-8ead9b6a-hb76   Ready    <none>   12m   v1.33.x-gk
 gke-gke-demo-frontend-primary-8ead9b6a-nnc9   Ready    <none>   12m   v1.33.x-gke.xxx
 ```
 
-#### Optional: Rename kubectl Contexts
+#### Rename kubectl Contexts
 
-The auto-generated names get unwieldy. Shorten them:
+The auto-generated names get unwieldy, and **the rest of this guide assumes the short aliases below.** Step 8 and every Test Scenario use `--context=frontend` / `--context=backend`; without the rename, those commands fail with `context not found`. Shorten:
 
 ```bash
 PROJECT=$(gcloud config get project)
@@ -470,15 +471,23 @@ kubectl --context=frontend get gateway -n gatus -w
 
 #### Get the Public ALB IPs
 
-The ALB IPs are the reserved global addresses created in the `network/` layer:
+> [!IMPORTANT]
+> Always read the ALB IP from the live Gateway, **not** from the `network/` Terraform output. The `network/` layer pre-reserves global addresses and the Gatus manifest annotates them via `networking.gke.io/addresses`, but on some current GKE versions the `gke-l7-global-external-managed` controller does **not** honor short-name annotations and mints a fresh address instead — leaving the reserved IPs in `STATUS=RESERVED` (unused) while Gatus serves on a different IP. Reading from `kubectl get gateway` always returns the live address regardless of which path is in effect.
 
 ```bash
-cd network/
-terraform output frontend_gateway_global_ip_address
-terraform output backend_gateway_global_ip_address
+FRONTEND_IP=$(kubectl --context=frontend get gateway frontend-public -n gatus \
+  -o jsonpath='{.status.addresses[0].value}')
+BACKEND_IP=$(kubectl --context=backend  get gateway backend-public  -n gatus \
+  -o jsonpath='{.status.addresses[0].value}')
+echo "Frontend ALB: $FRONTEND_IP"
+echo "Backend  ALB: $BACKEND_IP"
+
+# Optional: verify whether the reserved IP got bound (success path = STATUS=IN_USE)
+gcloud compute addresses list --global --filter="name~gke-demo" \
+  --format="table(name,address,status)"
 ```
 
-Open `http://<frontend-ip>/` and `http://<backend-ip>/` in a browser. Each shows a Gatus dashboard.
+Open `http://$FRONTEND_IP/` and `http://$BACKEND_IP/` in a browser. Each shows a Gatus dashboard.
 
 ---
 
@@ -489,8 +498,12 @@ Open `http://<frontend-ip>/` and `http://<backend-ip>/` in a browser. Each shows
 Verify the path GFE → Global External ALB → container-native NEG → Gatus pod is working end-to-end.
 
 ```bash
-FRONTEND_IP=$(cd network/ && terraform output -raw frontend_gateway_global_ip_address)
-BACKEND_IP=$(cd network/ && terraform output -raw backend_gateway_global_ip_address)
+# Read the live ALB IP from the Gateway resource — the network/ tf output returns the
+# *reserved* global IP, which the GKE Gateway controller may or may not have bound to.
+FRONTEND_IP=$(kubectl --context=frontend get gateway frontend-public -n gatus \
+  -o jsonpath='{.status.addresses[0].value}')
+BACKEND_IP=$(kubectl --context=backend  get gateway backend-public  -n gatus \
+  -o jsonpath='{.status.addresses[0].value}')
 
 curl -s -o /dev/null -w "%{http_code}\n" http://$FRONTEND_IP/
 # Expected: 200
@@ -1092,9 +1105,13 @@ The GKE Gateway controller takes 3-5 minutes to provision the Global External AL
    ```
    Status `RESERVED` is normal until the Gateway claims it (becomes `IN_USE`).
 
-3. **Check the GKE Gateway controller logs:**
+3. **Check Gateway events + GKE control-plane audit logs.** The `gke-l7-global-external-managed` controller is **GKE-managed** (runs outside your cluster) — there is no in-cluster pod or `gke-system` deployment to log against. Use:
    ```bash
-   kubectl --context=frontend logs -n gke-system deployment/gke-l7-global-external-managed -c gke-l7
+   kubectl --context=frontend get events -n gatus \
+     --field-selector involvedObject.kind=Gateway,involvedObject.name=frontend-public \
+     --sort-by=.lastTimestamp
+   gcloud logging read 'resource.type="gke_cluster" AND severity>=ERROR' \
+     --project=<PROJECT> --limit=50 --format="value(timestamp,textPayload)"
    ```
 
 ### ExternalDNS Not Creating DNS Records

--- a/blueprints/gcp-gke-multicluster/README.md
+++ b/blueprints/gcp-gke-multicluster/README.md
@@ -1,6 +1,9 @@
 # Multi-Cluster GKE with Aviatrix Transit Architecture
 
-Two GKE clusters on dedicated GCP VPCs, fronted by an Aviatrix transit fabric, demonstrating Distributed Cloud Firewall (DCF) for Kubernetes — the GCP counterpart to `aws-eks-multicluster` and `azure-aks-multicluster`.
+This blueprint deploys a multi-cluster Kubernetes environment on Google Cloud with Aviatrix transit networking, demonstrating Distributed Cloud Firewall (DCF) for Kubernetes — the GCP counterpart to `aws-eks-multicluster` and `azure-aks-multicluster`.
+
+> [!TIP]
+> **Optimized for Claude Code** — Run `/deploy-blueprint` for AI-guided deployment with prerequisite checks and automated orchestration, or `/analyze-blueprint` for resource and cost details. [Get Claude Code](https://claude.ai/code)
 
 > **Aviatrix Controller 9.0+ is required.** The blueprint relies on the controller programming a `0.0.0.0/0` route into each spoke VPC's routing table automatically; pre-9.0 controllers don't.
 
@@ -8,32 +11,39 @@ Two GKE clusters on dedicated GCP VPCs, fronted by an Aviatrix transit fabric, d
 
 ## Prerequisites
 
-### Aviatrix infrastructure
+Before deploying this infrastructure, ensure you have the following prerequisites in place.
+
+### Aviatrix Infrastructure
 
 | Component | Requirement | Notes |
 |-----------|-------------|-------|
-| Aviatrix Controller | 9.0+ | Default-route propagation into the spoke VPC requires controller 9.0. |
-| Aviatrix CoPilot | Recommended | Used for DCF visualization and SmartGroup browsing. |
-| Aviatrix GCP access account | Onboarded in Controller | Default name in this blueprint: `Google`. The service account JSON loaded into the controller needs at minimum `roles/compute.networkAdmin` (VPC + spoke gateway management) and `roles/container.clusterViewer` (GKE onboarding via `aviatrix_kubernetes_cluster`). |
+| **Aviatrix Controller** | 9.0.10 or newer | Default-route propagation into the spoke VPC requires Controller 9.0. K8s SmartGroup membership requires CoPilot 9.0+. |
+| **Aviatrix CoPilot** | Recommended | Required for DCF visualization, SmartGroup browsing, K8s cluster pod-IP membership, and FlowIQ flow inspection. |
+| **Aviatrix GCP access account** | Onboarded in Controller | Default name in this blueprint: `Google`. The service account JSON loaded into the Controller needs at minimum `roles/compute.networkAdmin` (VPC + spoke gateway management) and `roles/container.clusterViewer` (GKE onboarding via `aviatrix_kubernetes_cluster`). The built-in `Kubernetes Engine Admin` role is the simplest one-stop. |
 
-### Local tools
+### Local Tools
 
-| Tool | Version | Purpose |
-|------|---------|---------|
-| Terraform | >= 1.5 | Infrastructure provisioning |
-| `gcloud` CLI | latest | GCP authentication and `kubectl` plugin |
-| `kubectl` | latest | GKE cluster interaction |
-| `gke-gcloud-auth-plugin` | latest | Required by `kubectl` for GKE access tokens (`gcloud components install gke-gcloud-auth-plugin`) |
+| Tool | Version | Installation | Purpose |
+|------|---------|--------------|---------|
+| **Terraform** | >= 1.5 | [Install Guide](https://developer.hashicorp.com/terraform/install) | Infrastructure provisioning |
+| **`gcloud` CLI** | latest | [Install Guide](https://cloud.google.com/sdk/docs/install) | GCP authentication and the GKE auth plugin |
+| **`kubectl`** | latest | [Install Guide](https://kubernetes.io/docs/tasks/tools/) | Kubernetes cluster interaction |
+| **`gke-gcloud-auth-plugin`** | latest | `gcloud components install gke-gcloud-auth-plugin` | Required by `kubectl` for GKE token exchange |
+| **Helm** | >= 3.x | [Install Guide](https://helm.sh/docs/intro/install/) | Used by Terraform's Helm provider for ExternalDNS + k8s-firewall |
 
-### GCP authentication
+### GCP Authentication
 
 ```bash
 gcloud auth login
-gcloud auth application-default login   # ADC for Terraform google provider
-gcloud config set project cmchenry-01
+gcloud auth application-default login    # ADC for the Terraform google provider
+gcloud config set project <YOUR_PROJECT_ID>
 ```
 
-### GCP APIs to enable (one-time, project-level)
+The `aviatrix_gcp_account_name` referenced by `network/terraform.tfvars` must already be onboarded in the Aviatrix Controller and bound to a service account in this same GCP project.
+
+### Required GCP APIs
+
+Enable these once per project:
 
 ```bash
 gcloud services enable \
@@ -44,221 +54,1529 @@ gcloud services enable \
   iamcredentials.googleapis.com
 ```
 
-### GCP quotas
+The `network/main.tf` also enables them as Terraform-managed `google_project_service` resources, but enabling them up front avoids first-apply timing races.
 
-This blueprint deploys 3 Aviatrix gateways (n1-standard-1) + 2 GKE node pools (e2-standard-2 × ~2 nodes each) + 1 Apache test VM (e2-small). Default project quotas in `us-central1` are usually enough — the typical pinch points:
+### GCP Project Quotas
+
+This blueprint deploys 4 Aviatrix gateways, 4 GKE nodes, and 1 Apache test VM in a single region. Default project quotas in `us-central1` are usually enough; the typical pinch points:
 
 | Quota | Need | Default |
 |-------|------|---------|
-| `CPUS` (per region) | ~13 vCPU | 24+ |
-| `IN_USE_ADDRESSES` (per region) | ~6 (gateways + ALBs) | 8+ |
-| Backend services / URL maps (per project) | 2 each | high |
+| `CPUS` (per region) | ~13 vCPU (4 × n1-standard-1 + 4 × e2-standard-2 + 1 × e2-small) | 24+ |
+| `IN_USE_ADDRESSES` (per region) | ~6 (gateway public IPs + 2 reserved global IPs for ALBs) | 8+ |
+| `BACKEND_SERVICES` (per project) | 2 (one per GKE Gateway) | 75 |
+| `URL_MAPS` (per project) | 2 (one per GKE Gateway) | 25 |
 
-Check with `gcloud compute project-info describe --project cmchenry-01 --format="json(quotas)"`.
+Check current usage:
+```bash
+gcloud compute project-info describe \
+  --project=<YOUR_PROJECT_ID> \
+  --format="json(quotas[?metric=='CPUS' || metric=='IN_USE_ADDRESSES'])"
+```
+
+If you need an increase, file the request via Console → IAM & Admin → Quotas. Up to ~50 vCPUs is generally auto-approved.
 
 ---
 
-## Architecture
+## Architecture Overview
 
 ```
-                        Internet
-                           │
-            ┌──────────────┴──────────────┐
-            ▼                              ▼
-   Frontend Gateway              Backend Gateway
-   (Global External ALB)         (Global External ALB)
-   reserved IP from network/     reserved IP from network/
-            │                              │
-   ┌────────▼───────────┐         ┌────────▼───────────┐
-   │  Frontend VPC       │         │  Backend VPC        │
-   │  10.10.0.0/20       │         │  10.20.0.0/20       │
-   │                     │         │                     │
-   │  GKE frontend       │         │  GKE backend        │
-   │  (Dataplane V2 /    │         │  (Dataplane V2 /    │
-   │   Cilium eBPF)      │         │   Cilium eBPF)      │
-   │  pods 100.64.0.0/16 │         │  pods 100.64.0.0/16 │
-   │                     │         │                     │
-   │  Aviatrix Spoke GW  │         │  Aviatrix Spoke GW  │
-   └─────────┬───────────┘         └─────────┬───────────┘
-             │   Aviatrix Transit Fabric     │
-             └────────────┬──────────────────┘
-                          │
-                ┌─────────▼──────────┐
-                │ Aviatrix Transit   │
-                │ Transit VPC        │
-                │ 10.2.0.0/24        │
-                └─────────┬──────────┘
-                          │
-                ┌─────────▼──────────┐
-                │ DB VPC 10.5.0.0/22 │
-                │ Apache test VM    │
-                │ db.gcp.aviatrixdemo.local │
-                └────────────────────┘
+                              Internet
+                                 │
+                  ┌──────────────┴──────────────┐
+                  ▼                              ▼
+       Frontend GKE Gateway              Backend GKE Gateway
+     (Global External ALB)              (Global External ALB)
+       reserved global IPv4               reserved global IPv4
+                  │                              │
+       ┌──────────▼──────────┐         ┌──────────▼──────────┐
+       │ Frontend VPC         │         │ Backend VPC          │
+       │ 10.10.0.0/20         │         │ 10.20.0.0/20         │
+       │                      │         │                      │
+       │ GKE frontend         │         │ GKE backend          │
+       │ Dataplane V2 (eBPF)  │         │ Dataplane V2 (eBPF)  │
+       │ pods 100.64.0.0/16   │         │ pods 100.64.0.0/16   │
+       │                      │         │                      │
+       │ Aviatrix Spoke GW    │         │ Aviatrix Spoke GW    │
+       │ customized_snat      │         │ customized_snat      │
+       │  100.64/16 → GW IP   │         │  100.64/16 → GW IP   │
+       └──────────┬───────────┘         └──────────┬───────────┘
+                  │   Aviatrix Transit Fabric      │
+                  └───────────────┬────────────────┘
+                                  │
+                       ┌──────────▼──────────┐
+                       │ Aviatrix Transit    │
+                       │ Transit VPC         │
+                       │ 10.2.0.0/24         │
+                       └──────────┬──────────┘
+                                  │
+                       ┌──────────▼──────────┐
+                       │ DB Spoke VPC        │
+                       │ 10.5.0.0/22         │
+                       │ Apache test VM      │
+                       │ db.gcp.aviatrixdemo │
+                       │     .local          │
+                       └─────────────────────┘
 ```
 
-### Why GKE Gateway API instead of an internal NGINX
+### Why GKE Gateway API Instead of an Internal NGINX Layer
 
-The AKS variant of this blueprint uses **Azure App Gateway → internal NGINX LB** because Azure's L4 public LB combined with a `0/0 → spoke GW` UDR causes asymmetric routing on response traffic. **GCP doesn't have that trap with Google-managed L7 LBs** — return traffic flows back through Google's LB plane, not the VPC's `0/0` route. So we use **GKE Gateway API** (`gatewayClassName: gke-l7-global-external-managed`) which provisions a native Google global external Application Load Balancer, attaches the Gatus Service via container-native NEGs, and avoids the NGINX hop entirely.
+The AKS variant of this blueprint uses **Azure Application Gateway → internal NGINX** because Azure's public Standard Load Balancer combined with a `0/0 → spoke GW` UDR causes asymmetric routing: return traffic exits through the UDR and arrives at the client from the Aviatrix GW IP rather than the LB IP, so TCP drops it.
 
-### Pod networking (GKE Dataplane V2)
+**GCP doesn't have that trap with Google-managed L7 load balancers.** Return traffic for a Global External ALB flows back through Google's load balancer plane, not through the VPC's `0/0` route. So this blueprint uses **GKE Gateway API** (`gatewayClassName: gke-l7-global-external-managed`), which provisions a native Google Global External Application Load Balancer, attaches Gatus Services via container-native NEGs, and avoids the NGINX hop entirely.
 
-Both clusters use **GKE Dataplane V2** (Cilium-based eBPF, replaces kube-proxy). Pod IPs come from the alias secondary range `100.64.0.0/16` — **the same in both clusters, overlapping by design**. Aviatrix spoke gateways SNAT pod source IPs to the spoke GW's private IP before transit, so the overlap is invisible east-west. The cluster's `default_snat_status.disabled = true` ensures pod IPs reach the spoke GW unmasqueraded — equivalent to `enableIPv4Masquerade=false` in the AKS variant.
+### Traffic Flow (Internet → Gatus)
+
+```
+Internet client
+  → Reserved Global IPv4 :80
+  → Google Frontend (GFE) → Global External ALB
+  → Container-native NEG → Gatus pod :8080
+  ← response back through Google's LB plane
+  ← GFE → client
+```
+
+The Aviatrix `0/0 → spoke GW` route at priority 991 in the spoke VPC affects **VM-originated** egress (including pod-sourced traffic that's not response traffic for the ALB). Response traffic for ALB flows uses Google's LB plane and does not traverse the priority-991 route, so there is no asymmetric routing.
+
+### Pod Networking (GKE Dataplane V2)
+
+Both clusters run **GKE Dataplane V2** (Cilium-based eBPF, replaces kube-proxy; provides NetworkPolicy enforcement out of the box). Pod IPs come from the alias secondary range `100.64.0.0/16` — **the same in both clusters, fully overlapping by design.**
+
+Aviatrix spoke gateways SNAT pod source IPs to the spoke GW's private IP via `customized_snat` policies before forwarding to transit, allowing the overlapping pod CIDRs to coexist without routing conflicts. Each cluster's `default_snat_status.disabled = true` ensures pod IPs reach the spoke GW unmasqueraded — equivalent to `enableIPv4Masquerade=false` in the AKS variant.
+
+### Pod Traffic Flow (Cross-Cluster)
+
+```
+Frontend pod (100.64.x.x)
+  → frontend-nodes subnet (10.10.0.0/22)
+  → 0.0.0.0/0 priority-991 → Frontend Aviatrix Spoke GW (10.10.4.2)
+  → CONDUIT_SNAT iptables: src 100.64.0.0/16 → SNAT to 10.10.4.2
+  → IPsec tunnel to Aviatrix Transit GW
+  → IPsec tunnel to Backend Spoke GW
+  → Backend GKE service / pod IP (10.20.x.x or 100.64.x.x)
+  ← reverse path symmetric (SNAT preserves conntrack)
+```
 
 ---
 
-## Directory structure
+## Directory Structure
 
 ```
 gcp-gke-multicluster/
-├── network/                # Layer 1: VPCs, transit, spokes, DCF, Cloud DNS
-│   ├── main.tf             # Transit + 3 spokes + DB VM + global IPs + DNS zone
-│   ├── dcf.tf              # SmartGroups, WebGroups, ruleset
-│   ├── dcf-k8s.tf          # K8s-typed SmartGroups (gated by enable_k8s_smartgroup_demo)
+├── network/                       # Layer 1: Network foundation
+│   ├── main.tf                    # Transit + 3 spoke GWs + customized_snat + DB VM + global IPs + DNS
+│   ├── dcf.tf                     # SmartGroups, WebGroups, ruleset (priorities 10-25)
+│   ├── dcf-k8s.tf                 # K8s-typed SmartGroups (gated by enable_k8s_smartgroup_demo)
 │   ├── variables.tf
-│   ├── outputs.tf
+│   ├── outputs.tf                 # VPC IDs, subnet names, gateway IPs, DCF UUIDs
 │   └── modules/
-│       ├── gke-vpc/        # VPC + node subnet (with pod/service alias ranges)
-│       │                   #   + Aviatrix GW subnet + proxy-only subnet + firewall rules
-│       └── linux-vm/       # Ubuntu Apache test VM
+│       ├── gke-vpc/               # VPC + node subnet (with pod/service alias ranges)
+│       │                          #   + Aviatrix GW subnet + proxy-only subnet + firewall rules
+│       └── linux-vm/              # Ubuntu Apache test VM
 │
 ├── clusters/
-│   ├── frontend/           # Layer 2: GKE control plane + node pool + GSAs
-│   └── backend/            #          (parallel)
+│   ├── frontend/                  # Layer 2: Frontend GKE control plane + node pool + GSAs
+│   │   ├── main.tf                # GKE cluster, node pool, ExternalDNS GSA + WIF binding
+│   │   ├── onboarding.tf          # aviatrix_kubernetes_cluster registration
+│   │   ├── data.tf                # Read network state
+│   │   ├── variables.tf
+│   │   └── outputs.tf
+│   │
+│   └── backend/                   # Layer 2: Backend GKE control plane (parallel)
 │
 ├── nodes/
-│   ├── frontend/           # Layer 3: Helm — ExternalDNS (Cloud DNS) + k8s-firewall
-│   └── backend/            #          (parallel)
+│   ├── frontend/                  # Layer 3: Helm add-ons
+│   │   ├── main.tf                # google + kubernetes + helm provider blocks
+│   │   ├── helm.tf                # ExternalDNS (Cloud DNS) + Aviatrix k8s-firewall
+│   │   ├── data.tf                # Read network + cluster state
+│   │   ├── variables.tf
+│   │   └── outputs.tf
+│   │
+│   └── backend/                   # Layer 3: Backend Helm add-ons (parallel)
 │
-└── k8s-apps/               # Layer 4: Kubernetes manifests (kubectl apply)
-    ├── frontend/gatus.yaml     # Gatus + internal-LB Service + Gateway + HTTPRoute
+└── k8s-apps/                      # Layer 4: Kubernetes manifests (kubectl apply)
+    ├── frontend/gatus.yaml        # Gatus + Service + Gateway + HTTPRoute
     ├── backend/gatus.yaml
-    └── dcf-crd/                # FirewallPolicy / WebGroupPolicy CRD examples
+    └── dcf-crd/                   # DCF Kubernetes CRD policy examples
+        ├── firewallpolicy-infosec.yaml
+        └── webgrouppolicy-dev.yaml
 ```
+
+### State Dependencies
+
+```
+network/terraform.tfstate
+    │
+    ├── clusters/frontend/terraform.tfstate
+    │       │
+    │       └── nodes/frontend/terraform.tfstate
+    │
+    └── clusters/backend/terraform.tfstate
+            │
+            └── nodes/backend/terraform.tfstate
+```
+
+Each layer reads the previous layer's state via `data "terraform_remote_state" "local"`. **All state is local — no remote backend.** All blueprints in this repository follow the same convention.
 
 ---
 
-## Deployment
+## Complete Deployment Guide
 
-> Total wall-clock: ~40–55 min when running same-level layers in parallel (network ~10–15m → clusters ~10m parallel → nodes ~3m parallel → kubectl ~3m).
+> **Note:** Complete all items in the [Prerequisites](#prerequisites) section before proceeding.
+>
+> **Total deploy time:** ~40-55 minutes wall-clock when running same-level layers in parallel:
+> - network: ~10-15 min (most time is Aviatrix gateway creation + IPsec tunnel setup)
+> - clusters: ~10-15 min parallel (GKE control plane creation)
+> - nodes: ~2-3 min parallel (Helm chart installation)
+> - k8s-apps: ~2-3 min (kubectl apply + pod readiness)
 
-### Step 0 — credentials
+### Step 0: Get the Source
 
 ```bash
-# Aviatrix
-source ~/Documents/Scripting/chris-avx-lab/controller_env_ga.sh   # or set AVIATRIX_* manually
-
-# GCP
-gcloud auth application-default login
-gcloud config set project cmchenry-01
+git clone https://github.com/AviatrixSystems/aviatrix-blueprints.git
+cd aviatrix-blueprints/blueprints/gcp-gke-multicluster
 ```
 
-### Step 1 — network
+All subsequent `cd` paths are relative to `blueprints/gcp-gke-multicluster/`.
+
+### Step 1: Set Environment Variables
+
+```bash
+# Aviatrix Controller credentials (always required)
+export AVIATRIX_CONTROLLER_IP="<controller-ip>"
+export AVIATRIX_USERNAME="<username>"
+export AVIATRIX_PASSWORD="<password>"
+```
+
+**GCP authentication** — application default credentials are required for the Terraform `google` provider:
+
+```bash
+gcloud auth login
+gcloud auth application-default login
+gcloud config set project <YOUR_PROJECT_ID>
+
+# Verify
+gcloud auth list
+gcloud config get project
+```
+
+> [!IMPORTANT]
+> When the cluster layers run with `enable_aviatrix_onboarding = true` (default), the Aviatrix Controller calls each GKE API server directly after fetching the kubeconfig from the GKE container API. The controller's public egress IP must be in the cluster's `master_authorized_networks`:
+> - **If you set `master_authorized_cidr_blocks = ["0.0.0.0/0"]`** (the example default): no extra config needed — `0.0.0.0/0` already covers the controller.
+> - **If you restrict `master_authorized_cidr_blocks`** to your own IP: also set `aviatrix_controller_public_ip` in `clusters/*/terraform.tfvars` so the controller's IP gets appended automatically. For SaaS / Cloud Fabric controllers this is the same value as `AVIATRIX_CONTROLLER_IP`; for self-hosted controllers behind NAT, use the controller's public egress IP (not its management IP).
+
+### Step 2: Deploy Network Infrastructure
+
+The network layer creates the Aviatrix transit/spoke topology, three GCP VPCs with subnets and secondary alias ranges, the GCP private DNS zone, the DB test VM, and the DCF policy ruleset.
 
 ```bash
 cd network/
+
+# Initialize Terraform
+terraform init -upgrade
+
+# Create your variable file
 cp terraform.tfvars.example terraform.tfvars
-# Edit gcp_project_id / aviatrix_gcp_account_name if your defaults differ.
-terraform init
+# Edit terraform.tfvars — set at minimum:
+#   name_prefix                 (e.g., "gke-demo")
+#   aviatrix_gcp_account_name   (your GCP account name in Aviatrix Controller, e.g., "Google")
+#   gcp_project_id              (your GCP project ID)
+#   gcp_region                  (default: us-central1)
+#   gcp_zone                    (default: us-central1-a)
+vim terraform.tfvars
+
+# Deploy network infrastructure (~10-15 minutes)
 terraform apply
 ```
 
-Creates:
-- Aviatrix transit GW + 3 spoke GWs (frontend, backend, db) — all zonal in `us-central1-a`
-- 3 GCP VPCs with custom subnets (nodes + Aviatrix GW + proxy-only)
-- Cloud DNS private zone bound to all 3 VPCs
+> [!TIP]
+> If `terraform apply` fails partway through with a transient controller error like `connection reset by peer` or `502 Bad Gateway` (most often during `aviatrix_spoke_transit_attachment` or `aviatrix_gateway_snat`), simply re-run `terraform apply`. Terraform picks up where it left off and the controller normally accepts the retry. This is not a configuration bug.
+
+**What's created:**
+
+- Aviatrix Transit Gateway (`10.2.0.0/24`, `excluded_advertised_spoke_routes = "100.64.0.0/16"` to keep pod CIDRs out of BGP)
+- Frontend VPC (`10.10.0.0/20`) with Aviatrix spoke gateway and `customized_snat` policies
+- Backend VPC (`10.20.0.0/20`) with Aviatrix spoke gateway and `customized_snat` policies
+- DB spoke VPC (`10.5.0.0/22`) with Linux test VM (Apache, listens on port 80)
+- Each spoke VPC has subnets: nodes (`10.x.0.0/22`, with `100.64.0.0/16` pod and `172.16.0.0/20` service secondary ranges), Aviatrix GW (`10.x.4.0/28`), proxy-only (`10.x.5.0/24`)
+- GCP Private DNS zone (`gcp.aviatrixdemo.local.`) bound to all three spoke VPCs
 - Static A record `db.gcp.aviatrixdemo.local` → DB VM IP
-- 2 reserved global external IPv4 addresses for the GKE Gateways
-- DCF SmartGroups, WebGroups, ruleset
+- 2 reserved global external IPv4 addresses (one per cluster's GKE Gateway)
+- DCF SmartGroups, WebGroups, and policy ruleset (priorities 10-25; see [DCF Rules](#dcf-rules))
 
-### Step 2 — GKE clusters (parallel)
+### Step 3: Deploy Frontend GKE Cluster
+
+The cluster layer creates the GKE control plane (Dataplane V2 / Cilium eBPF), primary node pool, two service accounts (node SA, ExternalDNS GSA with Workload Identity Federation binding), and the `aviatrix_kubernetes_cluster` registration.
 
 ```bash
-cd ../clusters/frontend && cp terraform.tfvars.example terraform.tfvars
-terraform init && terraform apply &
+cd ../clusters/frontend/
 
-cd ../backend && cp terraform.tfvars.example terraform.tfvars
-terraform init && terraform apply &
-wait
+# Initialize Terraform
+terraform init
+
+# (Optional) Override defaults
+cp terraform.tfvars.example terraform.tfvars
+# Inputs you may want to set:
+#   master_authorized_cidr_blocks  (default ["0.0.0.0/0"]; restrict to your IP for prod)
+#   enable_aviatrix_onboarding     (default true — registers cluster with Controller)
+#   aviatrix_controller_public_ip  (required only when master_authorized_cidr_blocks is restrictive)
+vim terraform.tfvars   # only needed if you customized any of the above
+
+# Deploy cluster (~10-15 minutes)
+terraform apply
 ```
 
-Each layer creates: GKE cluster (Dataplane V2 / Cilium), primary node pool, node service account, ExternalDNS service account with Workload Identity Federation, and `aviatrix_kubernetes_cluster` registration.
+**What's created:**
 
-If you set `master_authorized_cidr_blocks` to anything other than `["0.0.0.0/0"]`, also set `aviatrix_controller_public_ip` so the controller's egress IP is appended to the GKE master allowlist for the onboarding handshake.
+- GKE cluster (`gke-demo-frontend`) — zonal, Dataplane V2 (Cilium eBPF), private nodes, public master endpoint with allowlist, Gateway API CRDs (channel STANDARD), Workload Identity (`<project>.svc.id.goog`)
+- Primary node pool (`primary`, default 2 × `e2-standard-2`, autoscale 1-3)
+- Node service account (`<cluster>-node-sa`) with logging/monitoring/artifact-reader roles
+- ExternalDNS service account (`<cluster>-edns`) with `roles/dns.admin` + a Workload Identity binding to `kube-system/external-dns`
+- `aviatrix_kubernetes_cluster` registration with the Aviatrix Controller (when `enable_aviatrix_onboarding = true`)
 
-### Step 3 — Helm add-ons (parallel)
+### Step 4: Deploy Backend GKE Cluster (Parallel with Step 3)
 
 ```bash
-cd ../../nodes/frontend && terraform init && terraform apply &
-cd ../backend && terraform init && terraform apply &
-wait
+cd ../backend/
+
+# Initialize Terraform
+terraform init
+
+# Same tfvars pattern as frontend
+cp terraform.tfvars.example terraform.tfvars
+vim terraform.tfvars   # only if customizing
+
+# Deploy cluster (~10-15 minutes)
+terraform apply
 ```
 
-Installs ExternalDNS (Cloud DNS provider, Workload Identity) and Aviatrix k8s-firewall.
+**What's created:** Same as the frontend cluster, scoped to the backend VPC.
 
-### Step 4 — Kubernetes apps
+Steps 3 and 4 can run in parallel in separate terminals. The two clusters have no Terraform-level dependency on each other.
 
-Connect kubectl to each cluster, then apply Gatus + Gateway:
+### Step 5: Deploy Frontend Helm Add-ons
+
+The node layer installs ExternalDNS (Cloud DNS provider via Workload Identity Federation) and the Aviatrix `k8s-firewall` Helm chart (DCF CRDs).
 
 ```bash
-gcloud container clusters get-credentials gke-demo-frontend --zone us-central1-a
-kubectl apply -f k8s-apps/frontend/gatus.yaml
+cd ../../nodes/frontend/
 
-gcloud container clusters get-credentials gke-demo-backend --zone us-central1-a
-kubectl apply -f k8s-apps/backend/gatus.yaml
+# Initialize Terraform
+terraform init
 
-# Optional DCF CRD examples (install in either cluster)
-kubectl apply -f k8s-apps/dcf-crd/
+# Deploy Helm charts (~2-3 minutes)
+terraform apply
 ```
 
-### Verify
+**What's created:**
+
+- ExternalDNS Helm release in `kube-system` (creates Private DNS A records for annotated Services and Gateways)
+- Aviatrix `k8s-firewall` Helm release (installs the `FirewallPolicy` and `WebGroupPolicy` CRDs plus a ClusterRole + ClusterRoleBinding granting the `avx-controller` ClusterRole read access on `pods/services/namespaces/endpointslices` and update permission on the DCF CRDs — **the chart contains no in-cluster controller pod**; the Aviatrix Controller itself watches the cluster API and reconciles CRs into Controller-side SmartGroups + policy-list rules)
+
+### Step 6: Deploy Backend Helm Add-ons (Parallel with Step 5)
 
 ```bash
-# Reserved Gateway IPs (printed by network/)
-terraform -chdir=network output frontend_gateway_global_ip_address
-terraform -chdir=network output backend_gateway_global_ip_address
+cd ../backend/
 
-# Open in browser — Gatus UI shows:
-#   Internal Services: green (east-west via Aviatrix transit + DCF allow rules)
-#   Egress: green for kubernetes.io / npmjs.org / github (DCF WebGroup allow)
-#   Threats: blocked (DCF deny rules — geo + ThreatIQ)
+# Initialize Terraform
+terraform init
+
+# Deploy Helm charts (~2-3 minutes)
+terraform apply
 ```
 
----
+Steps 5 and 6 can run in parallel in separate terminals.
 
-## Destroy
+### Step 7: Configure kubectl for Both Clusters
 
-**Order matters** — reverse of deploy:
+`gcloud container clusters get-credentials` creates a kubectl context with the auto-generated name `gke_<project>_<zone>_<cluster>`. We use that name directly in the examples below; if you'd rather use a short alias, see the [Optional: Rename kubectl Contexts](#optional-rename-kubectl-contexts) section.
 
 ```bash
-# 0. Remove K8s resources first
-kubectl delete -f k8s-apps/frontend/gatus.yaml
-kubectl delete -f k8s-apps/backend/gatus.yaml
-kubectl delete -f k8s-apps/dcf-crd/ --ignore-not-found
+# Pull credentials for both clusters
+gcloud container clusters get-credentials gke-demo-frontend \
+  --zone us-central1-a --project <YOUR_PROJECT_ID>
 
-# 1. (CRITICAL) flip enable_k8s_smartgroup_demo before destroying clusters
+gcloud container clusters get-credentials gke-demo-backend \
+  --zone us-central1-a --project <YOUR_PROJECT_ID>
+
+# Verify both clusters
+PROJECT=$(gcloud config get project)
+kubectl --context=gke_${PROJECT}_us-central1-a_gke-demo-frontend get nodes
+kubectl --context=gke_${PROJECT}_us-central1-a_gke-demo-backend get nodes
+```
+
+**Expected output (one row per node, default 2):**
+```
+NAME                                          STATUS   ROLES    AGE   VERSION
+gke-gke-demo-frontend-primary-8ead9b6a-hb76   Ready    <none>   12m   v1.33.x-gke.xxx
+gke-gke-demo-frontend-primary-8ead9b6a-nnc9   Ready    <none>   12m   v1.33.x-gke.xxx
+```
+
+#### Optional: Rename kubectl Contexts
+
+The auto-generated names get unwieldy. Shorten them:
+
+```bash
+PROJECT=$(gcloud config get project)
+kubectl config rename-context gke_${PROJECT}_us-central1-a_gke-demo-frontend frontend
+kubectl config rename-context gke_${PROJECT}_us-central1-a_gke-demo-backend  backend
+
+# All subsequent kubectl commands use --context=frontend or --context=backend
+kubectl --context=frontend get nodes
+```
+
+The remainder of this guide uses `--context=frontend` and `--context=backend` for brevity.
+
+### Step 8: Deploy Gatus Monitoring Dashboards
+
+Gatus is a YAML-driven uptime monitor. Each cluster runs its own dashboard that monitors:
+- Cross-cluster east-west via Aviatrix transit (`backend.gcp.aviatrixdemo.local:8080` from frontend, and vice-versa)
+- The DB VM via private DNS (`db.gcp.aviatrixdemo.local`)
+- DCF-allowed external endpoints (kubernetes.io, github.com/AviatrixSystems, npmjs.org)
+- DCF-blocked threat endpoints (geo-blocked country, ThreatGuard feed IP)
+
+Apply the manifests in this order — Gatus creates the `gatus` namespace, and the DCF CRD examples live in that namespace + a separate `dev` namespace:
+
+```bash
+# 1. Gatus dashboards (creates the gatus namespace + Gateway + HTTPRoute)
+kubectl --context=frontend apply -f k8s-apps/frontend/gatus.yaml
+kubectl --context=backend  apply -f k8s-apps/backend/gatus.yaml
+
+# 2. Create the dev namespace (used by webgrouppolicy-dev.yaml)
+kubectl --context=frontend create namespace dev --dry-run=client -o yaml | kubectl --context=frontend apply -f -
+kubectl --context=backend  create namespace dev --dry-run=client -o yaml | kubectl --context=backend  apply -f -
+
+# 3. DCF CRD examples (FirewallPolicy in gatus ns, WebGroupPolicy in dev ns)
+kubectl --context=frontend apply -f k8s-apps/dcf-crd/
+kubectl --context=backend  apply -f k8s-apps/dcf-crd/
+
+# Verify Gatus pods are running
+kubectl --context=frontend get pods -n gatus
+kubectl --context=backend  get pods -n gatus
+```
+
+**Expected output:**
+```
+NAME                        READY   STATUS    RESTARTS   AGE
+frontend-755f8587fb-m5f4m   1/1     Running   0          60s
+frontend-755f8587fb-zjczn   1/1     Running   0          60s
+```
+
+The first time the GKE Gateway resource provisions a Global External ALB it can take 3-5 minutes. Watch progress:
+```bash
+kubectl --context=frontend get gateway -n gatus -w
+# Wait for PROGRAMMED=True and ADDRESS populated
+```
+
+#### Get the Public ALB IPs
+
+The ALB IPs are the reserved global addresses created in the `network/` layer:
+
+```bash
 cd network/
-terraform apply -var enable_k8s_smartgroup_demo=false
+terraform output frontend_gateway_global_ip_address
+terraform output backend_gateway_global_ip_address
+```
 
-# 2. nodes (parallel)
-cd ../nodes/frontend && terraform destroy &
-cd ../backend && terraform destroy &
-wait
+Open `http://<frontend-ip>/` and `http://<backend-ip>/` in a browser. Each shows a Gatus dashboard.
 
-# 3. clusters (parallel)
-cd ../../clusters/frontend && terraform destroy &
-cd ../backend && terraform destroy &
-wait
+---
 
-# 4. network (last)
-cd ../../network && terraform destroy
+## Test Scenarios
+
+### Scenario 1: Internet Access via GKE Gateway (Public ALB)
+
+Verify the path GFE → Global External ALB → container-native NEG → Gatus pod is working end-to-end.
+
+```bash
+FRONTEND_IP=$(cd network/ && terraform output -raw frontend_gateway_global_ip_address)
+BACKEND_IP=$(cd network/ && terraform output -raw backend_gateway_global_ip_address)
+
+curl -s -o /dev/null -w "%{http_code}\n" http://$FRONTEND_IP/
+# Expected: 200
+
+curl -s -o /dev/null -w "%{http_code}\n" http://$BACKEND_IP/
+# Expected: 200
+```
+
+### Scenario 2: Pod-to-Internet Egress (Aviatrix `customized_snat`)
+
+A frontend pod's traffic to the internet should appear sourced from the **frontend spoke gateway's public IP** (not the pod IP, not the node IP). This proves the data path:
+1. Pod → priority-991 default route → Spoke GW
+2. Spoke GW iptables `CONDUIT_SNAT` → SNAT pod-CIDR src → spoke GW private IP
+3. Spoke GW eth0 → Internet Gateway → 1:1 NAT to spoke GW public IP
+
+```bash
+# Spawn a debug pod with curl/dig/tcpdump
+kubectl --context=frontend run debug --image=nicolaka/netshoot:latest \
+  --namespace=gatus --restart=Never --command -- sleep 600
+kubectl --context=frontend wait --for=condition=ready pod/debug -n gatus --timeout=60s
+
+# Pod IP (should be 100.64.x.x)
+kubectl --context=frontend get pod debug -n gatus -o jsonpath='{.status.podIP}'; echo
+
+# Internet egress source IP
+SPOKE_PUB=$(cd network/ && terraform output -raw frontend_spoke_gateway_public_ip)
+echo "Frontend spoke GW public IP: $SPOKE_PUB"
+
+kubectl --context=frontend exec -n gatus debug -- curl -sm 10 https://ifconfig.io
+# Expected: $SPOKE_PUB (the spoke GW's public IP)
+
+# HTTP test
+kubectl --context=frontend exec -n gatus debug -- curl -sm 10 -o /dev/null \
+  -w "HTTP %{http_code} in %{time_total}s\n" https://kubernetes.io
+# Expected: HTTP 200 in <1s
+```
+
+### Scenario 3: East-West Cross-Cluster (via Aviatrix Transit)
+
+Frontend pod hits backend service over the private DNS name. Both clusters use overlapping `100.64.0.0/16` pod CIDRs — Aviatrix `customized_snat` makes that invisible east-west.
+
+```bash
+# Cross-cluster: frontend pod → backend Gatus service via transit
+kubectl --context=frontend exec -n gatus debug -- \
+  curl -sm 8 -o /dev/null -w "HTTP %{http_code} in %{time_total}s\n" \
+  http://backend.gcp.aviatrixdemo.local:8080
+# Expected: HTTP 200 in <100ms
+
+# Frontend pod → DB VM (Apache) via transit
+kubectl --context=frontend exec -n gatus debug -- \
+  curl -sm 8 -o /dev/null -w "HTTP %{http_code} in %{time_total}s\n" \
+  http://db.gcp.aviatrixdemo.local
+# Expected: HTTP 200 in <100ms
+```
+
+The **Internal Services** group on the Gatus dashboard exercises the same cross-cluster path continuously.
+
+### Scenario 4: DCF Egress Allow (Customized SNAT + WebGroup Match)
+
+The DCF ruleset allows specific external destinations via WebGroups. Confirmed-allowed:
+- `kubernetes.io` (`*-wg-kubernetes-io`)
+- `github.com/AviatrixSystems/*` (`*-wg-github-aviatrix`)
+- `registry.npmjs.org` (`*-wg-npm-registry`)
+- Docker Hub (`*-wg-docker-hub`)
+- Required GCP services — `*.googleapis.com`, `*.gcr.io`, `*.pkg.dev` (`*-wg-gcp-required`)
+
+```bash
+# All should return HTTP 200
+for url in https://kubernetes.io https://github.com/AviatrixSystems/terraform-provider-aviatrix https://registry.npmjs.org; do
+  CODE=$(kubectl --context=frontend exec -n gatus debug -- curl -sm 8 -o /dev/null -w "%{http_code}" "$url")
+  echo "$url → $CODE"
+done
+```
+
+The **Egress** group on the Gatus dashboard runs the same checks every 60 seconds.
+
+### Scenario 5: DCF Threat Blocking (GeoBlock + ThreatIQ)
+
+The Gatus dashboard includes two threat endpoints **expected to be blocked**:
+- A geo-blocked destination (configurable in `network/dcf.tf`'s `geo_blocked` SmartGroup — default Iran/Russia/North Korea/China)
+- A ThreatGuard-feed IP
+
+These show as **red/down** in the Gatus dashboard, which is the correct behavior. If both show green, your ThreatGuard feed may not be active or the IP rolled out of the feed (Emerging Threats Open's `compromised-ips.txt` rotates roughly daily). To refresh:
+
+```bash
+# Pick a current IP from the feed
+curl -s https://rules.emergingthreats.net/blockrules/compromised-ips.txt | grep -vE '^(#|$)' | head -1
+
+# Update the IP in both gatus.yaml files
+vim k8s-apps/frontend/gatus.yaml   # find "Threat Feed - Malicious IP"
+vim k8s-apps/backend/gatus.yaml
+
+# Re-apply
+kubectl --context=frontend apply -f k8s-apps/frontend/gatus.yaml
+kubectl --context=backend  apply -f k8s-apps/backend/gatus.yaml
+```
+
+### Scenario 6: K8s-Typed SmartGroup Membership
+
+The K8s-typed SmartGroups created in `network/dcf-k8s.tf` populate dynamically from the cluster API once onboarding succeeds. **CoPilot is the canonical place to verify this** — the Controller API confirms cluster *registration* but doesn't expose resolved pod IPs.
+
+```bash
+# Confirm both clusters are registered with use_csp_credentials=true
+CID=$(curl -sk -X POST "https://${AVIATRIX_CONTROLLER_IP}/v1/api" \
+  -d "action=login&username=${AVIATRIX_USERNAME}&password=${AVIATRIX_PASSWORD}" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['CID'])")
+
+curl -sk -H "Authorization: cid ${CID}" \
+  "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/k8s/clusters" | python3 -m json.tool
+# Expected: both gke-demo-frontend and gke-demo-backend listed.
+```
+
+In **CoPilot**:
+- Cloud Workloads → Kubernetes Clusters: both clusters show **Onboarded: Yes** with namespace and pod counts populated. First-time sync after onboarding can take ~10 minutes.
+- Security → SmartGroups → `gke-demo-sg-frontend-gatus-ns` → Members tab: lists the gatus pod IPs (100.64.x.x range, dynamically resolved).
+
+The priority-50 DCF rule "Frontend Gatus to Backend Gatus k8s ns selector" (in `network/dcf.tf`, gated by `enable_k8s_smartgroup_demo`) references these K8s-typed SmartGroups. While membership is empty the rule is a no-op, but the lower-priority VPC-based rules (priority 14/15) still permit the cross-cluster gatus traffic, so dashboard checks remain green.
+
+### Scenario 7: DCF CRD-Based Policies (Kubernetes-Native)
+
+The `k8s-apps/dcf-crd/` manifests demonstrate Kubernetes-native DCF policy management — pods labeled `app=infosec` get an additional FirewallPolicy, pods in the `dev` namespace get a broader WebGroupPolicy.
+
+```bash
+# Already applied in Step 8 — verify they're accepted
+kubectl --context=frontend get firewallpolicies -n gatus
+kubectl --context=frontend get webgrouppolicies -n dev
+
+# Expected:
+# firewallpolicy.networking.aviatrix.com/infosec-egress
+# webgrouppolicy.networking.aviatrix.com/dev-external-apis
+```
+
+The Aviatrix `k8s-firewall` controller watches these CRDs and creates corresponding Controller-side SmartGroups + policy lists. Verify in CoPilot → Security → SmartGroups: you should see entries with the prefix `firewallpolicysource-` and `webgrouppolicy-target-`.
+
+### Scenario 8: Private DNS Resolution
+
+ExternalDNS creates Cloud DNS records for annotated Services and Gateways:
+
+```bash
+gcloud dns record-sets list \
+  --project=<YOUR_PROJECT_ID> \
+  --zone=gke-demo-private-zone \
+  --format="table(name,type,rrdatas.list():label=VALUES)"
+```
+
+**Expected records:**
+
+| FQDN | Resolves to | Source |
+|---|---|---|
+| `frontend.gcp.aviatrixdemo.local` | frontend cluster's internal LB IP (10.10.x.x) | Service `gatus/frontend` |
+| `backend.gcp.aviatrixdemo.local` | backend cluster's internal LB IP (10.20.x.x) | Service `gatus/backend` |
+| `db.gcp.aviatrixdemo.local` | DB VM IP (10.5.0.2) | Static record from Terraform |
+
+Verify resolution from inside a pod:
+```bash
+kubectl --context=frontend exec -n gatus debug -- nslookup backend.gcp.aviatrixdemo.local
+# Expected: 10.20.0.5 (or whatever the backend service-LB IP is)
 ```
 
 ---
 
-## GCP-specific gotchas
+## How It Works
 
-- **Aviatrix `vpc_id` for GCP** has the form `<vpc_name>~-~<project_id>` — composed locally in `gke-vpc/outputs.tf`. Not the GCP self_link.
-- **Aviatrix GW `region`** for GCP is a **zone** (`us-central1-a`), not a region. Aviatrix gateways on GCP are zonal.
-- **`single_ip_snat = true` is accepted on GCP** despite the doc claim, but it only covers **internet egress (eth0)**. East-west traffic through the Aviatrix transit is *not* SNATed by `single_ip_snat`. With overlapping pod CIDRs across two GKE clusters (`100.64.0.0/16` in both), un-SNATed pod IPs arriving at the destination spoke route back into the wrong cluster's pod range and replies fail. This blueprint uses `aviatrix_gateway_snat` with `customized_snat` mode and explicit policies for both the transit connection and `eth0` — same pattern as `aws-eks-multicluster`.
-- **Default 0/0 propagation** is a controller-9.0 feature. If running 9.0 and the spoke VPC's routing still doesn't have a `0.0.0.0/0` route after `terraform apply`, fall back to a manual `google_compute_route` per VPC pointing at the spoke GW's NIC.
-- **GKE master authorized networks** must include the Aviatrix spoke GW egress IP. The clusters layer appends it automatically. When `enable_aviatrix_onboarding=true` and your `master_authorized_cidr_blocks` is restrictive, also set `aviatrix_controller_public_ip` so the controller can reach the master endpoint during onboarding.
+### GKE Dataplane V2 + `default_snat_status.disabled`
+
+Both clusters use **Dataplane V2** (Cilium-based eBPF), which replaces kube-proxy. NetworkPolicy enforcement is enabled by default, and pod IPs come from the alias secondary range `100.64.0.0/16`.
+
+By default GKE applies node-level IP masquerade for pod traffic — pod source IPs are SNAT'd to the node IP before leaving the node. This blueprint disables that with `default_snat_status.disabled = true`, so pod IPs reach the Aviatrix spoke gateway **unmasqueraded**. The spoke GW then SNATs pod source IPs to its own private IP at the iptables `CONDUIT_SNAT` chain.
+
+This two-step is necessary because:
+- DCF SmartGroup matching needs to see the **original pod IP** at the spoke (for K8s-typed SmartGroup membership and for hostname-based policy lookups).
+- The transit fabric needs SNATed packets so overlapping pod CIDRs (both clusters use `100.64.0.0/16`) don't collide.
+
+### Aviatrix `customized_snat` on GCP
+
+This blueprint sets `aviatrix_gateway_snat` resources on each spoke gateway with `snat_mode = "customized_snat"` and three policies per spoke:
+
+```hcl
+# Pod CIDR → all destinations via transit (cross-cluster east-west)
+snat_policy {
+  src_cidr   = var.frontend_pods_cidr           # 100.64.0.0/16
+  dst_cidr   = "0.0.0.0/0"
+  interface  = ""
+  connection = module.gcp_transit.transit_gateway.gw_name
+  snat_ips   = module.frontend_spoke.spoke_gateway.private_ip
+}
+
+# Pod CIDR → internet via eth0
+snat_policy {
+  src_cidr  = var.frontend_pods_cidr            # 100.64.0.0/16
+  dst_cidr  = "0.0.0.0/0"
+  interface = "eth0"
+  snat_ips  = module.frontend_spoke.spoke_gateway.private_ip
+}
+
+# Node subnet → internet via eth0 (covers GKE node-level traffic)
+snat_policy {
+  src_cidr  = var.frontend_nodes_cidr           # 10.10.0.0/22
+  dst_cidr  = "0.0.0.0/0"
+  interface = "eth0"
+  snat_ips  = module.frontend_spoke.spoke_gateway.private_ip
+}
+```
+
+These render on the spoke GW as iptables rules in the `CONDUIT_SNAT` chain:
+
+```
+Chain CONDUIT_SNAT (1 references)
+ pkts bytes target     prot opt in     out     source               destination
+    0     0 ACCEPT     0    --  *      *       0.0.0.0/0   0.0.0.0/0   policy match dir out pol ipsec
+   12   720 SNAT       0    --  *      *       100.64.0.0/16 0.0.0.0/0  dst-group 0x1 to:10.10.4.2
+   33  1884 SNAT       0    --  *      eth0    100.64.0.0/16 0.0.0.0/0   to:10.10.4.2
+    0     0 SNAT       0    --  *      eth0    10.10.0.0/22  0.0.0.0/0   to:10.10.4.2
+```
+
+The first rule (IPsec policy match → ACCEPT) is an internal Aviatrix bypass for transit IPsec packets that should **not** be SNATed twice. The transit-direction SNAT rule (rule 2) uses `dst-group 0x1` which is the controller's representation of "any destination reachable through transit."
+
+### Why Not `single_ip_snat`?
+
+The `single_ip_snat = true` flag on the spoke gateway is the simplest pattern, and it works fine for north-south internet egress on GCP. **It does not, however, SNAT east-west traffic through the IPsec transit tunnel.** With overlapping pod CIDRs (both clusters use `100.64.0.0/16`), un-SNAT'd pod IPs arriving at the destination spoke route into the wrong cluster's pod range and replies fail. `customized_snat` with explicit `connection =` policies is the only way to SNAT both directions on GCP without triggering the AVXERR-NAT-0029 conflict that the AKS variant sees.
+
+### Controller-Managed `0.0.0.0/0` Default Route (Priority 991)
+
+Aviatrix Controller 9.0+ programs a `0.0.0.0/0 → spoke-GW-instance` route at priority 991 in each spoke VPC's route table (per **AVX-71737** — the route is **untagged** so it applies to GKE-managed nodes that don't carry the `avx-snat-noip` instance tag). You can verify:
+
+```bash
+gcloud compute routes list \
+  --project=<YOUR_PROJECT_ID> \
+  --filter="network:gke-demo-frontend-vpc AND priority=991" \
+  --format="table(name,priority,destRange,nextHopInstance.basename(),tags.list())"
+
+# Expected:
+# NAME                                  PRIORITY  DEST_RANGE  NEXT_HOP_INSTANCE        TAGS
+# avx-958e25524fb245ea8793514d423feb6e  991       0.0.0.0/0   gke-demo-frontend-spoke
+```
+
+There's also a priority-500 `0.0.0.0/0 → IGW` route **tagged** with `avx-<vpc-name>-vpc-gbl` — that's the egress route for the Aviatrix gateway VM itself. The 991 untagged route applies to all other VMs (GKE nodes, pods).
+
+### Reserved Global IPv4 Addresses for GKE Gateways
+
+The `network/` layer pre-reserves two `EXTERNAL` global addresses (one per cluster). The Gatus Gateway resource in each cluster references them by name via `networking.gke.io/addresses`. Reserving them in `network/` keeps DNS and downstream wiring stable across `nodes/` layer rebuilds — destroying and re-applying nodes won't change the public IP.
+
+---
+
+## DCF Rules
+
+The `network/dcf.tf` ruleset has these policies (priorities 10-25). Lower number = evaluated first.
+
+| Priority | Name | Source | Destination | Action |
+|---:|---|---|---|---|
+| 10 | Block GeoBlocked Countries | All GKE | Geo-blocked countries | DENY |
+| 11 | Block Threat Intel IPs | All GKE | ThreatGuard feed | DENY |
+| 14 | Frontend to Database | Frontend VPC | DB VPC | PERMIT |
+| 15 | Backend to Database | Backend VPC | DB VPC | PERMIT |
+| 16 | Frontend to Backend Services | Frontend VPC | Backend VPC | PERMIT |
+| 17 | Backend to Frontend Services | Backend VPC | Frontend VPC | PERMIT |
+| 20 | GKE Required GCP Services | All GKE | gcp_required WebGroup | PERMIT (HTTPS) |
+| 21 | GKE Required GCP Services HTTP | All GKE | gcp_required WebGroup | PERMIT (HTTP) |
+| 22 | Allow Kubernetes-io | All GKE | kubernetes_io WebGroup | PERMIT |
+| 23 | Allow Docker Hub | All GKE | docker_hub WebGroup | PERMIT |
+| 24 | Allow npm Registry | All GKE | npm_registry WebGroup | PERMIT |
+| 25 | Allow GitHub Aviatrix Repos | All GKE | github_aviatrix WebGroup | PERMIT |
+
+When `enable_k8s_smartgroup_demo = true` (default), an additional priority-50 rule fires between priorities 17 and 20:
+
+| Priority | Name | Source | Destination | Action |
+|---:|---|---|---|---|
+| 50 | Frontend Gatus to Backend Gatus k8s ns selector | K8s-typed SG `frontend-gatus-ns` | K8s-typed SG `backend-gatus-ns` | PERMIT |
+
+The implicit deny at the bottom of every policy list blocks anything not matched above.
+
+---
+
+## Day 2 Operations
+
+### Scale Node Pools
+
+The primary node pool autoscales from 1 to 3 nodes by default. To change the bounds:
+
+```bash
+cd clusters/frontend/
+vim terraform.tfvars
+# Edit node_pool_config = { initial_count = 2, min_count = 1, max_count = 3, machine_type = "e2-standard-2", disk_size_gb = 100 }
+
+terraform apply
+```
+
+The `lifecycle { ignore_changes = [node_count] }` on the node pool means autoscale-driven node count changes won't drift Terraform state.
+
+### Upgrade GKE Version
+
+GKE clusters in this blueprint use the `REGULAR` release channel — masters auto-upgrade according to the channel cadence and node pools auto-upgrade by default (`management.auto_upgrade = true`). To force an immediate version change:
+
+```bash
+gcloud container clusters upgrade gke-demo-frontend \
+  --zone us-central1-a --master \
+  --cluster-version 1.33.x-gke.xxx
+```
+
+The Terraform `lifecycle { ignore_changes = [min_master_version] }` block means out-of-band master version drift won't show up as `terraform plan` noise.
+
+### Add a New DCF WebGroup
+
+```hcl
+# In network/dcf.tf
+resource "aviatrix_web_group" "wg_my_service" {
+  name = "${var.name_prefix}-wg-my-service"
+  selector {
+    match_expressions {
+      snifilter = "*.example.com"
+    }
+  }
+}
+```
+
+Then add a rule to the policy list referencing the WebGroup. `terraform apply` in the network layer takes ~5 seconds.
+
+---
+
+## Destroy Instructions
+
+Always destroy in **reverse order**. Three cross-layer dependencies need explicit cleanup that Terraform doesn't handle automatically:
+
+1. **DCF CRs (`FirewallPolicy`, `WebGroupPolicy`) inject Controller-side state.** When the Aviatrix Controller's watch loop reconciles a CR it creates mirror SmartGroups and policy-list rules on the Controller (e.g., `firewallpolicysource-<ns>--<cr-name>--<cluster-hash>`, `webgrouppolicy-target-<ns>--<cr-name>--<cluster-hash>`, plus per-CR entries in the system `K8s Policy List` and per-CR `firewallpolicylist-*` lists). The watch loop **only garbage-collects this state when it observes a CR `delete` event on a still-reachable cluster.** If you destroy the cluster (or remove the Helm release that holds the CRDs) before the CRs are deleted, the watch loop never sees the delete and the Controller-side mirror state is **orphaned**. Orphans then block subsequent `aviatrix_kubernetes_cluster` destroy with `[AVXERR-SMARTGROUP-0003] ... present in one or more dfw policies`.
+2. **K8s SmartGroups in the network layer pin the cluster registrations.** The `aviatrix_kubernetes_cluster` resource cannot be deleted while any SmartGroup references its `cluster_id`. Toggle them off via `enable_k8s_smartgroup_demo = false` before destroying clusters.
+3. **ExternalDNS-created Cloud DNS records orphan if pods/Services are destroyed by Terraform without giving ExternalDNS a chance to issue the corresponding DNS deletes.** Always delete the Gatus manifests via `kubectl delete` first (graceful Service tear-down → ExternalDNS removes the A record) before tearing down the nodes layer.
+
+### Step 1: Delete Kubernetes Resources (DCF CRs first, then Gatus)
+
+> [!IMPORTANT]
+> Order matters: delete the DCF CRs **before** deleting Gatus. The CR-injected `firewallpolicysource-*` and `webgrouppolicy-target-*` SmartGroups are scoped to namespaces that exist (e.g., `gatus`, `dev`) — if the namespace is gone before the CR is deleted, the watch loop's namespace-resolved reference fails and the mirror SG can be left in a state that's hard to clean up.
+
+```bash
+# 1a. Delete DCF CRs (the watch loop tears down its mirror SmartGroups + policy rules)
+kubectl --context=frontend delete -f k8s-apps/dcf-crd/ --ignore-not-found
+kubectl --context=backend  delete -f k8s-apps/dcf-crd/ --ignore-not-found
+
+# 1b. Wait for the Controller's watch loop to finalize the deletions.
+#     Empirically ~30-60s on Controller 9.0.10 for two CRs across two clusters.
+sleep 60
+
+# 1c. Verify the CR-injected mirror state is GONE before proceeding.
+CID=$(curl -sk -X POST "https://${AVIATRIX_CONTROLLER_IP}/v1/api" \
+  -d "action=login&username=${AVIATRIX_USERNAME}&password=${AVIATRIX_PASSWORD}" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['CID'])")
+
+echo "Looking for orphan CR-injected SmartGroups (should be empty):"
+curl -sk -H "Authorization: cid ${CID}" "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/app-domains" \
+  | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for ad in d.get('app_domains', []):
+    n = ad.get('name', '')
+    if 'firewallpolicy' in n.lower() or 'webgrouppolicy' in n.lower():
+        print(f'  {n}')"
+# Expected: no output. If you see any names, the watch loop hasn't finalized yet —
+# wait another 60s and re-check, or jump to the Recovery procedure at the bottom.
+
+echo "Looking for orphan K8s policy-list rules (system list rules should be 0):"
+curl -sk -H "Authorization: cid ${CID}" "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/microseg/policy-list3" \
+  | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for pl in d.get('dcf_policies', []):
+    if pl.get('metadata', {}).get('k8s'):
+        rules = pl.get('policies', [])
+        print(f'  {pl.get(\"name\")} (uuid={pl.get(\"uuid\",\"\")[:8]}...) rules={len(rules)}')"
+# Expected:
+#   K8s Policy Block (uuid=defa11a1...) rules=0
+#   K8s Policy List  (uuid=defa11a1...) rules=0
+# Per-CR firewallpolicylist-* lists should NOT appear at all.
+
+# 1d. Delete Gatus and the Gateway/HTTPRoute (triggers ExternalDNS DNS-record cleanup
+#     and tears down the GKE Gateway-managed Global External ALB).
+kubectl --context=frontend delete -f k8s-apps/frontend/gatus.yaml --ignore-not-found
+kubectl --context=backend  delete -f k8s-apps/backend/gatus.yaml --ignore-not-found
+
+# 1e. Wait for ExternalDNS to remove the Cloud DNS records (~30-60s).
+sleep 60
+
+# 1f. Verify Cloud DNS records are cleaned up (only db.* should remain — Terraform-managed)
+gcloud dns record-sets list \
+  --project=<YOUR_PROJECT_ID> \
+  --zone=gke-demo-private-zone \
+  --format="value(name)" | grep -E "frontend|backend"
+# Expected: empty.
+```
+
+If 1c shows orphan SmartGroups after waiting 2 minutes, **do not proceed** — the watch loop didn't garbage-collect properly. Jump to the [Recovery: Orphaned CR-Injected State](#recovery-orphaned-cr-injected-state) procedure at the bottom of this section before continuing to Step 2.
+
+### Step 2: Destroy Node Layers (Parallel)
+
+```bash
+# Terminal 1
+cd nodes/frontend/ && terraform destroy
+
+# Terminal 2
+cd nodes/backend/ && terraform destroy
+```
+
+This removes the `external-dns` and `k8s-firewall` Helm releases. Removing `k8s-firewall` deletes the `FirewallPolicy` and `WebGroupPolicy` CRDs from the cluster — at this point the cluster has no DCF CRD support left, but that's fine because we already deleted all CRs in Step 1.
+
+### Step 3: Disable K8s SmartGroup Demo
+
+The K8s SmartGroups in `network/dcf-k8s.tf` and the priority-50 demo rule in `network/dcf.tf` reference the GKE cluster IDs. The Aviatrix Controller refuses to delete the `aviatrix_kubernetes_cluster` registration while any SmartGroup still references it. Disable both via the gating variable:
+
+```bash
+cd network/
+
+# Removes the 4 K8s SmartGroups and the priority-50 rule. ~10s.
+terraform apply -auto-approve -var enable_k8s_smartgroup_demo=false
+```
+
+> [!IMPORTANT]
+> If this step fails with `[AVXERR-SMARTGROUP-0003] Smart Group ... present in one or more dfw policies`, it's the same kind of eventual-consistency hiccup the AKS variant documents. The `depends_on` in `dcf.tf` is supposed to remove the priority-50 rule from the policy list before the SG delete, but in some controller builds the dynamic-rule edge gets dropped. Recovery is mechanical:
+>
+> ```bash
+> NAME_PREFIX=gke-demo
+> CID=$(curl -sk -X POST "https://${AVIATRIX_CONTROLLER_IP}/v1/api" \
+>   -d "action=login&username=${AVIATRIX_USERNAME}&password=${AVIATRIX_PASSWORD}" \
+>   | python3 -c "import sys,json; print(json.load(sys.stdin)['CID'])")
+>
+> # Build a pruned copy of the policy list (priority-50 removed) and PUT it back.
+> curl -sk -H "Authorization: cid ${CID}" \
+>   "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/microseg/policy-list3" \
+>   | NAME_PREFIX="$NAME_PREFIX" python3 -c "
+> import sys, json, os
+> target = os.environ['NAME_PREFIX'] + '-gke-multicluster'
+> d = json.load(sys.stdin)
+> for pl in d.get('dcf_policies', []):
+>     if pl.get('name') == target:
+>         pl['policies'] = [p for p in pl.get('policies', []) if p.get('priority') != 50]
+>         print(json.dumps(pl)); break" > /tmp/gke-prune.json
+> LIST_UUID=$(python3 -c "import json; print(json.load(open('/tmp/gke-prune.json'))['uuid'])")
+> curl -sk -X PUT -H "Authorization: cid ${CID}" -H "Content-Type: application/json" \
+>   --data-binary @/tmp/gke-prune.json \
+>   "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/microseg/policy-list3/${LIST_UUID}"
+>
+> # Then re-run the apply — Terraform reconciles state and completes the SG destroys.
+> terraform apply -auto-approve -var enable_k8s_smartgroup_demo=false
+> ```
+
+### Step 4: Destroy GKE Clusters (Parallel)
+
+`terraform destroy` removes the `aviatrix_kubernetes_cluster` registration as well as the GKE cluster itself.
+
+```bash
+# Terminal 1
+cd clusters/frontend/ && terraform destroy
+
+# Terminal 2
+cd clusters/backend/ && terraform destroy
+
+# Verify no stale K8s cluster registrations remain on the controller
+CID=$(curl -sk -X POST "https://${AVIATRIX_CONTROLLER_IP}/v1/api" \
+  -d "action=login&username=${AVIATRIX_USERNAME}&password=${AVIATRIX_PASSWORD}" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['CID'])")
+curl -sk -H "Authorization: cid ${CID}" \
+  "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/k8s/clusters"
+# Expected: []  (or no entries for gke-demo-*)
+```
+
+If `terraform destroy` here fails with the `cluster is still used in smart groups: ..., firewallpolicysource-..., webgrouppolicy-target-...` error, Step 1 didn't clean up the CR-injected state. Run the [Recovery procedure](#recovery-orphaned-cr-injected-state) below, then re-run `terraform destroy`.
+
+### Step 5: Destroy Network Layer
+
+```bash
+cd network/
+terraform destroy -var enable_k8s_smartgroup_demo=false
+```
+
+The `-var` is needed so the destroy plan matches the live state from Step 3 (otherwise Terraform plans to re-create the K8s SmartGroups before destroying everything).
+
+### Step 6: Clean Up kubectl Contexts (Optional)
+
+```bash
+# If you renamed the contexts in Step 7 of deployment
+kubectl config delete-context frontend
+kubectl config delete-context backend
+
+# Otherwise the auto-generated names
+kubectl config delete-context gke_<PROJECT>_us-central1-a_gke-demo-frontend
+kubectl config delete-context gke_<PROJECT>_us-central1-a_gke-demo-backend
+```
+
+### Recovery: Orphaned CR-Injected State
+
+If you skipped Step 1's CR cleanup OR the watch loop didn't finalize before the cluster was destroyed, you'll see one of these symptoms:
+
+- `terraform destroy` on a cluster fails with:
+  `failed to delete kubernetes cluster: HTTP DELETE ... cluster is still used in smart groups: ..., firewallpolicysource--<ns>--<cr-name>--<hash>, webgrouppolicy-target-<ns>--<cr-name>--<hash>`
+- CoPilot → Security → SmartGroups still shows entries with names starting `firewallpolicy-`, `firewallpolicysource-`, or `webgrouppolicy-` after both clusters are destroyed.
+- A `terraform plan` on `network/` shows phantom drift on system policy lists (`K8s Policy List`, `K8s Policy Block`).
+
+These are Controller-side records the watch loop didn't get a chance to clean up. Remove them via the Controller API:
+
+```bash
+CID=$(curl -sk -X POST "https://${AVIATRIX_CONTROLLER_IP}/v1/api" \
+  -d "action=login&username=${AVIATRIX_USERNAME}&password=${AVIATRIX_PASSWORD}" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['CID'])")
+
+# 1. Find K8s-injected per-CR policy lists (have metadata.k8s set, NOT system)
+echo "=== Per-CR policy lists (delete these) ==="
+curl -sk -H "Authorization: cid ${CID}" \
+  "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/microseg/policy-list3" \
+  | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for pl in d.get('dcf_policies', []):
+    md = pl.get('metadata', {})
+    uuid = pl.get('uuid', '')
+    # System lists start with defa11a1- and must be PUT-emptied, not DELETEd
+    if md.get('k8s') and not uuid.startswith('defa11a1-'):
+        print(f\"  DELETE: {pl.get('name')} (uuid={uuid})\")"
+
+# 2. For each non-system list (UUID NOT starting with "defa11a1-"), DELETE:
+curl -sk -X DELETE -H "Authorization: cid ${CID}" \
+  "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/microseg/policy-list3/<uuid>"
+
+# 3. For SYSTEM lists like "K8s Policy List" (defa11a1-3000-6000-4000-...), PUT
+#    with empty policies array to clear injected rules WITHOUT deleting the list.
+curl -sk -X PUT -H "Authorization: cid ${CID}" -H "Content-Type: application/json" \
+  -d '{"name":"K8s Policy List","attach_to":"defa11a1-3000-6000-5000-000000000000","policies":[],"metadata":{"k8s":{"resource-type":"k8s-policylist"}}}' \
+  "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/microseg/policy-list3/defa11a1-3000-6000-4000-000000000000"
+
+# 4. Now the orphan SmartGroups can be deleted:
+curl -sk -H "Authorization: cid ${CID}" \
+  "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/app-domains" \
+  | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for ad in d.get('app_domains', []):
+    n = ad.get('name', '')
+    if any(p in n for p in ['firewallpolicy-', 'firewallpolicysource-', 'webgrouppolicy-']):
+        print(ad['uuid'])
+" | xargs -I {} curl -sk -X DELETE -H "Authorization: cid ${CID}" \
+      "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/app-domains/{}"
+
+# 5. Verify clean
+curl -sk -H "Authorization: cid ${CID}" \
+  "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/app-domains" \
+  | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+print('Remaining CR-related app-domains:')
+for ad in d.get('app_domains', []):
+    n = ad.get('name', '')
+    if any(p in n for p in ['firewallpolicy-', 'firewallpolicysource-', 'webgrouppolicy-']):
+        print(f'  STILL PRESENT: {n}')"
+# Expected: empty (no STILL PRESENT lines).
+
+# 6. Resume Step 4 (cluster destroy) — or Step 3 if the SmartGroup demo toggle failed.
+```
+
+---
+
+## Troubleshooting
+
+### Pods Can't Reach the Internet
+
+1. **Verify the priority-991 default route is programmed in the spoke VPC:**
+   ```bash
+   gcloud compute routes list --project=<PROJECT> \
+     --filter="network:gke-demo-frontend-vpc AND priority=991" \
+     --format="table(name,priority,destRange,nextHopInstance.basename(),tags.list())"
+   ```
+   Expected: one untagged 991 route → `gke-demo-frontend-spoke`. If missing, the spoke gateway didn't finish provisioning — check `terraform apply` output and the controller's `Site2Cloud → IPSec` page.
+
+2. **Verify CONDUIT_SNAT is firing on the spoke GW:**
+   ```bash
+   ssh -tt -i <key.pem> ubuntu@$AVIATRIX_CONTROLLER_IP \
+     "bash -lic 'sshgw gke-demo-frontend-spoke -- sudo iptables -t nat -L CONDUIT_SNAT -v -n'"
+   ```
+   The rule `SNAT 100.64.0.0/16 → eth0 → 10.10.4.2` should have non-zero packet counters when pods are sending traffic. If zero counters but pods exist, traffic isn't reaching the spoke GW — check the priority-991 route and the GKE cluster's `default_snat_status.disabled`.
+
+3. **Verify the GKE node SA has the right roles:**
+   ```bash
+   gcloud projects get-iam-policy <PROJECT> \
+     --flatten="bindings[].members" \
+     --filter="bindings.members~gke-demo-frontend-node-sa" \
+     --format="value(bindings.role)"
+   ```
+   Should include `logging.logWriter`, `monitoring.metricWriter`, `monitoring.viewer`, `stackdriver.resourceMetadata.writer`, `artifactregistry.reader`.
+
+### GKE Gateway Stuck in `PROGRAMMED=False`
+
+The GKE Gateway controller takes 3-5 minutes to provision the Global External ALB on first deploy. If it's still false after 10 minutes:
+
+1. **Check Gateway events:**
+   ```bash
+   kubectl --context=frontend describe gateway frontend-public -n gatus
+   ```
+   Common errors: missing `networking.gke.io/addresses` annotation pointing at a reserved global address, or the reserved address has a region (must be `EXTERNAL` global).
+
+2. **Verify the reserved address exists and is unattached:**
+   ```bash
+   gcloud compute addresses list --global --filter="name~gke-demo-.*-gateway-ip" \
+     --format="table(name,address,addressType,status)"
+   ```
+   Status `RESERVED` is normal until the Gateway claims it (becomes `IN_USE`).
+
+3. **Check the GKE Gateway controller logs:**
+   ```bash
+   kubectl --context=frontend logs -n gke-system deployment/gke-l7-global-external-managed -c gke-l7
+   ```
+
+### ExternalDNS Not Creating DNS Records
+
+1. **Check ExternalDNS pod logs:**
+   ```bash
+   kubectl --context=frontend logs -n kube-system -l app.kubernetes.io/name=external-dns --tail=20
+   ```
+
+2. **Verify the Workload Identity binding:**
+   ```bash
+   kubectl --context=frontend describe sa external-dns -n kube-system
+   # Annotations should include iam.gke.io/gcp-service-account
+   ```
+
+3. **Verify the GSA has DNS admin role:**
+   ```bash
+   gcloud projects get-iam-policy <PROJECT> \
+     --flatten="bindings[].members" \
+     --filter="bindings.members~gke-demo-frontend-edns" \
+     --format="value(bindings.role)"
+   # Should include: roles/dns.admin
+   ```
+
+### GKE Cluster Shows "Onboarded: No" in CoPilot, or DCF CRs Aren't Reconciled
+
+After `clusters/*` and `nodes/*` apply succeed and you've applied DCF CRs from `k8s-apps/dcf-crd/`, but you don't see CR-injected SmartGroups in CoPilot (no `firewallpolicysource-*` or `webgrouppolicy-target-*` entries) and the system `K8s Policy List` shows 0 rules — the watch loop isn't reconciling. Walk these in order:
+
+1. **Check that the Controller's egress IP is in the GKE master allowlist:**
+   ```bash
+   gcloud container clusters describe gke-demo-frontend \
+     --zone us-central1-a --project <PROJECT> \
+     --format="value(masterAuthorizedNetworksConfig.cidrBlocks[].cidrBlock)"
+   # Expect to see: <controller_public_ip>/32, <spoke_gw_public_ip>/32, your IP
+   ```
+   If the controller IP is missing, set `aviatrix_controller_public_ip` in the cluster's `terraform.tfvars` and re-apply. (When `master_authorized_cidr_blocks = ["0.0.0.0/0"]`, this isn't needed — the controller is implicitly allowed.)
+
+2. **Verify the Aviatrix GCP access account's SA has GKE permissions:**
+   ```bash
+   # Find the access account's SA email
+   SA_EMAIL=$(curl -sk -H "Authorization: cid ${CID}" \
+     "https://${AVIATRIX_CONTROLLER_IP}/v1/api?action=list_accounts&CID=${CID}" \
+     | python3 -c "
+   import sys, json
+   d = json.load(sys.stdin)
+   for a in d['results']['account_list']:
+       if a.get('account_name') == 'Google':
+           print(a.get('gcloud_project_credentials_filename', ''))")
+
+   # Show roles assigned to that SA on the project
+   gcloud projects get-iam-policy <PROJECT> \
+     --flatten="bindings[].members" \
+     --filter="bindings.members:${SA_EMAIL}" \
+     --format="value(bindings.role)"
+   # Required permissions: container.clusters.get, container.clusters.getCredentials.
+   # roles/editor, roles/container.admin, roles/container.clusterAdmin all include them.
+   # roles/container.clusterViewer alone is NOT sufficient — it lacks getCredentials.
+   ```
+
+3. **Confirm the cluster registration exists on the Controller:**
+   ```bash
+   CID=$(curl -sk -X POST "https://${AVIATRIX_CONTROLLER_IP}/v1/api" \
+     -d "action=login&username=${AVIATRIX_USERNAME}&password=${AVIATRIX_PASSWORD}" \
+     | python3 -c "import sys,json; print(json.load(sys.stdin)['CID'])")
+   curl -sk -H "Authorization: cid ${CID}" \
+     "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/k8s/clusters" | python3 -m json.tool
+   ```
+   Both clusters should appear with `use_csp_credentials: true`.
+
+4. **Confirm the watch loop is actually reconciling.** The fastest way is to look for CR-injected SmartGroups + system-list rules:
+   ```bash
+   echo "=== CR-injected SmartGroups (should appear within ~60s of CR apply) ==="
+   curl -sk -H "Authorization: cid ${CID}" "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/app-domains" \
+     | python3 -c "
+   import sys, json
+   d = json.load(sys.stdin)
+   for ad in d.get('app_domains', []):
+       n = ad.get('name', '')
+       if 'firewallpolicy' in n.lower() or 'webgrouppolicy' in n.lower():
+           print(f'  {n}')"
+   # Expected after applying k8s-apps/dcf-crd/:
+   #   firewallpolicy-gatus--infosec-egress--security-tools--<hash>
+   #   firewallpolicy-smartgroup-gatus--infosec-egress--public-internet--<hash>
+   #   firewallpolicysource--gatus--infosec-egress--<hash>--2--0
+   #   webgrouppolicy-dev--dev-external-apis--<hash>
+   #   webgrouppolicy-target-dev--dev-external-apis--<hash>
+
+   echo "=== K8s system policy lists (should have 1+ rule per CR) ==="
+   curl -sk -H "Authorization: cid ${CID}" "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/microseg/policy-list3" \
+     | python3 -c "
+   import sys, json
+   d = json.load(sys.stdin)
+   for pl in d.get('dcf_policies', []):
+       if pl.get('metadata', {}).get('k8s'):
+           print(f\"  {pl.get('name')} rules={len(pl.get('policies',[]))}\")"
+   # Expected:
+   #   K8s Policy Block rules=0       (nothing in the FirewallPolicy DENY semantics for these CRs)
+   #   K8s Policy List  rules=2       (one per cluster, from webgrouppolicy)
+   #   firewallpolicylist-gatus--infosec-egress--<hash> rules=1   (one per cluster, from firewallpolicy)
+   ```
+   If the registration exists (step 3) but the SmartGroups + rules in step 4 are missing, try **forcing a re-onboard**:
+   ```bash
+   cd clusters/frontend/
+   terraform taint 'aviatrix_kubernetes_cluster.this[0]'
+   terraform apply
+   ```
+   The taint causes Terraform to delete and re-create the registration, which re-triggers the controller's onboarding handshake. Wait ~60s after apply for the watch loop to spin up, then re-check step 4. **Note:** if there are already CR-injected SmartGroups present, the destroy half of the taint will fail with `cluster is still used in smart groups` — that's expected; it confirms the watch loop IS working. In that case the registration was healthy all along; check CoPilot UI directly.
+
+5. **Check CoPilot directly.** The controller API only confirms registration; CoPilot is the only surface that exposes resolved pod-IP membership for K8s-typed SmartGroups. Cloud Workloads → Kubernetes Clusters should show **Onboarded: Yes** with namespace and pod counts. First-time sync after onboarding can take up to ~10 minutes.
+
+### Cross-Cluster East-West Pings/Curls Time Out
+
+1. **Verify the priority-991 route on both spoke VPCs** (see "Pods Can't Reach the Internet" #1).
+
+2. **Verify CONDUIT_SNAT has the transit-direction rule** (rule 2 in the chain — `dst-group 0x1`):
+   ```bash
+   ssh -tt -i <key.pem> ubuntu@$AVIATRIX_CONTROLLER_IP \
+     "bash -lic 'sshgw gke-demo-frontend-spoke -- sudo iptables -t nat -L CONDUIT_SNAT -v -n'"
+   ```
+   If only the eth0 rule exists, the `connection = module.gcp_transit.transit_gateway.gw_name` policy didn't apply — check the network layer's `aviatrix_gateway_snat` resource state.
+
+3. **Verify the IPsec tunnel is up (Aviatrix CoPilot → Topology):** both spoke gateways should show green to the transit gateway.
+
+4. **Check transit-side BGP** for the pod CIDR. The blueprint uses `excluded_advertised_spoke_routes = "100.64.0.0/16"` so pod CIDRs are NOT advertised to peers (that's intentional — SNAT covers it).
+
+### Aviatrix Controller Errors on `aviatrix_gateway_snat` Apply
+
+If the apply fails with `Failed to register gateway with controller` or `gateway not ready`:
+
+1. The spoke gateway and the SNAT resource race during first apply. **Wait 30-60 seconds and re-run `terraform apply`** — the spoke GW finishes its IPsec tunnel setup and accepts the SNAT config on the retry.
+
+2. Check the controller's `Multi-Cloud Transit → Gateways` page. The spoke gateway should show **Up** with all tunnels green.
+
+### Terraform Remote State Errors
+
+If a layer fails with `No such file or directory` for a state file:
+```
+Error: Failed to read state file
+path = "../../network/terraform.tfstate"
+```
+
+Ensure the previous layer has been successfully applied:
+```bash
+ls -la network/terraform.tfstate
+ls -la clusters/frontend/terraform.tfstate
+```
+
+The deployment order is `network → clusters → nodes`. Each layer requires the previous to have completed `terraform apply`.
+
+### `gke-gcloud-auth-plugin` Not Found
+
+```
+error: gke-gcloud-auth-plugin must be installed
+```
+
+Install:
+```bash
+gcloud components install gke-gcloud-auth-plugin
+```
+
+After installing, re-run `gcloud container clusters get-credentials` so kubeconfig regenerates with the correct exec credential.
+
+---
+
+## Resource Inventory
+
+### Compute Resources
+
+| Component | Resource Type | Qty | Machine Type | Notes |
+|-----------|---------------|----:|--------------|-------|
+| **Aviatrix Gateways** | | | | |
+| Transit GW | GCE VM | 1 | n1-standard-1 | Zonal (us-central1-a), no HA |
+| Frontend Spoke GW | GCE VM | 1 | n1-standard-1 | `customized_snat`, no HA |
+| Backend Spoke GW | GCE VM | 1 | n1-standard-1 | `customized_snat`, no HA |
+| DB Spoke GW | GCE VM | 1 | n1-standard-1 | `single_ip_snat`, no HA |
+| **GKE** | | | | |
+| Frontend Control Plane | GKE | 1 | — | Zonal, REGULAR channel, Free tier |
+| Backend Control Plane | GKE | 1 | — | Zonal, REGULAR channel, Free tier |
+| Frontend Node Pool | GCE MIG | 2 (desired) | e2-standard-2 | min=1, max=3, autoscale |
+| Backend Node Pool | GCE MIG | 2 (desired) | e2-standard-2 | min=1, max=3, autoscale |
+| **Test VM** | | | | |
+| DB Linux VM | GCE VM | 1 | e2-small | DB spoke, Apache |
+
+**Total VMs (at desired state):** 9
+
+### Networking Resources
+
+| Component | Qty | Details |
+|-----------|----:|---------|
+| VPCs | 4 | Transit (`10.2.0.0/24`), Frontend (`10.10.0.0/20`), Backend (`10.20.0.0/20`), DB (`10.5.0.0/22`) |
+| Subnets | 11 | Per spoke VPC: nodes, Aviatrix GW, proxy-only. DB: VMs subnet + Aviatrix GW subnet. Transit: 1. |
+| Cloud Routes (Aviatrix-managed) | ~16 | Per spoke: priority-500 IGW (tagged), priority-991 default (untagged) → spoke GW, three RFC1918 → spoke GW |
+| Reserved Global IPv4 | 2 | One per cluster's GKE Gateway |
+| Cloud DNS Private Zone | 1 | `gcp.aviatrixdemo.local.` linked to all 3 spoke VPCs |
+| Static DNS Records | 1 | `db.gcp.aviatrixdemo.local` → DB VM IP |
+| GCP Firewall Rules | ~12 | Created by `gke-vpc` module (allow internal + allow GKE control plane to nodes) |
+
+### Subnet Layout (per Spoke VPC, example: Frontend `10.10.0.0/20`)
+
+| Subnet Name | CIDR | Size | Purpose | Secondary Ranges |
+|---|---|---:|---|---|
+| `gke-demo-frontend-nodes` | `10.10.0.0/22` | 1024 IPs | GKE node VMs | pods (`100.64.0.0/16`), services (`172.16.0.0/20`) |
+| `gke-demo-frontend-avx-gw` | `10.10.4.0/28` | 16 IPs | Aviatrix spoke gateway | — |
+| `gke-demo-frontend-proxy-only` | `10.10.5.0/24` | 256 IPs | GKE Gateway proxies | — |
+
+### DCF Inventory
+
+| Component | Qty | Names (with `name_prefix = gke-demo`) |
+|---|---:|---|
+| SmartGroups (VPC-typed) | 4 | `gke-demo-sg-{frontend,backend,db}-vpc`, `gke-demo-sg-all-gke` |
+| SmartGroups (service-typed) | 3 | `gke-demo-sg-{frontend,backend}-service`, `gke-demo-sg-database` |
+| SmartGroups (threat) | 2 | `gke-demo-sg-geo-blocked`, `gke-demo-sg-threat-intel` |
+| SmartGroups (K8s-typed, gated) | 4 | `gke-demo-sg-{frontend,backend}-cluster`, `gke-demo-sg-{frontend,backend}-gatus-ns` |
+| WebGroups | 5 | `gke-demo-wg-{kubernetes-io,docker-hub,npm-registry,github-aviatrix,gcp-required}` |
+| Policy lists | 1 | `gke-demo-gke-multicluster` (12 rules + optional priority-50) |
+
+---
+
+## Monthly Cost Estimate (us-central1, On-Demand)
+
+> Prices are on-demand rates as of early 2026. Actual costs vary with traffic, autoscaling, sustained-use discounts (up to ~30% on continuous VMs), and committed-use discounts (up to ~57%). Aviatrix licensing is billed separately and not included below.
+
+### Compute
+
+| Resource | Machine Type | Qty | Hourly | Monthly (730 hrs) |
+|---|---|---:|---:|---:|
+| Aviatrix Transit GW | n1-standard-1 | 1 | $0.0475 | $34.68 |
+| Aviatrix Frontend Spoke GW | n1-standard-1 | 1 | $0.0475 | $34.68 |
+| Aviatrix Backend Spoke GW | n1-standard-1 | 1 | $0.0475 | $34.68 |
+| Aviatrix DB Spoke GW | n1-standard-1 | 1 | $0.0475 | $34.68 |
+| GKE Frontend Nodes | e2-standard-2 | 2 | $0.0670 ea | $97.82 |
+| GKE Backend Nodes | e2-standard-2 | 2 | $0.0670 ea | $97.82 |
+| DB Test VM | e2-small | 1 | $0.0167 | $12.19 |
+| **Subtotal Compute** | | | | **$346.55** |
+
+### GKE Control Plane
+
+| Resource | Tier | Qty | Hourly | Monthly |
+|---|---|---:|---:|---:|
+| Frontend Control Plane | Standard (zonal) | 1 | $0.10 | $73.00 |
+| Backend Control Plane | Standard (zonal) | 1 | $0.10 | $73.00 |
+| **Subtotal GKE Control Plane** | | | | **$146.00** |
+
+> GKE Standard charges $0.10/hr per cluster. The first cluster per billing account is free under the GKE free tier.
+
+### Load Balancers (Global External ALB)
+
+| Component | Rate | Qty | Monthly |
+|---|---:|---:|---:|
+| GKE Gateway forwarding rules | $0.025/hr | 2 | $36.50 |
+| Data processing | $0.008/GB | ~20 GB | ~$0.16 |
+| **Subtotal Load Balancers** | | | **~$36.66** |
+
+### Networking
+
+| Resource | Rate | Qty | Monthly |
+|---|---:|---:|---:|
+| Reserved Global Static IPs (when in use) | Free while attached | 2 | $0.00 |
+| Cloud DNS Private Zone | $0.20/zone/month | 1 | $0.20 |
+| Cloud DNS queries | $0.40/M (first 1B) | ~1M | ~$0.40 |
+| VPC, subnets, routes | Free | — | $0.00 |
+| **Subtotal Networking** | | | **~$0.60** |
+
+### Storage
+
+| Resource | Type | Qty | Monthly |
+|---|---|---:|---:|
+| GKE Node OS Disks (100 GB pd-balanced) | Persistent disk balanced | 4 | $40.00 |
+| Aviatrix GW OS Disks (~10 GB pd-standard) | Persistent disk standard | 4 | ~$1.60 |
+| DB VM OS Disk (10 GB pd-balanced) | Persistent disk balanced | 1 | $1.00 |
+| **Subtotal Storage** | | | **~$42.60** |
+
+### Data Transfer (Estimated for Lab Workloads)
+
+| Type | Est. Volume | Rate | Monthly |
+|---|---:|---:|---:|
+| Cross-VPC via Aviatrix transit (in-region) | ~50 GB | Free (same region) | $0.00 |
+| Internet egress | ~10 GB | $0.12/GB | ~$1.20 |
+| **Subtotal Data Transfer** | | | **~$1.20** |
+
+### Total Estimated Monthly Cost
+
+| Category | Cost |
+|---|---:|
+| Compute | $346.55 |
+| GKE Control Plane | $146.00 |
+| Load Balancers | $36.66 |
+| Networking | $0.60 |
+| Storage | $42.60 |
+| Data Transfer | $1.20 |
+| **Total** | **~$573/month** |
+
+> **Lab cost optimization:** if you run this only during business hours (8 hrs × 22 days = 176 hrs/month vs 730), you can scale to **~$138/month**. For destroy-and-redeploy daily use (40 hrs/month), expect **~$31/month**. The bulk of the cost is the four `n1-standard-1` Aviatrix gateways + four `e2-standard-2` GKE nodes + two GKE control planes.
+
+---
+
+## Networking Details
+
+### CIDR Plan
+
+| Layer | CIDR | Notes |
+|---|---|---|
+| Aviatrix Transit | `10.2.0.0/24` | Single-AZ transit GW. `excluded_advertised_spoke_routes = 100.64.0.0/16`. |
+| Frontend VPC | `10.10.0.0/20` | nodes `10.10.0.0/22`, GW `10.10.4.0/28`, proxy-only `10.10.5.0/24` |
+| Backend VPC | `10.20.0.0/20` | nodes `10.20.0.0/22`, GW `10.20.4.0/28`, proxy-only `10.20.5.0/24` |
+| DB VPC | `10.5.0.0/22` | VMs `10.5.0.0/24`, GW `10.5.1.0/28` |
+| GKE pods (both clusters) | `100.64.0.0/16` | Overlapping by design — Aviatrix `customized_snat` makes overlap invisible east-west |
+| GKE services (both clusters) | `172.16.0.0/20` | ClusterIP range; never leaves the cluster |
+| Frontend GKE master | `172.20.0.0/28` | Private master endpoint range |
+| Backend GKE master | `172.20.1.0/28` | Private master endpoint range |
+
+### Cloud Route Tables (per Spoke VPC)
+
+The Aviatrix Controller programs four routes per spoke VPC. With `name_prefix = gke-demo`, on the frontend VPC:
+
+| Priority | Destination | Next Hop | Tags | Purpose |
+|---:|---|---|---|---|
+| 500 | `0.0.0.0/0` | `default-internet-gateway` | `avx-gke-demo-frontend-vpc-gbl` | Spoke GW VM's own internet egress |
+| 991 | `0.0.0.0/0` | spoke GW VM | (none — untagged per AVX-71737) | All other VMs (GKE nodes, pods) → spoke GW |
+| 1000 | `10.0.0.0/8` | spoke GW VM | (none) | RFC1918 → transit |
+| 1000 | `172.16.0.0/12` | spoke GW VM | (none) | RFC1918 → transit |
+| 1000 | `192.168.0.0/16` | spoke GW VM | (none) | RFC1918 → transit |
+
+The priority-500 route is the lowest-priority `0/0 → IGW` route that exists, but its tag (`avx-<vpc>-gbl`) restricts it to the Aviatrix GW VM. The priority-991 route is **untagged**, so it applies to every other VM in the VPC including GKE nodes and pods. This is the heart of how Aviatrix gets pod traffic to the spoke GW for SNAT and DCF inspection.
+
+---
+
+## Tested With
+
+| Component | Version |
+|---|---|
+| Terraform | 1.14.0 |
+| Aviatrix Provider (`AviatrixSystems/aviatrix`) | ~> 8.2 (8.2.0 verified) |
+| Google Provider (`hashicorp/google`) | ~> 6.0 (6.50.0 verified) |
+| Kubernetes Provider (`hashicorp/kubernetes`) | ~> 2.30 |
+| Helm Provider (`hashicorp/helm`) | ~> 2.16 |
+| Aviatrix Controller | 9.0.10-1000.116 |
+| Aviatrix CoPilot | 9.0.x |
+| Aviatrix Gateway Image | 9.0.10-1000.116 |
+| Aviatrix `mc-transit` module | ~> 8.0 (8.2.0 verified) |
+| Aviatrix `mc-spoke` module | ~> 8.0 (8.2.3 verified) |
+| GKE | 1.33 (REGULAR channel, varies — see `kubectl version` after deploy) |
+| ExternalDNS Helm chart | 1.15.0 |
+| Aviatrix `k8s-firewall` Helm chart | 1.0.0 |
+| `gcloud` SDK | latest |
+| `kubectl` | latest |
+
+---
+
+## Variables
+
+### `network/` Layer Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `name_prefix` | string | `"gke-demo"` | Prefix for all resource names. |
+| `aviatrix_controller_ip` | string | `null` | Aviatrix Controller IP/hostname. Leave null and export `AVIATRIX_CONTROLLER_IP` instead. |
+| `aviatrix_username` | string | `null` | Aviatrix Controller username. Leave null and export `AVIATRIX_USERNAME` instead. |
+| `aviatrix_password` | string (sensitive) | `null` | Aviatrix Controller password. Leave null and export `AVIATRIX_PASSWORD` instead. |
+| `aviatrix_gcp_account_name` | string | — | **Required.** Aviatrix GCP access account name (configured in Controller — typically `"Google"`). |
+| `gcp_project_id` | string | — | **Required.** GCP project that owns the VPCs, GKE clusters, and DB VM. |
+| `gcp_region` | string | `"us-central1"` | GCP region for subnets and zonal resources. |
+| `gcp_zone` | string | `"us-central1-a"` | GCP zone for zonal GKE clusters and the DB VM. |
+| `gw_instance_size` | string | `"n1-standard-1"` | GCE machine type for the Aviatrix transit + spoke gateways. Step up to `n1-standard-4` or higher for bandwidth-heavy workloads. |
+| `transit_cidr` | string | `"10.2.0.0/24"` | CIDR for the Aviatrix Transit VPC. |
+| `frontend_vpc_cidr` | string | `"10.10.0.0/20"` | Aggregate CIDR documented for the frontend VPC. |
+| `frontend_nodes_cidr` | string | `"10.10.0.0/22"` | Primary CIDR for the frontend GKE node subnet. |
+| `frontend_avx_gw_cidr` | string | `"10.10.4.0/28"` | Aviatrix spoke GW subnet CIDR for frontend. |
+| `frontend_proxy_only_cidr` | string | `"10.10.5.0/24"` | Regional proxy-only subnet CIDR for frontend (used by GCP-managed L7 ALB / Gateway API). |
+| `frontend_master_cidr` | string | `"172.20.0.0/28"` | GKE control-plane CIDR (/28) for the frontend cluster. |
+| `backend_vpc_cidr` | string | `"10.20.0.0/20"` | Aggregate CIDR documented for the backend VPC. |
+| `backend_nodes_cidr` | string | `"10.20.0.0/22"` | Primary CIDR for the backend GKE node subnet. |
+| `backend_avx_gw_cidr` | string | `"10.20.4.0/28"` | Aviatrix spoke GW subnet CIDR for backend. |
+| `backend_proxy_only_cidr` | string | `"10.20.5.0/24"` | Regional proxy-only subnet CIDR for backend. |
+| `backend_master_cidr` | string | `"172.20.1.0/28"` | GKE control-plane CIDR (/28) for the backend cluster. |
+| `db_vpc_cidr` | string | `"10.5.0.0/22"` | Aggregate CIDR for the DB test VPC. |
+| `db_subnet_cidr` | string | `"10.5.0.0/24"` | Primary subnet CIDR for the DB test VM. |
+| `db_avx_gw_cidr` | string | `"10.5.1.0/28"` | Aviatrix spoke GW subnet CIDR for the DB VPC. |
+| `frontend_pods_cidr` | string | `"100.64.0.0/16"` | Pod alias range for the frontend GKE cluster. Default overlaps with backend by design (Aviatrix spoke GW SNATs pod IPs); use non-overlapping ranges for working east-west on GCP. |
+| `backend_pods_cidr` | string | `"100.64.0.0/16"` | Pod alias range for the backend GKE cluster. See `frontend_pods_cidr` notes. |
+| `services_cidr` | string | `"172.16.0.0/20"` | GKE Services secondary range — overlapping by design (kube-internal, never leaves the cluster). |
+| `private_dns_zone_name` | string | `"gcp.aviatrixdemo.local."` | Cloud DNS private zone DNS name (must end with `.`). |
+| `enable_k8s_smartgroup_demo` | bool | `true` | Create K8s-typed SmartGroups + the priority-50 demo DCF rule. Set to `false` and apply BEFORE destroying clusters/* (the K8s registration cannot be deleted while these SmartGroups reference its `cluster_id`). |
+
+### `clusters/<frontend|backend>/` Layer Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `node_pool_config` | object | `{ machine_type = "e2-standard-2", disk_size_gb = 50, initial_count = 2, min_count = 1, max_count = 3 }` | Sizing for the primary GKE node pool. |
+| `master_authorized_cidr_blocks` | list(string) | `["0.0.0.0/0"]` | User CIDR blocks allowed to reach the GKE master endpoint. The Aviatrix spoke GW egress IP and (when onboarding is on) the Controller IP are appended automatically. |
+| `enable_aviatrix_onboarding` | bool | `true` | Register this GKE cluster with the Aviatrix Controller so DCF SmartGroups can target k8s clusters/namespaces/services/pods. |
+| `aviatrix_controller_ip` | string | `null` | Aviatrix Controller IP/hostname (or set `AVIATRIX_CONTROLLER_IP` env var). |
+| `aviatrix_username` | string | `null` | Aviatrix Controller username (or set `AVIATRIX_USERNAME` env var). |
+| `aviatrix_password` | string (sensitive) | `null` | Aviatrix Controller password (or set `AVIATRIX_PASSWORD` env var). |
+| `aviatrix_controller_public_ip` | string | `null` | Public egress IP of the Controller, appended to GKE `master_authorized_networks` when `enable_aviatrix_onboarding = true`. Required only when `master_authorized_cidr_blocks` is restrictive. |
+
+### `nodes/<frontend|backend>/` Layer Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `external_dns_chart_version` | string | `"1.15.0"` | ExternalDNS Helm chart version (must support `gateway-httproute` source — chart >= 1.14). |
+| `k8s_firewall_chart_version` | string | `"9.0.0"` | Aviatrix k8s-firewall Helm chart version (8.2.0 or 9.0.0 — published in https://aviatrixsystems.github.io/k8s-firewall-charts/index.yaml). |
+
+---
+
+## Outputs
+
+### `network/` Layer Outputs
+
+| Output | Type | Description |
+|---|---|---|
+| `name_prefix` | string | The blueprint's `name_prefix` (default `gke-demo`). Used by downstream layers for resource naming. |
+| `gcp_project_id` | string | The GCP project ID. |
+| `gcp_region` | string | The GCP region (e.g., `us-central1`). |
+| `gcp_zone` | string | The GCP zone (e.g., `us-central1-a`). |
+| `private_dns_zone_name` | string | Cloud DNS private zone DNS name (`gcp.aviatrixdemo.local.`). |
+| `frontend_cluster_name` / `backend_cluster_name` | string | GKE cluster name (e.g., `gke-demo-frontend`). |
+| `frontend_cluster_id` / `backend_cluster_id` | string | GKE cluster `self_link` (used by Aviatrix Controller for K8s SmartGroups). |
+| `frontend_vpc_name` / `backend_vpc_name` | string | VPC name. |
+| `frontend_vpc_self_link` / `backend_vpc_self_link` | string | VPC self-link (consumed by `clusters/`). |
+| `frontend_nodes_subnet_name` / `backend_nodes_subnet_name` | string | Node subnet name. |
+| `frontend_pods_range_name` / `backend_pods_range_name` | string | Pod alias range name. |
+| `frontend_services_range_name` / `backend_services_range_name` | string | Service alias range name. |
+| `frontend_master_cidr` / `backend_master_cidr` | string | GKE master endpoint CIDR. |
+| `frontend_spoke_gateway_public_ip` / `backend_spoke_gateway_public_ip` | string | Spoke GW public egress IP (also the SNAT source for pod-to-internet). |
+| `frontend_gateway_global_ip_name` / `backend_gateway_global_ip_name` | string | Reserved global IPv4 resource name (referenced by GKE Gateway). |
+| `frontend_gateway_global_ip_address` / `backend_gateway_global_ip_address` | string | The actual IPv4 address (this is what you point a browser at). |
+| `frontend_pods_cidr` / `backend_pods_cidr` | string | Pod CIDR (default `100.64.0.0/16` for both). |
+| `services_cidr` | string | Service CIDR (default `172.16.0.0/20`). |
+| `dcf_ruleset_uuid` | string | UUID of the DCF policy list. |
+| `smartgroup_*_uuid` | string | UUIDs of all SmartGroups (for cross-layer references). |
+| `webgroup_*_uuid` | string | UUIDs of all WebGroups. |
+
+### `clusters/<x>/` Layer Outputs
+
+| Output | Type | Description |
+|---|---|---|
+| `cluster_name` | string | GKE cluster name. |
+| `cluster_endpoint` | string | GKE master endpoint hostname (no `https://` prefix). |
+| `cluster_ca_certificate` | string (sensitive) | Cluster CA in base64. |
+| `cluster_self_link` | string | Cluster self-link. |
+| `external_dns_service_account_email` | string | GSA email for the ExternalDNS Workload Identity binding. |
+| `node_service_account_email` | string | GSA email for the node pool. |
+| `workload_identity_pool` | string | Workload Identity pool (`<project>.svc.id.goog`). |
+
+### `nodes/<x>/` Layer Outputs
+
+| Output | Type | Description |
+|---|---|---|
+| `external_dns_namespace` | string | Always `kube-system`. |
+| `k8s_firewall_namespace` | string | Always `k8s-firewall`. |
+
+---
+
+## Known Limitations
+
+- **No HA on Aviatrix gateways.** All gateways are deployed `ha_gw = false` for cost reasons. For production, set `ha_gw = true` on each `mc-spoke` and `mc-transit` module call.
+- **Single-zone GKE clusters.** Both clusters are zonal (us-central1-a). For HA across zones, switch to a regional cluster (`location = local.region`) and update `clusters/*/main.tf`'s `frontend_cluster_id` local in `network/main.tf` to use `/locations/<region>/` instead of `/zones/<zone>/`.
+- **Single project.** All VPCs and clusters live in one GCP project. Cross-project Aviatrix transit is supported by the controller but requires Shared VPC setup not in this blueprint.
+- **DB VM is unmanaged.** Apache is installed via startup-script and not Terraform-managed beyond the VM. Reapply the VM module to refresh.
+
+---
+
+## Additional Resources
+
+- [Aviatrix Distributed Cloud Firewall (DCF) Documentation](https://docs.aviatrix.com/documentation/latest/network-security/distributed-cloud-firewall.html)
+- [Aviatrix `mc-spoke` module on Terraform Registry](https://registry.terraform.io/modules/terraform-aviatrix-modules/mc-spoke/aviatrix)
+- [Aviatrix `mc-transit` module on Terraform Registry](https://registry.terraform.io/modules/terraform-aviatrix-modules/mc-transit/aviatrix)
+- [GKE Gateway API](https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api)
+- [GKE Dataplane V2](https://cloud.google.com/kubernetes-engine/docs/concepts/dataplane-v2)
+- [ExternalDNS for GCP Cloud DNS](https://kubernetes-sigs.github.io/external-dns/v0.14.0/tutorials/gke/)
+- Sibling blueprints: [`aws-eks-multicluster`](../aws-eks-multicluster/), [`azure-aks-multicluster`](../azure-aks-multicluster/)
+
+---
+
+## GCP-Specific Gotchas (Reference)
+
+These are the GCP-only quirks worth knowing if you adapt this blueprint:
+
+- **Aviatrix `vpc_id` for GCP** has the form `<vpc_name>~-~<project_id>`, not the GCP self-link. Composed locally in `gke-vpc/outputs.tf`.
+- **Aviatrix gateway `region`** for GCP is a **zone** (`us-central1-a`), not a region. Aviatrix gateways on GCP are zonal.
+- **`single_ip_snat = true` only covers internet egress on GCP.** Cross-cluster east-west via the IPsec transit is **not** SNATed. With overlapping pod CIDRs, this leads to pod-IP collisions at the destination spoke. Use `customized_snat` with explicit `connection =` policies (as this blueprint does).
+- **GKE secondary alias ranges aren't enumerated in the controller's `vpc_cidr` list.** This was previously believed to break customized_snat route programming on GCP — verified end-to-end on Controller 9.0.10-1000.116 that the priority-991 default route is programmed correctly via the spoke-creation path, independent of the SNAT policy. Cross-validated by `gcloud compute routes list` after `terraform apply` of this blueprint.
+- **The 991 route is untagged** (per AVX-71737) so it applies to GKE-managed nodes that don't carry the legacy `avx-snat-noip` tag.
+- **GKE master authorized networks must include the Aviatrix spoke GW egress IP.** The `clusters/*` layer appends it automatically. When `enable_aviatrix_onboarding=true` and `master_authorized_cidr_blocks` is restrictive, also set `aviatrix_controller_public_ip` so the controller can reach the master endpoint during onboarding.

--- a/blueprints/gcp-gke-multicluster/architecture.svg
+++ b/blueprints/gcp-gke-multicluster/architecture.svg
@@ -1,0 +1,627 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1200" width="1600" height="1200">
+<defs>
+    <filter id="shadow-sm" x="-2%" y="-2%" width="104%" height="108%">
+        <feDropShadow dx="0" dy="1" stdDeviation="1" flood-color="#000" flood-opacity="0.10"/>
+    </filter>
+    <filter id="shadow-md" x="-2%" y="-2%" width="104%" height="108%">
+        <feDropShadow dx="0" dy="1" stdDeviation="1.5" flood-color="#000" flood-opacity="0.12"/>
+    </filter>
+    <linearGradient id="avx-gradient" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0%" stop-color="#fa6b1e"/>
+        <stop offset="100%" stop-color="#e24c01"/>
+    </linearGradient>
+    <linearGradient id="gcp-gradient" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0%" stop-color="#4285F4"/>
+        <stop offset="100%" stop-color="#1A73E8"/>
+    </linearGradient>
+    <marker id="arrow-end" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#78909C"/>
+    </marker>
+    <marker id="arrow-orange" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#fa6b1e"/>
+    </marker>
+    <marker id="arrow-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#1565C0"/>
+    </marker>
+    <marker id="arrow-purple" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#6A1B9A"/>
+    </marker>
+    <marker id="arrow-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#2E7D32"/>
+    </marker>
+
+    <!-- GKE icon (compact) -->
+    <symbol id="ic-gke" viewBox="0 0 512 512">
+        <path fill="#34A853" d="M256,459c-2.7,0-5.4-.7-7.8-2l-166.2-93.5c-5-2.8-8.2-8.2-8.2-14v-187c0-5.8,3.1-11.1,8.2-13.9L248.2,55c4.9-2.7,10.8-2.7,15.7,0l166.2,93.5c5,2.8,8.2,8.2,8.2,13.9v187c0,5.8-3.1,11.1-8.2,14l-166.2,93.5c-2.4,1.4-5.1,2-7.8,2h0ZM105.8,340.1l150.2,84.5,150.2-84.5v-168.3l-150.2-84.5-150.2,84.5v168.3Z"/>
+        <path fill="#4285F4" d="M422.2,367.9l-90.9-51.2c-7.7-4.3-10.4-14.1-6.1-21.8s14.1-10.4,21.8-6.1l59.3,33.3v-187s21.5,12.1,23.9,13.4c.8.5,1.6,1,2.3,1.6,3.6,2.9,5.8,7.4,5.8,12.4v187c0,5.7-3,10.9-7.9,13.8-2.5,1.5-8.1,4.5-8.1,4.5h0Z"/>
+        <path fill="#FBBC04" d="M81.7,363.3c-4.9-2.9-7.9-8.1-7.9-13.8v-187c0-6,3.3-11.2,8.2-13.9,2.3-1.3,23.8-13.4,23.8-13.4v187l59.3-33.3c7.7-4.3,17.5-1.6,21.8,6.1,4.3,7.7,1.6,17.5-6.1,21.8l-90.9,51.2s-5.6-3.1-8.1-4.5h0Z"/>
+        <path fill="#EA4335" d="M339.1,225.2c-2.7,0-5.4-.7-7.8-2.1l-75.3-42.3-75.3,42.3c-7.7,4.3-17.5,1.6-21.8-6.1-4.3-7.7-1.6-17.5,6.1-21.8l83.1-46.8c4.9-2.7,10.8-2.7,15.7,0l83.1,46.8c7.7,4.3,10.4,14.1,6.1,21.8-2.9,5.2-8.4,8.2-14,8.2h0Z"/>
+    </symbol>
+
+    <!-- GCE / Compute Engine icon (compact) -->
+    <symbol id="ic-gce" viewBox="0 0 512 512">
+        <path fill="#4285F4" d="M380.7,396.7h-249.3c-8.8,0-16-7.2-16-16v-249.3c0-8.8,7.2-16,16-16h249.3c8.8,0,16,7.2,16,16v249.3c0,8.8-7.2,16-16,16ZM147.3,364.7h217.3v-217.3h-217.3v217.3Z"/>
+        <path fill="#34A853" d="M315,331h-118c-8.8,0-16-7.2-16-16v-118c0-8.8,7.2-16,16-16h118c8.8,0,16,7.2,16,16v118c0,8.8-7.2,16-16,16ZM213,299h86v-86h-86v86Z"/>
+        <path fill="#EA4335" d="M349.5,147.3c-8.8,0-16-7.2-16-16v-62.3c0-8.8,7.2-16,16-16s16,7.2,16,16v62.3c0,8.8-7.2,16-16,16Zm-93.5,0c-8.8,0-16-7.2-16-16v-62.3c0-8.8,7.2-16,16-16s16,7.2,16,16v62.3c0,8.8-7.2,16-16,16Z"/>
+        <path fill="#FBBC04" d="M162.5,147.3c-8.8,0-16-7.2-16-16v-62.3c0-8.8,7.2-16,16-16s16,7.2,16,16v62.3c0,8.8-7.2,16-16,16Z"/>
+    </symbol>
+
+    <!-- Networking icon (used for GKE Gateway / Global ALB) -->
+    <symbol id="ic-glb" viewBox="0 0 512 512">
+        <path fill="#4285F4" d="M309.033,202.967c-29.242-29.242-76.824-29.242-106.066,0l-22.627-22.627c20.21-20.21,47.08-31.34,75.66-31.34s55.45,11.13,75.66,31.34l-22.627,22.627h0Z"/>
+        <path fill="#4285F4" d="M256,363c-28.58,0-55.45-11.13-75.66-31.34l22.627-22.627c29.242,29.242,76.824,29.242,106.066,0l22.627,22.627c-20.21,20.21-47.08,31.34-75.66,31.34Z"/>
+        <path fill="#9aa0a6" d="M331.66,331.66l-22.627-22.627c29.242-29.243,29.242-76.823,0-106.066l22.627-22.627c41.72,41.719,41.72,109.602,0,151.32h0Z"/>
+        <path fill="#9aa0a6" d="M180.34,331.66c-41.72-41.719-41.72-109.602,0-151.32l22.627,22.627c-29.242,29.243-29.242,76.823,0,106.066l-22.627,22.627Z"/>
+        <path fill="#4285F4" d="M170.229,147.603c5.406-9.256,8.521-20.007,8.521-31.478,0-34.531-28.094-62.625-62.625-62.625s-62.625,28.094-62.625,62.625,28.094,62.625,62.625,62.625c11.471,0,22.222-3.114,31.478-8.52l45.281,45.281c5.831-9.07,13.557-16.796,22.627-22.627l-45.281-45.281h-.001ZM116.125,146.75c-16.887,0-30.625-13.738-30.625-30.625s13.738-30.625,30.625-30.625,30.625,13.738,30.625,30.625-13.738,30.625-30.625,30.625Z"/>
+        <path fill="#9aa0a6" d="M215.51,319.117c-9.07-5.831-16.796-13.557-22.627-22.627l-45.281,45.281c-9.256-5.406-20.007-8.52-31.478-8.52-34.531,0-62.625,28.094-62.625,62.625s28.094,62.625,62.625,62.625,62.625-28.094,62.625-62.625c0-11.471-3.114-22.222-8.521-31.478l45.281-45.281h0ZM116.125,426.5c-16.887,0-30.625-13.738-30.625-30.625s13.738-30.625,30.625-30.625,30.625,13.738,30.625,30.625-13.738,30.625-30.625,30.625Z"/>
+        <path fill="#4285F4" d="M395.875,333.25c-11.471,0-22.222,3.114-31.478,8.52l-45.281-45.281c-5.831,9.07-13.557,16.796-22.627,22.627l45.281,45.281c-5.406,9.256-8.521,20.007-8.521,31.478,0,34.531,28.094,62.625,62.625,62.625s62.625-28.094,62.625-62.625-28.094-62.625-62.625-62.625h.001ZM395.875,426.5c-16.887,0-30.625-13.738-30.625-30.625s13.738-30.625,30.625-30.625,30.625,13.738,30.625,30.625-13.738,30.625-30.625,30.625Z"/>
+        <path fill="#9aa0a6" d="M395.875,53.5c-34.531,0-62.625,28.094-62.625,62.625,0,11.645,3.205,22.551,8.764,31.902l-45.118,45.118c9.03,5.887,16.707,13.663,22.481,22.773l45.444-45.444c9.16,5.255,19.758,8.276,31.054,8.276,34.531,0,62.625-28.094,62.625-62.625s-28.094-62.625-62.625-62.625ZM395.875,146.75c-16.887,0-30.625-13.738-30.625-30.625s13.738-30.625,30.625-30.625,30.625,13.738,30.625,30.625-13.738,30.625-30.625,30.625Z"/>
+    </symbol>
+
+    <!-- Official Aviatrix-on-GCP Spoke Gateway (blue, branded) -->
+    <symbol id="ic-avx-gw" viewBox="0 0 72 72">
+        <circle cx="36" cy="36" r="36" fill="white"/>
+        <path d="M72 36C72 55.8823 55.8823 72 36 72C16.1177 72 0 55.8823 0 36C0 16.1177 16.1177 0 36 0C55.8823 0 72 16.1177 72 36ZM4.032 36C4.032 53.6554 18.3446 67.968 36 67.968C53.6554 67.968 67.968 53.6554 67.968 36C67.968 18.3446 53.6554 4.032 36 4.032C18.3446 4.032 4.032 18.3446 4.032 36Z" fill="#4285F4"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M71.382 42.6772C71.5043 42.0248 71.6091 41.3662 71.6957 40.7019C71.8965 39.163 72 37.5936 72 36C72 34.4064 71.8965 32.837 71.6957 31.2981C71.6091 30.6338 71.5043 29.9752 71.382 29.3228C71.2584 28.6642 71.117 28.012 70.9581 27.3665C68.8853 27.7535 67.4532 29.699 67.7293 31.8154C67.9077 33.1832 68 34.5798 68 36C68 37.4202 67.9077 38.8168 67.7293 40.1846C67.4532 42.301 68.8853 44.2465 70.9581 44.6335C71.117 43.988 71.2584 43.3358 71.382 42.6772ZM66.8203 54.6143C65.0803 53.4222 62.6915 53.7862 61.3907 55.4789C59.6861 57.6972 57.6972 59.6861 55.4789 61.3907C53.7862 62.6915 53.4222 65.0803 54.6143 66.8203C55.1859 66.4743 55.7471 66.113 56.2973 65.7367C56.8481 65.36 57.388 64.9683 57.9162 64.5624C60.4101 62.6459 62.6459 60.4101 64.5624 57.9162C64.9683 57.388 65.36 56.8481 65.7367 56.2973C66.113 55.7471 66.4743 55.1859 66.8203 54.6143ZM44.6334 70.9581C44.2465 68.8853 42.301 67.4532 40.1846 67.7293C38.8168 67.9077 37.4202 68 36 68C34.5798 68 33.1832 67.9077 31.8154 67.7293C29.699 67.4532 27.7535 68.8853 27.3665 70.9581C28.012 71.117 28.6642 71.2584 29.3228 71.382C29.9752 71.5043 30.6338 71.6091 31.2981 71.6957C32.8369 71.8965 34.4064 72 36 72C37.5936 72 39.163 71.8965 40.7019 71.6957C41.3662 71.6091 42.0248 71.5043 42.6772 71.382C43.3358 71.2584 43.988 71.117 44.6334 70.9581ZM17.3857 66.8203C18.5778 65.0803 18.2138 62.6915 16.5211 61.3907C14.3028 59.6861 12.3139 57.6972 10.6093 55.4789C9.30852 53.7862 6.91971 53.4222 5.1797 54.6143C5.52565 55.1859 5.88705 55.7471 6.26332 56.2973C6.64004 56.8481 7.03167 57.388 7.43762 57.9162C9.35409 60.4101 11.5899 62.6459 14.0838 64.5624C14.612 64.9683 15.1519 65.36 15.7027 65.7367C16.2529 66.113 16.8141 66.4743 17.3857 66.8203ZM1.04188 44.6334C3.1147 44.2465 4.54675 42.301 4.27068 40.1846C4.09227 38.8168 4 37.4202 4 36C4 34.5798 4.09227 33.1832 4.27068 31.8154C4.54675 29.699 3.1147 27.7535 1.04188 27.3665C0.883018 28.012 0.741566 28.6642 0.618047 29.3228C0.495691 29.9752 0.390932 30.6338 0.304283 31.2981C0.103548 32.8369 0 34.4064 0 36C0 37.5936 0.103548 39.163 0.304282 40.7019C0.390932 41.3662 0.495691 42.0248 0.618047 42.6772C0.741566 43.3358 0.883018 43.988 1.04188 44.6334ZM5.1797 17.3857C6.91971 18.5778 9.30852 18.2138 10.6093 16.5211C12.3139 14.3028 14.3028 12.3139 16.5211 10.6093C18.2138 9.30852 18.5778 6.91971 17.3857 5.1797C16.8141 5.52565 16.2529 5.88705 15.7027 6.26332C15.1519 6.64004 14.612 7.03167 14.0838 7.43762C11.5899 9.35409 9.35409 11.5899 7.43762 14.0838C7.03167 14.612 6.64004 15.1519 6.26332 15.7027C5.88705 16.2529 5.52565 16.8141 5.1797 17.3857ZM27.3665 1.04188C27.7535 3.1147 29.699 4.54675 31.8154 4.27068C33.1832 4.09227 34.5798 4 36 4C37.4202 4 38.8168 4.09227 40.1846 4.27068C42.301 4.54675 44.2465 3.1147 44.6335 1.04188C43.988 0.883019 43.3358 0.741566 42.6772 0.618047C42.0248 0.495691 41.3662 0.390932 40.7019 0.304282C39.163 0.103548 37.5936 0 36 0C34.4064 0 32.837 0.103548 31.2981 0.304282C30.6338 0.390931 29.9752 0.495691 29.3228 0.618046C28.6642 0.741566 28.012 0.883018 27.3665 1.04188ZM54.6143 5.1797C53.4222 6.91971 53.7862 9.30852 55.4789 10.6093C57.6972 12.3139 59.6861 14.3028 61.3907 16.5211C62.6915 18.2138 65.0803 18.5778 66.8203 17.3857C66.4743 16.8141 66.113 16.2529 65.7367 15.7027C65.36 15.1519 64.9683 14.612 64.5624 14.0838C62.6459 11.5899 60.4101 9.35409 57.9162 7.43762C57.388 7.03167 56.8481 6.64004 56.2973 6.26332C55.7471 5.88705 55.1859 5.52565 54.6143 5.1797Z" fill="#4285F4"/>
+        <path d="M31.3483 25.5944L35.8202 21.0693C35.9389 20.9769 36.0577 20.9769 36.1798 21.0693L40.767 25.5944C40.8586 25.6868 40.8892 25.8066 40.8009 25.8956C40.767 25.9846 40.6788 26.0154 40.5872 25.9846H37.8525C37.7338 25.9846 37.615 26.1044 37.615 26.2242V32.0705C37.615 32.1903 37.5234 32.2827 37.4047 32.2827H34.6225C34.5003 32.317 34.3782 32.2211 34.3782 32.1013V26.2276C34.3782 26.1078 34.29 25.988 34.1746 25.988H31.5282C31.3789 25.988 31.2907 25.8682 31.2907 25.7142C31.3178 25.6902 31.3178 25.6286 31.3483 25.5978V25.5944ZM40.7704 46.4056L36.1798 50.9307C36.0577 51.0231 35.9355 51.0231 35.8168 50.9307L31.3449 46.4056C31.2567 46.2858 31.2839 46.1318 31.406 46.0736C31.4399 46.0462 31.4671 46.0154 31.5248 46.0154H34.1712C34.2866 46.0154 34.3748 45.8956 34.3748 45.7758V39.9295C34.3748 39.8097 34.4664 39.7173 34.5852 39.7173H37.4081C37.5268 39.7173 37.6184 39.8063 37.6184 39.9295V45.7758C37.6184 45.8956 37.7372 46.0154 37.8559 46.0154H40.4685C40.5872 45.9264 40.7399 45.9538 40.8281 46.0736C40.8892 46.166 40.862 46.3132 40.767 46.4056H40.7704ZM27.2667 40.4361V37.7662C27.2667 37.6498 27.1479 37.5608 27.0292 37.5266H21.2375C21.1154 37.5266 21 37.441 21 37.3212V34.5008C21 34.381 21.1154 34.2954 21.2375 34.2612H27.0292C27.1479 34.2612 27.2667 34.1722 27.2667 34.0558V31.3859C27.2395 31.2627 27.3006 31.1463 27.3888 31.1121C27.477 31.0539 27.5992 31.1121 27.6603 31.1737L32.1287 35.7604C32.2203 35.8494 32.2203 35.9658 32.1287 36.0616L27.6569 40.5867C27.5686 40.6791 27.4465 40.7065 27.3583 40.6483C27.2904 40.5867 27.2633 40.4977 27.2633 40.4361H27.2667ZM44.7333 31.3825V34.0524C44.7333 34.1756 44.8521 34.2646 44.9708 34.2646H50.7625C50.8846 34.2988 51 34.3844 51 34.5042V37.3212C51 37.4445 50.8846 37.5335 50.7625 37.5335H44.9708C44.8521 37.5677 44.7333 37.6533 44.7333 37.7731V40.4429C44.7605 40.5593 44.6723 40.6483 44.5501 40.6825C44.4619 40.6825 44.4008 40.6483 44.3465 40.5901L39.8679 36.0034C39.7797 35.9144 39.7797 35.798 39.8679 35.7022L44.3465 31.1771C44.4008 31.0847 44.5501 31.0573 44.6417 31.1155C44.7333 31.1771 44.7605 31.2969 44.7333 31.3894V31.3825Z" fill="#4285F4"/>
+        <path d="M61.4559 61.4558C58.113 64.7988 54.1444 67.4505 49.7767 69.2597C45.4089 71.0688 40.7276 72 36 72C31.2725 72 26.5912 71.0688 22.2234 69.2597C17.8557 67.4505 13.8871 64.7987 10.5442 61.4558L23.2721 48.7279C24.9436 50.3994 26.9279 51.7252 29.1118 52.6298C31.2956 53.5344 33.6363 54 36.0001 54C38.3639 54 40.7045 53.5344 42.8884 52.6298C45.0722 51.7252 47.0565 50.3994 48.728 48.7279L61.4559 61.4558Z" fill="#4285F4"/>
+        <path d="M35.776 68.848C35.072 68.848 34.3893 68.7147 33.728 68.448C33.0773 68.1813 32.5013 67.8027 32 67.312L33.088 66.048C33.4613 66.4 33.888 66.688 34.368 66.912C34.848 67.1253 35.328 67.232 35.808 67.232C36.4053 67.232 36.8587 67.1093 37.168 66.864C37.4773 66.6187 37.632 66.2933 37.632 65.888C37.632 65.4507 37.4773 65.136 37.168 64.944C36.8693 64.752 36.4853 64.5547 36.016 64.352L34.576 63.728C34.2347 63.5787 33.8987 63.3867 33.568 63.152C33.248 62.9173 32.9813 62.6187 32.768 62.256C32.5653 61.8933 32.464 61.456 32.464 60.944C32.464 60.3893 32.6133 59.8933 32.912 59.456C33.2213 59.008 33.6373 58.656 34.16 58.4C34.6933 58.1333 35.3013 58 35.984 58C36.592 58 37.1787 58.1227 37.744 58.368C38.3093 58.6027 38.7947 58.9227 39.2 59.328L38.256 60.512C37.9253 60.2347 37.5733 60.016 37.2 59.856C36.8373 59.696 36.432 59.616 35.984 59.616C35.4933 59.616 35.0933 59.728 34.784 59.952C34.4853 60.1653 34.336 60.464 34.336 60.848C34.336 61.1147 34.4107 61.3387 34.56 61.52C34.72 61.6907 34.928 61.84 35.184 61.968C35.44 62.0853 35.712 62.2027 36 62.32L37.424 62.912C38.0427 63.1787 38.5493 63.5307 38.944 63.968C39.3387 64.3947 39.536 64.9867 39.536 65.744C39.536 66.3093 39.3867 66.8267 39.088 67.296C38.7893 67.7653 38.3573 68.144 37.792 68.432C37.2373 68.7093 36.5653 68.848 35.776 68.848Z" fill="white"/>
+    </symbol>
+
+    <!-- Official Aviatrix-on-GCP Transit Gateway (blue, with "T" mark) -->
+    <symbol id="ic-avx-transit-gw" viewBox="0 0 72 72">
+        <circle cx="36" cy="36" r="36" fill="white"/>
+        <path d="M72 36C72 55.8823 55.8823 72 36 72C16.1177 72 0 55.8823 0 36C0 16.1177 16.1177 0 36 0C55.8823 0 72 16.1177 72 36ZM4.032 36C4.032 53.6554 18.3446 67.968 36 67.968C53.6554 67.968 67.968 53.6554 67.968 36C67.968 18.3446 53.6554 4.032 36 4.032C18.3446 4.032 4.032 18.3446 4.032 36Z" fill="#4285F4"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M71.382 42.6772C71.5043 42.0248 71.6091 41.3662 71.6957 40.7019C71.8965 39.163 72 37.5936 72 36C72 34.4064 71.8965 32.837 71.6957 31.2981C71.6091 30.6338 71.5043 29.9752 71.382 29.3228C71.2584 28.6642 71.117 28.012 70.9581 27.3665C68.8853 27.7535 67.4532 29.699 67.7293 31.8154C67.9077 33.1832 68 34.5798 68 36C68 37.4202 67.9077 38.8168 67.7293 40.1846C67.4532 42.301 68.8853 44.2465 70.9581 44.6335C71.117 43.988 71.2584 43.3358 71.382 42.6772ZM66.8203 54.6143C65.0803 53.4222 62.6915 53.7862 61.3907 55.4789C59.6861 57.6972 57.6972 59.6861 55.4789 61.3907C53.7862 62.6915 53.4222 65.0803 54.6143 66.8203C55.1859 66.4743 55.7471 66.113 56.2973 65.7367C56.8481 65.36 57.388 64.9683 57.9162 64.5624C60.4101 62.6459 62.6459 60.4101 64.5624 57.9162C64.9683 57.388 65.36 56.8481 65.7367 56.2973C66.113 55.7471 66.4743 55.1859 66.8203 54.6143ZM44.6334 70.9581C44.2465 68.8853 42.301 67.4532 40.1846 67.7293C38.8168 67.9077 37.4202 68 36 68C34.5798 68 33.1832 67.9077 31.8154 67.7293C29.699 67.4532 27.7535 68.8853 27.3665 70.9581C28.012 71.117 28.6642 71.2584 29.3228 71.382C29.9752 71.5043 30.6338 71.6091 31.2981 71.6957C32.8369 71.8965 34.4064 72 36 72C37.5936 72 39.163 71.8965 40.7019 71.6957C41.3662 71.6091 42.0248 71.5043 42.6772 71.382C43.3358 71.2584 43.988 71.117 44.6334 70.9581ZM17.3857 66.8203C18.5778 65.0803 18.2138 62.6915 16.5211 61.3907C14.3028 59.6861 12.3139 57.6972 10.6093 55.4789C9.30852 53.7862 6.91971 53.4222 5.1797 54.6143C5.52565 55.1859 5.88705 55.7471 6.26332 56.2973C6.64004 56.8481 7.03167 57.388 7.43762 57.9162C9.35409 60.4101 11.5899 62.6459 14.0838 64.5624C14.612 64.9683 15.1519 65.36 15.7027 65.7367C16.2529 66.113 16.8141 66.4743 17.3857 66.8203ZM1.04188 44.6334C3.1147 44.2465 4.54675 42.301 4.27068 40.1846C4.09227 38.8168 4 37.4202 4 36C4 34.5798 4.09227 33.1832 4.27068 31.8154C4.54675 29.699 3.1147 27.7535 1.04188 27.3665C0.883018 28.012 0.741566 28.6642 0.618047 29.3228C0.495691 29.9752 0.390932 30.6338 0.304283 31.2981C0.103548 32.8369 0 34.4064 0 36C0 37.5936 0.103548 39.163 0.304282 40.7019C0.390932 41.3662 0.495691 42.0248 0.618047 42.6772C0.741566 43.3358 0.883018 43.988 1.04188 44.6334ZM5.1797 17.3857C6.91971 18.5778 9.30852 18.2138 10.6093 16.5211C12.3139 14.3028 14.3028 12.3139 16.5211 10.6093C18.2138 9.30852 18.5778 6.91971 17.3857 5.1797C16.8141 5.52565 16.2529 5.88705 15.7027 6.26332C15.1519 6.64004 14.612 7.03167 14.0838 7.43762C11.5899 9.35409 9.35409 11.5899 7.43762 14.0838C7.03167 14.612 6.64004 15.1519 6.26332 15.7027C5.88705 16.2529 5.52565 16.8141 5.1797 17.3857ZM27.3665 1.04188C27.7535 3.1147 29.699 4.54675 31.8154 4.27068C33.1832 4.09227 34.5798 4 36 4C37.4202 4 38.8168 4.09227 40.1846 4.27068C42.301 4.54675 44.2465 3.1147 44.6335 1.04188C43.988 0.883019 43.3358 0.741566 42.6772 0.618047C42.0248 0.495691 41.3662 0.390932 40.7019 0.304282C39.163 0.103548 37.5936 0 36 0C34.4064 0 32.837 0.103548 31.2981 0.304282C30.6338 0.390931 29.9752 0.495691 29.3228 0.618046C28.6642 0.741566 28.012 0.883018 27.3665 1.04188ZM54.6143 5.1797C53.4222 6.91971 53.7862 9.30852 55.4789 10.6093C57.6972 12.3139 59.6861 14.3028 61.3907 16.5211C62.6915 18.2138 65.0803 18.5778 66.8203 17.3857C66.4743 16.8141 66.113 16.2529 65.7367 15.7027C65.36 15.1519 64.9683 14.612 64.5624 14.0838C62.6459 11.5899 60.4101 9.35409 57.9162 7.43762C57.388 7.03167 56.8481 6.64004 56.2973 6.26332C55.7471 5.88705 55.1859 5.52565 54.6143 5.1797Z" fill="#4285F4"/>
+        <path d="M31.3483 25.5944L35.8202 21.0693C35.9389 20.9769 36.0577 20.9769 36.1798 21.0693L40.767 25.5944C40.8586 25.6868 40.8892 25.8066 40.8009 25.8956C40.767 25.9846 40.6788 26.0154 40.5872 25.9846H37.8525C37.7338 25.9846 37.615 26.1044 37.615 26.2242V32.0705C37.615 32.1903 37.5234 32.2827 37.4047 32.2827H34.6225C34.5003 32.317 34.3782 32.2211 34.3782 32.1013V26.2276C34.3782 26.1078 34.29 25.988 34.1746 25.988H31.5282C31.3789 25.988 31.2907 25.8682 31.2907 25.7142C31.3178 25.6902 31.3178 25.6286 31.3483 25.5978V25.5944ZM40.7704 46.4056L36.1798 50.9307C36.0577 51.0231 35.9355 51.0231 35.8168 50.9307L31.3449 46.4056C31.2567 46.2858 31.2839 46.1318 31.406 46.0736C31.4399 46.0462 31.4671 46.0154 31.5248 46.0154H34.1712C34.2866 46.0154 34.3748 45.8956 34.3748 45.7758V39.9295C34.3748 39.8097 34.4664 39.7173 34.5852 39.7173H37.4081C37.5268 39.7173 37.6184 39.8063 37.6184 39.9295V45.7758C37.6184 45.8956 37.7372 46.0154 37.8559 46.0154H40.4685C40.5872 45.9264 40.7399 45.9538 40.8281 46.0736C40.8892 46.166 40.862 46.3132 40.767 46.4056H40.7704ZM27.2667 40.4361V37.7662C27.2667 37.6498 27.1479 37.5608 27.0292 37.5266H21.2375C21.1154 37.5266 21 37.441 21 37.3212V34.5008C21 34.381 21.1154 34.2954 21.2375 34.2612H27.0292C27.1479 34.2612 27.2667 34.1722 27.2667 34.0558V31.3859C27.2395 31.2627 27.3006 31.1463 27.3888 31.1121C27.477 31.0539 27.5992 31.1121 27.6603 31.1737L32.1287 35.7604C32.2203 35.8494 32.2203 35.9658 32.1287 36.0616L27.6569 40.5867C27.5686 40.6791 27.4465 40.7065 27.3583 40.6483C27.2904 40.5867 27.2633 40.4977 27.2633 40.4361H27.2667ZM44.7333 31.3825V34.0524C44.7333 34.1756 44.8521 34.2646 44.9708 34.2646H50.7625C50.8846 34.2988 51 34.3844 51 34.5042V37.3212C51 37.4445 50.8846 37.5335 50.7625 37.5335H44.9708C44.8521 37.5677 44.7333 37.6533 44.7333 37.7731V40.4429C44.7605 40.5593 44.6723 40.6483 44.5501 40.6825C44.4619 40.6825 44.4008 40.6483 44.3465 40.5901L39.8679 36.0034C39.7797 35.9144 39.7797 35.798 39.8679 35.7022L44.3465 31.1771C44.4008 31.0847 44.5501 31.0573 44.6417 31.1155C44.7333 31.1771 44.7605 31.2969 44.7333 31.3894V31.3825Z" fill="#4285F4"/>
+        <path d="M10.1038 10.9923C13.3878 7.59155 17.3095 4.87095 21.645 2.98583C25.9805 1.10071 30.6448 0.0879893 35.3717 0.00548314C40.0986 -0.077023 44.7954 0.772305 49.194 2.50497C53.5927 4.23764 57.607 6.81972 61.0077 10.1038L49.004 22.534C47.2356 20.8263 45.1482 19.4836 42.8609 18.5826C40.5736 17.6816 38.1313 17.2399 35.6733 17.2829C33.2153 17.3258 30.7899 17.8524 28.5354 18.8326C26.281 19.8129 24.2417 21.2276 22.5339 22.996L10.1038 10.9923Z" fill="#4285F4"/>
+        <path d="M35.024 14.464V5.568H32V4H39.904V5.568H36.88V14.464H35.024Z" fill="white"/>
+    </symbol>
+
+    <!-- Aviatrix Controller (orange shield) -->
+    <symbol id="ic-controller" viewBox="0 0 88 64">
+        <path d="M85,43.2C82.8,40.4,76,32,76,32L59.3,11.2L54.2,4.9C51.7,1.8,47.9,0,44,0C40,0,36.1,1.8,33.6,4.9L28.5,11.2L11.8,32L2.8,43.2C-1.7,48.7-0.7,56.9,5,61.2C7.5,63,10.2,64,13.1,64C16,64,20.8,62.3,23.5,59.1L28.6,52.8L41.8,36.4L34.7,21.97L59.5,52.8L64.6,59.1C67.2,62.3,71,64,74.9,64C78.9,64,80.6,63.1,83.1,61.2C88.8,56.9,89.6,48.7,85.1,43.2H85Z" fill="url(#avx-gradient)"/>
+    </symbol>
+
+    <!-- Internet cloud -->
+    <symbol id="ic-internet" viewBox="0 0 100 60">
+        <path d="M25,45 Q5,45 5,30 Q5,15 22,15 Q25,5 40,5 Q55,5 60,15 Q70,12 78,20 Q92,22 92,35 Q92,48 78,48 L25,48 Z" fill="#E3F2FD" stroke="#1565C0" stroke-width="1.6"/>
+    </symbol>
+</defs>
+
+<!-- Background -->
+<rect width="1600" height="1200" fill="#FFFFFF" stroke="#B0BEC5" stroke-width="1"/>
+
+<!-- Title -->
+<text x="800" y="30" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="20" font-weight="700" fill="#111118">Multi-Cluster GKE with Aviatrix Transit</text>
+<text x="800" y="50" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="12" font-weight="400" fill="#4A5568">Overlapping pod CIDRs (100.64.0.0/16) · Spoke-GW SNAT hides the overlap · Direct internet egress, no Cloud NAT · GKE Gateway (Global ALB) handles ingress out-of-band — Blueprint Architecture</text>
+
+<!-- Internet cloud at very top -->
+<g id="node-internet">
+  <use href="#ic-internet" x="730" y="68" width="140" height="84"/>
+  <text x="800" y="115" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="13" font-weight="700" fill="#0D47A1">Internet</text>
+</g>
+
+<!-- =============================================== -->
+<!-- GCP region container -->
+<!-- =============================================== -->
+<g id="container-gcp-region">
+  <rect x="30" y="160" width="1540" height="835" rx="6" ry="6" fill="#E8F0FE" stroke="#1A73E8" stroke-width="1.8" filter="url(#shadow-sm)"/>
+  <text x="46" y="180" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="12" font-weight="700" fill="#1A73E8" letter-spacing="0.3">GCP · us-central1 (Iowa)</text>
+</g>
+
+<!-- =============================================== -->
+<!-- GCP Edge band: GKE Gateways (Global ALB) -->
+<!-- =============================================== -->
+<g id="container-edge-band">
+  <rect x="50" y="195" width="1290" height="90" rx="4" ry="4" fill="#FFFFFF" stroke="#9AA0A6" stroke-width="1.4" stroke-dasharray="6 3"/>
+  <text x="60" y="213" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11" font-weight="600" fill="#5F6368" letter-spacing="0.3">GCP Edge · Google-managed Global External ALB plane (out-of-band of Aviatrix data path)</text>
+</g>
+
+<!-- Frontend GKE Gateway (Global ALB) -->
+<g id="node-fe-glb">
+  <rect x="200" y="226" width="280" height="50" rx="4" ry="4" fill="#FFFFFF" stroke="#1A73E8" stroke-width="1.6" filter="url(#shadow-sm)"/>
+  <use href="#ic-glb" x="210" y="232" width="38" height="38"/>
+  <text x="260" y="246" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11" font-weight="700" fill="#111118">Frontend GKE Gateway</text>
+  <text x="260" y="259" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="400" fill="#4A5568">Global External ALB · gke-l7-global-external-managed</text>
+  <text x="260" y="270" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="500" fill="#1565C0">frontend GW IP, reserved · NEG → Gatus</text>
+</g>
+
+<!-- Backend GKE Gateway (Global ALB) -->
+<g id="node-be-glb">
+  <rect x="900" y="226" width="280" height="50" rx="4" ry="4" fill="#FFFFFF" stroke="#1A73E8" stroke-width="1.6" filter="url(#shadow-sm)"/>
+  <use href="#ic-glb" x="910" y="232" width="38" height="38"/>
+  <text x="960" y="246" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11" font-weight="700" fill="#111118">Backend GKE Gateway</text>
+  <text x="960" y="259" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="400" fill="#4A5568">Global External ALB · gke-l7-global-external-managed</text>
+  <text x="960" y="270" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="500" fill="#1565C0">backend GW IP, reserved · NEG → Gatus</text>
+</g>
+
+<!-- Aviatrix Controller / CoPilot -->
+<g id="container-controller">
+  <rect x="1360" y="195" width="200" height="90" rx="4" ry="4" fill="#FFFFFF" stroke="#C25E0E" stroke-width="1.6" filter="url(#shadow-sm)"/>
+  <use href="#ic-controller" x="1370" y="208" width="32" height="22"/>
+  <text x="1408" y="220" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11" font-weight="700" fill="#111118">Aviatrix Control Plane</text>
+  <text x="1408" y="232" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="400" fill="#4A5568">Controller + CoPilot</text>
+  <!-- DCF rules badge -->
+  <rect x="1370" y="245" width="180" height="32" rx="3" fill="#FDE8E8" stroke="#8E0000" stroke-width="1" stroke-dasharray="4 2"/>
+  <text x="1460" y="259" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="700" fill="#8E0000">DCF · 12-rule policy</text>
+  <text x="1460" y="271" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#4A5568">4 K8s SmartGroups · fabric-wide</text>
+</g>
+
+<!-- =============================================== -->
+<!-- Spoke VPCs -->
+<!-- =============================================== -->
+
+<!-- Frontend Spoke VPC -->
+<g id="container-fe-vpc">
+  <rect x="50" y="305" width="510" height="540" rx="4" ry="4" fill="#FFFFFF" stroke="#1A73E8" stroke-width="1.8" filter="url(#shadow-sm)"/>
+  <text x="62" y="324" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11" font-weight="700" fill="#1A73E8" letter-spacing="0.3">Frontend Spoke VPC · 10.10.0.0/20</text>
+</g>
+
+<!-- Frontend nodes subnet (with cluster) -->
+<g id="container-fe-nodes">
+  <rect x="65" y="338" width="480" height="285" rx="3" ry="3" fill="#F8F9FA" stroke="#5F6368" stroke-width="1.2" stroke-dasharray="5 3"/>
+  <text x="75" y="354" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="600" fill="#5F6368">subnet · gke-demo-frontend-nodes · 10.10.0.0/22</text>
+  <text x="75" y="367" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#5F6368">secondary: services 172.16.0.0/20</text>
+
+  <!-- GKE cluster boundary (inside subnet) -->
+  <rect x="78" y="378" width="454" height="235" rx="4" ry="4" fill="#E6F4EA" stroke="#0F9D58" stroke-width="1.6"/>
+  <use href="#ic-gke" x="86" y="386" width="28" height="28"/>
+  <text x="120" y="397" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11" font-weight="700" fill="#0F9D58">GKE · gke-demo-frontend</text>
+  <text x="120" y="409" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#4A5568">zonal · GKE Dataplane V2 (Cilium/eBPF)</text>
+
+  <!-- default_snat_status badge -->
+  <rect x="345" y="386" width="180" height="22" rx="3" fill="#FFFFFF" stroke="#0F9D58" stroke-width="1.2"/>
+  <text x="435" y="401" text-anchor="middle" font-family="'Courier New',monospace" font-size="9" font-weight="700" fill="#0F9D58">default_snat_status: disabled</text>
+
+  <!-- pod range -->
+  <rect x="86" y="425" width="190" height="44" rx="3" fill="#FFF8E1" stroke="#F9AB00" stroke-width="1.2" stroke-dasharray="3 2"/>
+  <text x="181" y="440" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="700" fill="#A65A00">pods · 100.64.0.0/16</text>
+  <text x="181" y="453" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#A65A00">alias range · OVERLAPS with backend</text>
+  <text x="181" y="463" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#A65A00">source IP preserved end-to-end → GW</text>
+
+  <!-- Worker nodes -->
+  <rect x="290" y="425" width="105" height="44" rx="3" fill="#FFFFFF" stroke="#5F6368" stroke-width="1"/>
+  <use href="#ic-gce" x="295" y="430" width="22" height="22"/>
+  <text x="355" y="440" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="600" fill="#111118">node-1</text>
+  <text x="355" y="452" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="7" font-weight="400" fill="#4A5568">e2-standard-2</text>
+
+  <rect x="408" y="425" width="105" height="44" rx="3" fill="#FFFFFF" stroke="#5F6368" stroke-width="1"/>
+  <use href="#ic-gce" x="413" y="430" width="22" height="22"/>
+  <text x="473" y="440" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="600" fill="#111118">node-2</text>
+  <text x="473" y="452" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="7" font-weight="400" fill="#4A5568">e2-standard-2</text>
+
+  <!-- Gatus service -->
+  <rect x="86" y="485" width="427" height="40" rx="3" fill="#FFFFFF" stroke="#1A73E8" stroke-width="1.2"/>
+  <circle cx="105" cy="505" r="9" fill="#1A73E8"/>
+  <text x="105" y="509" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="700" fill="#FFFFFF">G</text>
+  <text x="125" y="500" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="700" fill="#111118">Gatus Service (workload)</text>
+  <text x="125" y="513" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#4A5568">NEG-attached → Frontend GKE Gateway above</text>
+  <text x="125" y="522" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="500" fill="#0F9D58">east-west calls Backend Gatus via spoke→transit→spoke</text>
+
+  <!-- Private GKE master callout -->
+  <rect x="86" y="540" width="427" height="60" rx="3" fill="#FAFAFA" stroke="#9AA0A6" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="299" y="556" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="700" fill="#5F6368">Google control-plane project (managed)</text>
+  <text x="299" y="569" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="500" fill="#1A73E8">Private GKE master · 172.20.0.0/28</text>
+  <text x="299" y="582" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#5F6368">PSC peering to nodes · K8s API plane</text>
+  <text x="299" y="594" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#5F6368">DCF metadata discovery via Aviatrix Controller</text>
+</g>
+
+<!-- proxy-only subnet (frontend, thin band) -->
+<g id="container-fe-proxy">
+  <rect x="65" y="635" width="295" height="34" rx="3" ry="3" fill="#F1F3F4" stroke="#9AA0A6" stroke-width="1" stroke-dasharray="4 2"/>
+  <text x="212" y="650" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="600" fill="#5F6368">subnet · gke-demo-frontend-proxy-only · 10.10.5.0/24</text>
+  <text x="212" y="662" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#5F6368">GKE Gateway proxies (regional, proxy-only)</text>
+</g>
+
+<!-- avx-gw subnet (frontend) -->
+<g id="container-fe-avx-subnet">
+  <rect x="65" y="685" width="480" height="148" rx="3" ry="3" fill="#FFF8F0" stroke="#C25E0E" stroke-width="1.4" stroke-dasharray="5 3"/>
+  <text x="75" y="701" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="600" fill="#C25E0E">subnet · gke-demo-frontend-avx-gw · 10.10.4.0/28</text>
+</g>
+
+<!-- Frontend Aviatrix Spoke GW -->
+<g id="node-fe-avx-gw">
+  <use href="#ic-avx-gw" x="120" y="715" width="58" height="58"/>
+  <text x="149" y="789" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11" font-weight="700" fill="#111118">Frontend Spoke GW</text>
+  <text x="149" y="800" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="400" fill="#4A5568">n1-standard-1 · 10.10.4.2</text>
+  <text x="149" y="811" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="500" fill="#C25E0E">public IP allocated</text>
+
+  <!-- HEADLINE: SNAT badge -->
+  <rect x="200" y="710" width="335" height="116" rx="4" fill="#FFF3E0" stroke="#FA6B1E" stroke-width="2"/>
+  <text x="367" y="726" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11" font-weight="800" fill="#C25E0E">⬣ SNAT (customized_snat / CONDUIT_SNAT)</text>
+  <text x="208" y="743" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="700" fill="#5D2E00">Three policies on this spoke GW:</text>
+  <text x="208" y="757" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8.5" font-weight="500" fill="#5D2E00">• pods 100.64.0.0/16 → transit fabric → SNAT to GW priv IP</text>
+  <text x="208" y="770" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8.5" font-weight="500" fill="#5D2E00">• pods 100.64.0.0/16 → internet (eth0) → SNAT to GW pub IP</text>
+  <text x="208" y="783" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8.5" font-weight="500" fill="#5D2E00">• nodes 10.10.0.0/22 → internet (eth0) → SNAT to GW pub IP</text>
+  <text x="208" y="800" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="600" fill="#C62828">→ hides overlapping 100.64.0.0/16 east-west and north-south</text>
+  <text x="208" y="815" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="500" fill="#5D2E00">DCF SmartGroups still see original pod IP pre-NAT</text>
+</g>
+
+<!-- "no SNAT" badge between cluster and spoke GW (frontend) -->
+<g id="badge-fe-no-snat">
+  <rect x="65" y="635" width="0" height="0" /> <!-- spacer -->
+  <rect x="370" y="635" width="175" height="34" rx="3" fill="#E6F4EA" stroke="#0F9D58" stroke-width="1.4"/>
+  <text x="457" y="649" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="700" fill="#0F9D58">✓ no SNAT pod → spoke GW</text>
+  <text x="457" y="662" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#0F9D58">pod IP 100.64.x.x preserved in-VPC</text>
+</g>
+
+<!-- =============================================== -->
+<!-- DB Spoke VPC (narrower) -->
+<!-- =============================================== -->
+<g id="container-db-vpc">
+  <rect x="580" y="305" width="290" height="540" rx="4" ry="4" fill="#FFFFFF" stroke="#1A73E8" stroke-width="1.8" filter="url(#shadow-sm)"/>
+  <text x="592" y="324" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11" font-weight="700" fill="#1A73E8" letter-spacing="0.3">DB Spoke VPC · 10.5.0.0/22</text>
+</g>
+
+<!-- DB vms subnet -->
+<g id="container-db-vms">
+  <rect x="595" y="338" width="260" height="285" rx="3" ry="3" fill="#F8F9FA" stroke="#5F6368" stroke-width="1.2" stroke-dasharray="5 3"/>
+  <text x="725" y="354" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="600" fill="#5F6368">subnet · gke-demo-db-vms · 10.5.0.0/24</text>
+
+  <!-- DB VM -->
+  <rect x="650" y="385" width="150" height="110" rx="4" ry="4" fill="#FFFFFF" stroke="#1A73E8" stroke-width="1.4" filter="url(#shadow-sm)"/>
+  <use href="#ic-gce" x="700" y="395" width="48" height="48"/>
+  <text x="725" y="460" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11" font-weight="700" fill="#111118">cc-db (Apache)</text>
+  <text x="725" y="473" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="400" fill="#4A5568">e2-small · routable IP</text>
+  <text x="725" y="486" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="500" fill="#5C6BC0">db.gcp.aviatrixdemo.local</text>
+
+  <text x="725" y="525" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#5F6368">private Cloud DNS zone</text>
+  <text x="725" y="537" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#5F6368">no 100.64 overlap here (routable IP)</text>
+  <text x="725" y="555" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="500" fill="#1565C0">reachable from frontend &amp; backend pods</text>
+  <text x="725" y="567" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="500" fill="#1565C0">via Aviatrix transit fabric</text>
+</g>
+
+<!-- DB avx-gw subnet -->
+<g id="container-db-avx-subnet">
+  <rect x="595" y="685" width="260" height="148" rx="3" ry="3" fill="#FFF8F0" stroke="#C25E0E" stroke-width="1.4" stroke-dasharray="5 3"/>
+  <text x="725" y="701" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="600" fill="#C25E0E">subnet · avx-gw · 10.5.1.0/28</text>
+</g>
+
+<!-- DB Aviatrix Spoke GW -->
+<g id="node-db-avx-gw">
+  <use href="#ic-avx-gw" x="697" y="715" width="58" height="58"/>
+  <text x="725" y="789" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11" font-weight="700" fill="#111118">DB Spoke GW</text>
+  <text x="725" y="800" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="400" fill="#4A5568">n1-standard-1 · 10.5.1.2</text>
+  <text x="725" y="811" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="500" fill="#C25E0E">public IP allocated</text>
+</g>
+
+<!-- =============================================== -->
+<!-- Backend Spoke VPC -->
+<!-- =============================================== -->
+<g id="container-be-vpc">
+  <rect x="890" y="305" width="510" height="540" rx="4" ry="4" fill="#FFFFFF" stroke="#1A73E8" stroke-width="1.8" filter="url(#shadow-sm)"/>
+  <text x="902" y="324" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11" font-weight="700" fill="#1A73E8" letter-spacing="0.3">Backend Spoke VPC · 10.20.0.0/20</text>
+</g>
+
+<!-- Backend nodes subnet -->
+<g id="container-be-nodes">
+  <rect x="905" y="338" width="480" height="285" rx="3" ry="3" fill="#F8F9FA" stroke="#5F6368" stroke-width="1.2" stroke-dasharray="5 3"/>
+  <text x="915" y="354" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="600" fill="#5F6368">subnet · gke-demo-backend-nodes · 10.20.0.0/22</text>
+  <text x="915" y="367" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#5F6368">secondary: services 172.16.0.0/20</text>
+
+  <!-- GKE cluster boundary -->
+  <rect x="918" y="378" width="454" height="235" rx="4" ry="4" fill="#E6F4EA" stroke="#0F9D58" stroke-width="1.6"/>
+  <use href="#ic-gke" x="926" y="386" width="28" height="28"/>
+  <text x="960" y="397" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11" font-weight="700" fill="#0F9D58">GKE · gke-demo-backend</text>
+  <text x="960" y="409" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#4A5568">zonal · GKE Dataplane V2 (Cilium/eBPF)</text>
+
+  <rect x="1185" y="386" width="180" height="22" rx="3" fill="#FFFFFF" stroke="#0F9D58" stroke-width="1.2"/>
+  <text x="1275" y="401" text-anchor="middle" font-family="'Courier New',monospace" font-size="9" font-weight="700" fill="#0F9D58">default_snat_status: disabled</text>
+
+  <!-- pod range -->
+  <rect x="926" y="425" width="190" height="44" rx="3" fill="#FFF8E1" stroke="#F9AB00" stroke-width="1.2" stroke-dasharray="3 2"/>
+  <text x="1021" y="440" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="700" fill="#A65A00">pods · 100.64.0.0/16</text>
+  <text x="1021" y="453" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#A65A00">alias range · OVERLAPS with frontend</text>
+  <text x="1021" y="463" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#A65A00">source IP preserved end-to-end → GW</text>
+
+  <!-- Worker nodes -->
+  <rect x="1130" y="425" width="105" height="44" rx="3" fill="#FFFFFF" stroke="#5F6368" stroke-width="1"/>
+  <use href="#ic-gce" x="1135" y="430" width="22" height="22"/>
+  <text x="1195" y="440" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="600" fill="#111118">node-1</text>
+  <text x="1195" y="452" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="7" font-weight="400" fill="#4A5568">e2-standard-2</text>
+
+  <rect x="1248" y="425" width="105" height="44" rx="3" fill="#FFFFFF" stroke="#5F6368" stroke-width="1"/>
+  <use href="#ic-gce" x="1253" y="430" width="22" height="22"/>
+  <text x="1313" y="440" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="600" fill="#111118">node-2</text>
+  <text x="1313" y="452" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="7" font-weight="400" fill="#4A5568">e2-standard-2</text>
+
+  <!-- Gatus service -->
+  <rect x="926" y="485" width="427" height="40" rx="3" fill="#FFFFFF" stroke="#1A73E8" stroke-width="1.2"/>
+  <circle cx="945" cy="505" r="9" fill="#1A73E8"/>
+  <text x="945" y="509" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="700" fill="#FFFFFF">G</text>
+  <text x="965" y="500" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="700" fill="#111118">Gatus Service (workload)</text>
+  <text x="965" y="513" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#4A5568">NEG-attached → Backend GKE Gateway above</text>
+  <text x="965" y="522" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="500" fill="#0F9D58">east-west calls Frontend Gatus via spoke→transit→spoke</text>
+
+  <!-- Private GKE master callout -->
+  <rect x="926" y="540" width="427" height="60" rx="3" fill="#FAFAFA" stroke="#9AA0A6" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="1139" y="556" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="700" fill="#5F6368">Google control-plane project (managed)</text>
+  <text x="1139" y="569" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="500" fill="#1A73E8">Private GKE master · 172.20.1.0/28</text>
+  <text x="1139" y="582" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#5F6368">PSC peering to nodes · K8s API plane</text>
+  <text x="1139" y="594" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#5F6368">DCF metadata discovery via Aviatrix Controller</text>
+</g>
+
+<!-- proxy-only subnet (backend) -->
+<g id="container-be-proxy">
+  <rect x="1090" y="635" width="295" height="34" rx="3" ry="3" fill="#F1F3F4" stroke="#9AA0A6" stroke-width="1" stroke-dasharray="4 2"/>
+  <text x="1237" y="650" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="600" fill="#5F6368">subnet · gke-demo-backend-proxy-only · 10.20.5.0/24</text>
+  <text x="1237" y="662" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#5F6368">GKE Gateway proxies (regional, proxy-only)</text>
+</g>
+
+<!-- "no SNAT" badge between cluster and spoke GW (backend) -->
+<g id="badge-be-no-snat">
+  <rect x="905" y="635" width="175" height="34" rx="3" fill="#E6F4EA" stroke="#0F9D58" stroke-width="1.4"/>
+  <text x="992" y="649" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="700" fill="#0F9D58">✓ no SNAT pod → spoke GW</text>
+  <text x="992" y="662" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="400" fill="#0F9D58">pod IP 100.64.x.x preserved in-VPC</text>
+</g>
+
+<!-- Backend avx-gw subnet -->
+<g id="container-be-avx-subnet">
+  <rect x="905" y="685" width="480" height="148" rx="3" ry="3" fill="#FFF8F0" stroke="#C25E0E" stroke-width="1.4" stroke-dasharray="5 3"/>
+  <text x="915" y="701" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="600" fill="#C25E0E">subnet · gke-demo-backend-avx-gw · 10.20.4.0/28</text>
+</g>
+
+<!-- Backend Aviatrix Spoke GW -->
+<g id="node-be-avx-gw">
+  <use href="#ic-avx-gw" x="1303" y="715" width="58" height="58"/>
+  <text x="1332" y="789" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11" font-weight="700" fill="#111118">Backend Spoke GW</text>
+  <text x="1332" y="800" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="400" fill="#4A5568">n1-standard-1 · 10.20.4.2</text>
+  <text x="1332" y="811" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="500" fill="#C25E0E">public IP allocated</text>
+
+  <!-- HEADLINE: SNAT badge -->
+  <rect x="915" y="710" width="335" height="116" rx="4" fill="#FFF3E0" stroke="#FA6B1E" stroke-width="2"/>
+  <text x="1082" y="726" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11" font-weight="800" fill="#C25E0E">⬣ SNAT (customized_snat / CONDUIT_SNAT)</text>
+  <text x="923" y="743" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="700" fill="#5D2E00">Three policies on this spoke GW:</text>
+  <text x="923" y="757" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8.5" font-weight="500" fill="#5D2E00">• pods 100.64.0.0/16 → transit fabric → SNAT to GW priv IP</text>
+  <text x="923" y="770" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8.5" font-weight="500" fill="#5D2E00">• pods 100.64.0.0/16 → internet (eth0) → SNAT to GW pub IP</text>
+  <text x="923" y="783" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8.5" font-weight="500" fill="#5D2E00">• nodes 10.20.0.0/22 → internet (eth0) → SNAT to GW pub IP</text>
+  <text x="923" y="800" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="600" fill="#C62828">→ hides overlapping 100.64.0.0/16 east-west and north-south</text>
+  <text x="923" y="815" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="500" fill="#5D2E00">DCF SmartGroups still see original pod IP pre-NAT</text>
+</g>
+
+<!-- =============================================== -->
+<!-- Aviatrix Transit VPC (centered, below spokes) -->
+<!-- =============================================== -->
+<g id="container-transit-vpc">
+  <rect x="500" y="880" width="600" height="110" rx="4" ry="4" fill="#FFF8F0" stroke="#C25E0E" stroke-width="1.8" filter="url(#shadow-sm)"/>
+  <text x="800" y="900" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11" font-weight="700" fill="#C25E0E" letter-spacing="0.3">Aviatrix Transit VPC · 10.2.0.0/24</text>
+</g>
+
+<!-- Aviatrix Transit GW -->
+<g id="node-transit-gw">
+  <use href="#ic-avx-transit-gw" x="770" y="912" width="60" height="60"/>
+  <text x="800" y="987" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11" font-weight="700" fill="#111118">Aviatrix Transit GW</text>
+</g>
+
+<!-- Subtitle inside transit VPC -->
+<text x="540" y="970" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="500" fill="#4A5568">n1-standard-1</text>
+<text x="1060" y="970" text-anchor="end" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="500" fill="#4A5568">single-AZ · in-cloud IPsec</text>
+
+<!-- =============================================== -->
+<!-- IPsec tunnels (Spoke GW → Transit GW) -->
+<!-- =============================================== -->
+<g id="tunnels">
+  <!-- Frontend → Transit -->
+  <path d="M 149,773 L 149,860 L 800,860 L 800,912" fill="none" stroke="#FA6B1E" stroke-width="2" stroke-linecap="round"/>
+  <rect x="280" y="852" width="155" height="16" rx="3" fill="#FFFFFF" fill-opacity="0.95" stroke="#C25E0E" stroke-width="0.6"/>
+  <text x="357" y="864" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="600" fill="#C25E0E">Aviatrix transit (IPsec)</text>
+
+  <!-- DB → Transit -->
+  <path d="M 725,773 L 725,860 L 800,860 L 800,912" fill="none" stroke="#FA6B1E" stroke-width="2" stroke-linecap="round"/>
+
+  <!-- Backend → Transit -->
+  <path d="M 1332,773 L 1332,860 L 800,860 L 800,912" fill="none" stroke="#FA6B1E" stroke-width="2" stroke-linecap="round"/>
+  <rect x="1170" y="852" width="155" height="16" rx="3" fill="#FFFFFF" fill-opacity="0.95" stroke="#C25E0E" stroke-width="0.6"/>
+  <text x="1247" y="864" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="600" fill="#C25E0E">Aviatrix transit (IPsec)</text>
+</g>
+
+<!-- =============================================== -->
+<!-- Internet ingress arrows (Internet → GKE Gateways) -->
+<!-- =============================================== -->
+<g id="ingress">
+  <!-- Internet → Frontend GKE Gateway -->
+  <path d="M 770,135 Q 600,165 340,226" fill="none" stroke="#1565C0" stroke-width="2" marker-end="url(#arrow-blue)"/>
+  <rect x="495" y="160" width="195" height="16" rx="3" fill="#FFFFFF" stroke="#1565C0" stroke-width="0.6"/>
+  <text x="592" y="172" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="600" fill="#1565C0">A · north-south ingress (HTTPS)</text>
+
+  <!-- Internet → Backend GKE Gateway -->
+  <path d="M 830,135 Q 1000,165 1040,226" fill="none" stroke="#1565C0" stroke-width="2" marker-end="url(#arrow-blue)"/>
+  <rect x="900" y="160" width="195" height="16" rx="3" fill="#FFFFFF" stroke="#1565C0" stroke-width="0.6"/>
+  <text x="997" y="172" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="600" fill="#1565C0">A · north-south ingress (HTTPS)</text>
+</g>
+
+<!-- GKE Gateway → cluster (NEG) -->
+<g id="neg-arrows">
+  <path d="M 340,278 L 340,378" fill="none" stroke="#1565C0" stroke-width="1.4" stroke-dasharray="5 3" marker-end="url(#arrow-blue)"/>
+  <rect x="350" y="318" width="80" height="14" rx="2" fill="#FFFFFF" stroke="#1565C0" stroke-width="0.5"/>
+  <text x="390" y="328" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="500" fill="#1565C0">NEG → Gatus</text>
+
+  <path d="M 1040,278 L 1040,378" fill="none" stroke="#1565C0" stroke-width="1.4" stroke-dasharray="5 3" marker-end="url(#arrow-blue)"/>
+  <rect x="1050" y="318" width="80" height="14" rx="2" fill="#FFFFFF" stroke="#1565C0" stroke-width="0.5"/>
+  <text x="1090" y="328" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="500" fill="#1565C0">NEG → Gatus</text>
+</g>
+
+<!-- =============================================== -->
+<!-- Direct egress arrows (Spoke GW → Internet, no Cloud NAT) -->
+<!-- =============================================== -->
+<g id="egress">
+  <!-- Frontend GW → Internet -->
+  <path d="M 100,742 C 30,500 30,200 730,108" fill="none" stroke="#2E7D32" stroke-width="2" marker-end="url(#arrow-green)"/>
+  <rect x="35" y="305" width="105" height="32" rx="3" fill="#E6F4EA" stroke="#0F9D58" stroke-width="1.2"/>
+  <text x="87" y="318" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="700" fill="#0F9D58">C · egress (eth0)</text>
+  <text x="87" y="330" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="500" fill="#0F9D58">✓ no Cloud NAT</text>
+
+  <!-- Backend GW → Internet -->
+  <path d="M 1380,742 C 1570,500 1570,200 880,108" fill="none" stroke="#2E7D32" stroke-width="2" marker-end="url(#arrow-green)"/>
+  <rect x="1455" y="305" width="105" height="32" rx="3" fill="#E6F4EA" stroke="#0F9D58" stroke-width="1.2"/>
+  <text x="1507" y="318" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="700" fill="#0F9D58">C · egress (eth0)</text>
+  <text x="1507" y="330" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="500" fill="#0F9D58">✓ no Cloud NAT</text>
+
+  <!-- DB GW → Internet -->
+  <path d="M 678,720 C 660,520 660,300 770,140" fill="none" stroke="#2E7D32" stroke-width="1.6" stroke-dasharray="6 3" marker-end="url(#arrow-green)"/>
+  <rect x="555" y="465" width="105" height="20" rx="3" fill="#E6F4EA" stroke="#0F9D58" stroke-width="1"/>
+  <text x="607" y="478" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="600" fill="#0F9D58">egress (eth0)</text>
+</g>
+
+<!-- =============================================== -->
+<!-- Controller management dotted lines -->
+<!-- =============================================== -->
+<g id="ctrl-mgmt" stroke="#9AA0A6" stroke-width="1" stroke-dasharray="3 3" fill="none">
+  <path d="M 1460,285 Q 1460,500 1332,742"/>
+  <path d="M 1460,285 Q 1460,500 800,920"/>
+  <path d="M 1460,285 Q 1460,500 725,742"/>
+  <path d="M 1460,285 Q 1460,500 149,742"/>
+</g>
+<text x="1413" y="318" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="500" fill="#5F6368">mgmt (HTTPS)</text>
+
+<!-- =============================================== -->
+<!-- East-west flow callout (purple — Flow B) -->
+<!-- =============================================== -->
+<g id="ew-flow">
+  <rect x="50" y="855" width="430" height="22" rx="3" fill="#F3E5F5" stroke="#6A1B9A" stroke-width="1"/>
+  <text x="265" y="869" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="700" fill="#6A1B9A">B · east-west: pod 100.64.x.x → SNAT 10.10.4.2 → IPsec → spoke → pod</text>
+</g>
+
+<!-- =============================================== -->
+<!-- Default route annotations on spoke VPCs (placed in space below avx-gw subnet) -->
+<!-- =============================================== -->
+<text x="305" y="843" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-style="italic" font-weight="500" fill="#7B5E00">VPC route: 0.0.0.0/0 → spoke GW (priority 991, untagged) — Controller-managed</text>
+<text x="725" y="843" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-style="italic" font-weight="500" fill="#7B5E00">VPC route: 0.0.0.0/0 → spoke GW (pri 991)</text>
+<text x="1145" y="843" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-style="italic" font-weight="500" fill="#7B5E00">VPC route: 0.0.0.0/0 → spoke GW (priority 991, untagged) — Controller-managed</text>
+
+<!-- =============================================== -->
+<!-- DCF policy enforcement panel (fabric-wide, with examples) -->
+<!-- =============================================== -->
+<g id="dcf-band">
+  <rect x="50" y="1005" width="1500" height="155" rx="4" ry="4" fill="#FDF6F6" stroke="#8E0000" stroke-width="1.6" stroke-dasharray="6 3" filter="url(#shadow-sm)"/>
+  <text x="60" y="1024" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="12" font-weight="800" fill="#C62828">DCF Policy Enforcement (fabric-wide · evaluated at every spoke gateway)</text>
+  <text x="60" y="1037" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="500" fill="#5F6368">SmartGroups are NAT-aware: rules match the original pod IP (100.64.x.x) before spoke-GW SNAT. Cluster onboarding tags pods by namespace + service via the K8s-firewall agent.</text>
+
+  <!-- SmartGroup definitions (left column) -->
+  <text x="60" y="1062" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="700" fill="#111118">SmartGroups (K8s-typed, 4 used in this blueprint)</text>
+
+  <rect x="60" y="1070" width="320" height="18" rx="2" fill="#FFFFFF" stroke="#9AA0A6" stroke-width="0.6"/>
+  <text x="68" y="1083" text-anchor="start" font-family="'Courier New',monospace" font-size="9" font-weight="600" fill="#0F9D58">sg-fe-gatus</text>
+  <text x="155" y="1083" text-anchor="start" font-family="'Courier New',monospace" font-size="8" font-weight="400" fill="#4A5568">cluster=gke-demo-frontend, ns=default, svc=gatus</text>
+
+  <rect x="60" y="1090" width="320" height="18" rx="2" fill="#FFFFFF" stroke="#9AA0A6" stroke-width="0.6"/>
+  <text x="68" y="1103" text-anchor="start" font-family="'Courier New',monospace" font-size="9" font-weight="600" fill="#0F9D58">sg-be-gatus</text>
+  <text x="155" y="1103" text-anchor="start" font-family="'Courier New',monospace" font-size="8" font-weight="400" fill="#4A5568">cluster=gke-demo-backend,  ns=default, svc=gatus</text>
+
+  <rect x="60" y="1110" width="320" height="18" rx="2" fill="#FFFFFF" stroke="#9AA0A6" stroke-width="0.6"/>
+  <text x="68" y="1123" text-anchor="start" font-family="'Courier New',monospace" font-size="9" font-weight="600" fill="#0F9D58">sg-all-gke-pods</text>
+  <text x="155" y="1123" text-anchor="start" font-family="'Courier New',monospace" font-size="8" font-weight="400" fill="#4A5568">any cluster, any ns (CIDR 100.64.0.0/16)</text>
+
+  <rect x="60" y="1130" width="320" height="18" rx="2" fill="#FFFFFF" stroke="#9AA0A6" stroke-width="0.6"/>
+  <text x="68" y="1143" text-anchor="start" font-family="'Courier New',monospace" font-size="9" font-weight="600" fill="#7C3AED">sg-db-vm</text>
+  <text x="155" y="1143" text-anchor="start" font-family="'Courier New',monospace" font-size="8" font-weight="400" fill="#4A5568">VPC-typed: 10.5.0.0/24 (DB Spoke VPC, vms subnet)</text>
+
+  <!-- Policy rule table (right side) -->
+  <text x="395" y="1062" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="700" fill="#111118">Policy rule list (12 rules total · top 6 shown · first match wins)</text>
+
+  <!-- Header row -->
+  <rect x="395" y="1068" width="1155" height="16" fill="#FFEAEA" stroke="#C62828" stroke-width="0.6"/>
+  <text x="403" y="1080" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="700" fill="#5D2E00">#</text>
+  <text x="425" y="1080" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="700" fill="#5D2E00">Source</text>
+  <text x="650" y="1080" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="700" fill="#5D2E00">Destination</text>
+  <text x="940" y="1080" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="700" fill="#5D2E00">Protocol / Port</text>
+  <text x="1130" y="1080" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="700" fill="#5D2E00">Action</text>
+  <text x="1215" y="1080" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="700" fill="#5D2E00">Why</text>
+
+  <!-- Rule 1 -->
+  <rect x="395" y="1085" width="1155" height="13" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="0.4"/>
+  <text x="403" y="1095" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#111118">10</text>
+  <text x="425" y="1095" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#0F9D58">sg-fe-gatus</text>
+  <text x="650" y="1095" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#0F9D58">sg-be-gatus</text>
+  <text x="940" y="1095" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#111118">TCP/443, TCP/80</text>
+  <text x="1130" y="1095" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" font-weight="700" fill="#0F9D58">PERMIT</text>
+  <text x="1215" y="1095" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" fill="#4A5568">cross-cluster Gatus health check (east-west)</text>
+
+  <!-- Rule 2 -->
+  <rect x="395" y="1098" width="1155" height="13" fill="#F8F9FA" stroke="#E0E0E0" stroke-width="0.4"/>
+  <text x="403" y="1108" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#111118">20</text>
+  <text x="425" y="1108" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#0F9D58">sg-be-gatus</text>
+  <text x="650" y="1108" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#0F9D58">sg-fe-gatus</text>
+  <text x="940" y="1108" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#111118">TCP/443, TCP/80</text>
+  <text x="1130" y="1108" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" font-weight="700" fill="#0F9D58">PERMIT</text>
+  <text x="1215" y="1108" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" fill="#4A5568">return path (stateful — symmetric pair w/ 10)</text>
+
+  <!-- Rule 3 -->
+  <rect x="395" y="1111" width="1155" height="13" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="0.4"/>
+  <text x="403" y="1121" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#111118">30</text>
+  <text x="425" y="1121" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#0F9D58">sg-all-gke-pods</text>
+  <text x="650" y="1121" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#7C3AED">sg-db-vm</text>
+  <text x="940" y="1121" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#111118">TCP/80 (Apache)</text>
+  <text x="1130" y="1121" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" font-weight="700" fill="#0F9D58">PERMIT</text>
+  <text x="1215" y="1121" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" fill="#4A5568">pods → db.gcp.aviatrixdemo.local (DB read)</text>
+
+  <!-- Rule 4 -->
+  <rect x="395" y="1124" width="1155" height="13" fill="#F8F9FA" stroke="#E0E0E0" stroke-width="0.4"/>
+  <text x="403" y="1134" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#111118">40</text>
+  <text x="425" y="1134" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#0F9D58">sg-all-gke-pods</text>
+  <text x="650" y="1134" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#1565C0">webcat:business-services, webcat:cdn</text>
+  <text x="940" y="1134" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#111118">TCP/443</text>
+  <text x="1130" y="1134" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" font-weight="700" fill="#0F9D58">PERMIT</text>
+  <text x="1215" y="1134" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" fill="#4A5568">pod → internet (web-category match · ThreatIQ enriched)</text>
+
+  <!-- Rule 5 -->
+  <rect x="395" y="1137" width="1155" height="13" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="0.4"/>
+  <text x="403" y="1147" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#111118">50</text>
+  <text x="425" y="1147" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#0F9D58">sg-all-gke-pods</text>
+  <text x="650" y="1147" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#C62828">webcat:malware, webcat:proxy-avoidance, GeoIP:CN/RU/KP</text>
+  <text x="940" y="1147" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#111118">any</text>
+  <text x="1130" y="1147" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" font-weight="700" fill="#C62828">DENY + log</text>
+  <text x="1215" y="1147" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" fill="#4A5568">block known-bad categories &amp; high-risk geos</text>
+
+  <!-- Rule 6 (default) -->
+  <rect x="395" y="1150" width="1155" height="13" fill="#F8F9FA" stroke="#E0E0E0" stroke-width="0.4"/>
+  <text x="403" y="1160" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#111118">999</text>
+  <text x="425" y="1160" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#5F6368">any</text>
+  <text x="650" y="1160" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#5F6368">any</text>
+  <text x="940" y="1160" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" fill="#111118">any</text>
+  <text x="1130" y="1160" text-anchor="start" font-family="'Courier New',monospace" font-size="8.5" font-weight="700" fill="#C62828">DENY</text>
+  <text x="1215" y="1160" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" fill="#4A5568">default deny — zero-trust posture, fabric-wide</text>
+</g>
+
+<!-- =============================================== -->
+<!-- Legend -->
+<!-- =============================================== -->
+<g id="legend">
+  <rect x="1400" y="855" width="160" height="135" rx="4" ry="4" fill="#FFFFFF" stroke="#9AA0A6" stroke-width="1"/>
+  <text x="1480" y="870" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10" font-weight="700" fill="#111118">Traffic flows</text>
+
+  <line x1="1412" y1="884" x2="1432" y2="884" stroke="#1565C0" stroke-width="2"/>
+  <text x="1438" y="888" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="600" fill="#1565C0">A · north-south (ALB)</text>
+
+  <line x1="1412" y1="903" x2="1432" y2="903" stroke="#6A1B9A" stroke-width="2"/>
+  <text x="1438" y="907" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="600" fill="#6A1B9A">B · east-west (cluster)</text>
+
+  <line x1="1412" y1="922" x2="1432" y2="922" stroke="#2E7D32" stroke-width="2"/>
+  <text x="1438" y="926" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="600" fill="#2E7D32">C · pod → internet</text>
+
+  <line x1="1412" y1="941" x2="1432" y2="941" stroke="#FA6B1E" stroke-width="2"/>
+  <text x="1438" y="945" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="600" fill="#C25E0E">Aviatrix IPsec</text>
+
+  <line x1="1412" y1="960" x2="1432" y2="960" stroke="#9AA0A6" stroke-width="1" stroke-dasharray="3 3"/>
+  <text x="1438" y="964" text-anchor="start" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="500" fill="#5F6368">control / mgmt</text>
+
+  <text x="1480" y="980" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="8" font-weight="500" fill="#5F6368">orange = Aviatrix · blue = GCP-native</text>
+</g>
+
+<!-- =============================================== -->
+<!-- East-west PURPLE flow (B): Frontend pod → SNAT → IPsec → Backend pod -->
+<!-- Drawn as a colored overlay arrow from FE Gatus down through transit and back up to BE Gatus -->
+<!-- =============================================== -->
+<g id="ew-purple-overlay" opacity="0.9">
+  <!-- FE Gatus → FE Spoke GW (within VPC, no SNAT yet) — routed around master callout -->
+  <path d="M 100,505 L 60,505 L 60,675 L 149,675 L 149,710" fill="none" stroke="#6A1B9A" stroke-width="2.2" marker-end="url(#arrow-purple)"/>
+  <rect x="22" y="552" width="80" height="14" rx="2" fill="#FFFFFF" fill-opacity="0.95" stroke="#6A1B9A" stroke-width="0.6"/>
+  <text x="62" y="562" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="600" fill="#6A1B9A">src 100.64.x.x</text>
+
+  <!-- BE Spoke GW → BE Gatus (within VPC, post-tunnel decap) — routed around master callout -->
+  <path d="M 1332,710 L 1332,675 L 1390,675 L 1390,505 L 1353,505" fill="none" stroke="#6A1B9A" stroke-width="2.2" marker-end="url(#arrow-purple)"/>
+  <rect x="1352" y="552" width="80" height="14" rx="2" fill="#FFFFFF" fill-opacity="0.95" stroke="#6A1B9A" stroke-width="0.6"/>
+  <text x="1392" y="562" text-anchor="middle" font-family="'Inter','Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="9" font-weight="600" fill="#6A1B9A">dst 100.64.x.x</text>
+</g>
+</svg>

--- a/blueprints/gcp-gke-multicluster/clusters/backend/data.tf
+++ b/blueprints/gcp-gke-multicluster/clusters/backend/data.tf
@@ -1,0 +1,6 @@
+data "terraform_remote_state" "network" {
+  backend = "local"
+  config = {
+    path = "../../network/terraform.tfstate"
+  }
+}

--- a/blueprints/gcp-gke-multicluster/clusters/backend/main.tf
+++ b/blueprints/gcp-gke-multicluster/clusters/backend/main.tf
@@ -1,18 +1,3 @@
-terraform {
-  required_version = ">= 1.5"
-
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = "~> 6.0"
-    }
-    aviatrix = {
-      source  = "AviatrixSystems/aviatrix"
-      version = "~> 8.2"
-    }
-  }
-}
-
 provider "google" {
   project = local.project_id
   region  = local.region

--- a/blueprints/gcp-gke-multicluster/clusters/backend/main.tf
+++ b/blueprints/gcp-gke-multicluster/clusters/backend/main.tf
@@ -1,0 +1,258 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 8.2"
+    }
+  }
+}
+
+provider "google" {
+  project = local.project_id
+  region  = local.region
+}
+
+provider "aviatrix" {
+  controller_ip           = var.aviatrix_controller_ip
+  username                = var.aviatrix_username
+  password                = var.aviatrix_password
+  skip_version_validation = true
+}
+
+locals {
+  cluster_name   = data.terraform_remote_state.network.outputs.backend_cluster_name
+  project_id     = data.terraform_remote_state.network.outputs.gcp_project_id
+  region         = data.terraform_remote_state.network.outputs.gcp_region
+  zone           = data.terraform_remote_state.network.outputs.gcp_zone
+  vpc_self_link  = data.terraform_remote_state.network.outputs.backend_vpc_self_link
+  nodes_subnet   = data.terraform_remote_state.network.outputs.backend_nodes_subnet_name
+  pods_range     = data.terraform_remote_state.network.outputs.backend_pods_range_name
+  services_range = data.terraform_remote_state.network.outputs.backend_services_range_name
+  master_cidr    = data.terraform_remote_state.network.outputs.backend_master_cidr
+  spoke_gw_ip    = data.terraform_remote_state.network.outputs.backend_spoke_gateway_public_ip
+
+  # GKE master authorized networks = user IPs ∪ {spoke GW egress IP} ∪ {controller IP if onboarding enabled}.
+  # Spoke GW egress is required because GKE node→master health checks egress
+  # via the spoke (the master endpoint is public). Controller IP is required
+  # because the onboarding flow has the controller call the GKE API server
+  # directly after fetching credentials via the GCP access account.
+  authorized_networks = concat(
+    [for cidr in var.master_authorized_cidr_blocks : { cidr_block = cidr, display_name = "user" }],
+    [{ cidr_block = "${local.spoke_gw_ip}/32", display_name = "aviatrix-spoke-egress" }],
+    var.enable_aviatrix_onboarding && var.aviatrix_controller_public_ip != null
+    ? [{ cidr_block = "${var.aviatrix_controller_public_ip}/32", display_name = "aviatrix-controller" }]
+    : [],
+  )
+}
+
+#####################
+# Service account for the GKE nodes
+#####################
+
+resource "google_service_account" "node" {
+  account_id   = "${local.cluster_name}-node-sa"
+  display_name = "GKE node SA for ${local.cluster_name}"
+  project      = local.project_id
+}
+
+# Minimum permissions for GKE nodes per
+# https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa
+resource "google_project_iam_member" "node_log_writer" {
+  project = local.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.node.email}"
+}
+
+resource "google_project_iam_member" "node_metric_writer" {
+  project = local.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.node.email}"
+}
+
+resource "google_project_iam_member" "node_monitoring_viewer" {
+  project = local.project_id
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${google_service_account.node.email}"
+}
+
+resource "google_project_iam_member" "node_resource_metadata" {
+  project = local.project_id
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.node.email}"
+}
+
+resource "google_project_iam_member" "node_artifact_reader" {
+  project = local.project_id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${google_service_account.node.email}"
+}
+
+#####################
+# GKE cluster
+#####################
+
+resource "google_container_cluster" "this" {
+  name     = local.cluster_name
+  project  = local.project_id
+  location = local.zone
+
+  # Manage the system node pool separately (best practice — lets us recreate
+  # node pools without destroying the cluster control plane).
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  network         = local.vpc_self_link
+  subnetwork      = local.nodes_subnet
+  networking_mode = "VPC_NATIVE"
+
+  # Dataplane V2 = Cilium-based eBPF. Replaces kube-proxy; provides network
+  # policy + observability. NetworkPolicy enforcement is enabled by default
+  # under DPV2, so the legacy network_policy block is omitted.
+  datapath_provider = "ADVANCED_DATAPATH"
+
+  release_channel {
+    channel = "REGULAR"
+  }
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = local.pods_range
+    services_secondary_range_name = local.services_range
+  }
+
+  # Private nodes (no public IPs) but public master endpoint with allowlist.
+  # Node egress flows through the Aviatrix spoke GW via the VPC's default
+  # route (programmed by Aviatrix 9.0).
+  private_cluster_config {
+    enable_private_nodes    = true
+    enable_private_endpoint = false
+    master_ipv4_cidr_block  = local.master_cidr
+  }
+
+  master_authorized_networks_config {
+    dynamic "cidr_blocks" {
+      for_each = local.authorized_networks
+      content {
+        cidr_block   = cidr_blocks.value.cidr_block
+        display_name = cidr_blocks.value.display_name
+      }
+    }
+  }
+
+  # Pod source IPs reach the spoke GW unmasqueraded — Aviatrix SNATs them.
+  # Equivalent to Cilium enableIPv4Masquerade=false in the AKS variant.
+  default_snat_status {
+    disabled = true
+  }
+
+  workload_identity_config {
+    workload_pool = "${local.project_id}.svc.id.goog"
+  }
+
+  # Enable Gateway API CRDs — backs `gke-l7-global-external-managed` Gateway
+  # provisioning by the GKE controller.
+  gateway_api_config {
+    channel = "CHANNEL_STANDARD"
+  }
+
+  # Required deletion-protection knob — explicit so destroy works in lab use.
+  deletion_protection = false
+
+  # Release channel advances master_version out of band — let it drift.
+  lifecycle {
+    ignore_changes = [min_master_version]
+  }
+}
+
+#####################
+# Node pool
+#####################
+
+resource "google_container_node_pool" "primary" {
+  name       = "primary"
+  project    = local.project_id
+  location   = local.zone
+  cluster    = google_container_cluster.this.name
+  node_count = var.node_pool_config.initial_count
+
+  autoscaling {
+    min_node_count = var.node_pool_config.min_count
+    max_node_count = var.node_pool_config.max_count
+  }
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  upgrade_settings {
+    strategy        = "SURGE"
+    max_surge       = 1
+    max_unavailable = 0
+  }
+
+  node_config {
+    machine_type = var.node_pool_config.machine_type
+    disk_size_gb = var.node_pool_config.disk_size_gb
+    disk_type    = "pd-balanced"
+
+    service_account = google_service_account.node.email
+    oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+
+    # Workload Identity for pod-level IAM (used by ExternalDNS in nodes/).
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+
+    shielded_instance_config {
+      enable_secure_boot          = true
+      enable_integrity_monitoring = true
+    }
+
+    labels = {
+      environment = "demo"
+      blueprint   = "gcp-gke-multicluster"
+      cluster     = "backend"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+}
+
+#####################
+# Service account for ExternalDNS (Workload Identity Federation for GKE)
+#
+# Bound to KSA `kube-system/external-dns` via roles/iam.workloadIdentityUser.
+# The KSA is created by the ExternalDNS Helm chart in nodes/frontend.
+#####################
+
+resource "google_service_account" "external_dns" {
+  account_id   = "${local.cluster_name}-edns"
+  display_name = "ExternalDNS for ${local.cluster_name}"
+  project      = local.project_id
+}
+
+# Manage records in the private Cloud DNS zone.
+resource "google_project_iam_member" "external_dns_admin" {
+  project = local.project_id
+  role    = "roles/dns.admin"
+  member  = "serviceAccount:${google_service_account.external_dns.email}"
+}
+
+# Bind the KSA to the GSA — Workload Identity Federation for GKE.
+# The pool `<project>.svc.id.goog` only exists once a cluster with
+# workload_identity_config has been created — explicit dep avoids the race.
+resource "google_service_account_iam_member" "external_dns_wif" {
+  service_account_id = google_service_account.external_dns.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${local.project_id}.svc.id.goog[kube-system/external-dns]"
+
+  depends_on = [google_container_cluster.this]
+}

--- a/blueprints/gcp-gke-multicluster/clusters/backend/onboarding.tf
+++ b/blueprints/gcp-gke-multicluster/clusters/backend/onboarding.tf
@@ -1,0 +1,34 @@
+#####################
+# Aviatrix Controller Onboarding
+#
+# Registers the GKE cluster with the Aviatrix Controller so DCF SmartGroups
+# can target Kubernetes-typed selectors (cluster, namespace, service, pod)
+# instead of just VPC selectors.
+#
+# Auth flow:
+#   1. Controller calls GKE container.googleapis.com via the Aviatrix GCP
+#      access account's service account to fetch a kubeconfig.
+#   2. Controller connects to the cluster's public master endpoint with that
+#      kubeconfig (the master endpoint must allow the controller's egress IP
+#      via master_authorized_networks).
+#
+# Requirements (NOT enforced by Terraform — pre-checks for the operator):
+#   - Aviatrix GCP access account onboarded (see network/, var.aviatrix_gcp_account_name).
+#   - That account's service account has roles/container.viewer (read kubeconfig)
+#     and roles/container.admin or equivalent (lookup cluster details). The
+#     "Kubernetes Engine Admin" predefined role works.
+#   - Controller's public egress IP is in the cluster's master_authorized_networks
+#     (see var.aviatrix_controller_public_ip).
+#####################
+
+resource "aviatrix_kubernetes_cluster" "this" {
+  count = var.enable_aviatrix_onboarding ? 1 : 0
+
+  cluster_id          = google_container_cluster.this.self_link
+  use_csp_credentials = true
+
+  depends_on = [
+    google_container_cluster.this,
+    google_container_node_pool.primary,
+  ]
+}

--- a/blueprints/gcp-gke-multicluster/clusters/backend/outputs.tf
+++ b/blueprints/gcp-gke-multicluster/clusters/backend/outputs.tf
@@ -1,5 +1,6 @@
 output "cluster_name" {
-  value = google_container_cluster.this.name
+  description = "Name of the GKE cluster (matches network layer's backend_cluster_name)."
+  value       = google_container_cluster.this.name
 }
 
 output "cluster_self_link" {
@@ -19,7 +20,8 @@ output "cluster_ca_certificate" {
 }
 
 output "node_service_account_email" {
-  value = google_service_account.node.email
+  description = "GSA email used by the GKE node pool (least-privilege; consumed by IAM bindings in this layer)."
+  value       = google_service_account.node.email
 }
 
 output "external_dns_service_account_email" {
@@ -28,5 +30,6 @@ output "external_dns_service_account_email" {
 }
 
 output "workload_identity_pool" {
-  value = "${data.terraform_remote_state.network.outputs.gcp_project_id}.svc.id.goog"
+  description = "Workload Identity pool for the project (<project-id>.svc.id.goog); used by KSA→GSA bindings in nodes/backend."
+  value       = "${data.terraform_remote_state.network.outputs.gcp_project_id}.svc.id.goog"
 }

--- a/blueprints/gcp-gke-multicluster/clusters/backend/outputs.tf
+++ b/blueprints/gcp-gke-multicluster/clusters/backend/outputs.tf
@@ -1,0 +1,32 @@
+output "cluster_name" {
+  value = google_container_cluster.this.name
+}
+
+output "cluster_self_link" {
+  description = "GKE cluster self_link — used as cluster_id by aviatrix_kubernetes_cluster and K8s SmartGroups"
+  value       = google_container_cluster.this.self_link
+}
+
+output "cluster_endpoint" {
+  description = "Public master endpoint (for kubectl after master_authorized_networks allowlists your IP)"
+  value       = google_container_cluster.this.endpoint
+}
+
+output "cluster_ca_certificate" {
+  description = "Cluster CA cert (base64) — consumed by the kubernetes/helm providers in nodes/"
+  value       = google_container_cluster.this.master_auth[0].cluster_ca_certificate
+  sensitive   = true
+}
+
+output "node_service_account_email" {
+  value = google_service_account.node.email
+}
+
+output "external_dns_service_account_email" {
+  description = "GSA email bound to KSA kube-system/external-dns via Workload Identity Federation"
+  value       = google_service_account.external_dns.email
+}
+
+output "workload_identity_pool" {
+  value = "${data.terraform_remote_state.network.outputs.gcp_project_id}.svc.id.goog"
+}

--- a/blueprints/gcp-gke-multicluster/clusters/backend/terraform.tfvars.example
+++ b/blueprints/gcp-gke-multicluster/clusters/backend/terraform.tfvars.example
@@ -1,0 +1,14 @@
+# Aviatrix Controller credentials should be exported as env vars (not in this file):
+#   export AVIATRIX_CONTROLLER_IP=...
+#   export AVIATRIX_USERNAME=...
+#   export AVIATRIX_PASSWORD=...
+
+# Add your IP or 0.0.0.0/0 (lab); the spoke GW + controller IP are appended automatically.
+# master_authorized_cidr_blocks = ["0.0.0.0/0"]
+
+# Tighten if you restrict master_authorized_cidr_blocks; otherwise null is fine.
+# aviatrix_controller_public_ip = null
+
+# Onboarding requires the Aviatrix GCP access account's SA to have at least
+# roles/container.clusterViewer in the project. See onboarding.tf header.
+# enable_aviatrix_onboarding = true

--- a/blueprints/gcp-gke-multicluster/clusters/backend/variables.tf
+++ b/blueprints/gcp-gke-multicluster/clusters/backend/variables.tf
@@ -1,0 +1,75 @@
+variable "node_pool_config" {
+  description = "Sizing for the primary GKE node pool"
+  type = object({
+    machine_type  = string
+    disk_size_gb  = number
+    initial_count = number
+    min_count     = number
+    max_count     = number
+  })
+  default = {
+    # 2 vCPU, 8 GB — comfortable for Cilium + system pods + Gatus + DCF agent.
+    machine_type  = "e2-standard-2"
+    disk_size_gb  = 50
+    initial_count = 2
+    min_count     = 1
+    max_count     = 3
+  }
+}
+
+variable "master_authorized_cidr_blocks" {
+  description = <<-EOT
+    User CIDR blocks allowed to reach the GKE master endpoint.
+    Add your current public IP (e.g., ["1.2.3.4/32"]).
+    Use ["0.0.0.0/0"] to allow all (lab only).
+    The Aviatrix spoke GW egress IP and (when enable_aviatrix_onboarding=true)
+    the Aviatrix Controller IP are appended automatically.
+  EOT
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+#####################
+# Aviatrix Cluster Onboarding
+#####################
+
+variable "enable_aviatrix_onboarding" {
+  description = <<-EOT
+    Register this GKE cluster with the Aviatrix Controller so DCF SmartGroups
+    can target k8s clusters, namespaces, services, and pods.
+    When true, the Aviatrix GCP access account's service account needs at
+    minimum roles/container.clusterViewer on the project (for getKubeconfig).
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "aviatrix_controller_ip" {
+  description = "Aviatrix Controller IP/hostname (or set AVIATRIX_CONTROLLER_IP env var)"
+  type        = string
+  default     = null
+}
+
+variable "aviatrix_username" {
+  description = "Aviatrix Controller username (or set AVIATRIX_USERNAME env var)"
+  type        = string
+  default     = null
+}
+
+variable "aviatrix_password" {
+  description = "Aviatrix Controller password (or set AVIATRIX_PASSWORD env var)"
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "aviatrix_controller_public_ip" {
+  description = <<-EOT
+    Public egress IP of the Aviatrix Controller, appended to GKE
+    master_authorized_networks when enable_aviatrix_onboarding = true.
+    Required only when master_authorized_cidr_blocks is restrictive; skip
+    if you used ["0.0.0.0/0"].
+  EOT
+  type        = string
+  default     = null
+}

--- a/blueprints/gcp-gke-multicluster/clusters/backend/versions.tf
+++ b/blueprints/gcp-gke-multicluster/clusters/backend/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 8.2"
+    }
+  }
+}

--- a/blueprints/gcp-gke-multicluster/clusters/frontend/data.tf
+++ b/blueprints/gcp-gke-multicluster/clusters/frontend/data.tf
@@ -1,0 +1,6 @@
+data "terraform_remote_state" "network" {
+  backend = "local"
+  config = {
+    path = "../../network/terraform.tfstate"
+  }
+}

--- a/blueprints/gcp-gke-multicluster/clusters/frontend/main.tf
+++ b/blueprints/gcp-gke-multicluster/clusters/frontend/main.tf
@@ -1,18 +1,3 @@
-terraform {
-  required_version = ">= 1.5"
-
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = "~> 6.0"
-    }
-    aviatrix = {
-      source  = "AviatrixSystems/aviatrix"
-      version = "~> 8.2"
-    }
-  }
-}
-
 provider "google" {
   project = local.project_id
   region  = local.region

--- a/blueprints/gcp-gke-multicluster/clusters/frontend/main.tf
+++ b/blueprints/gcp-gke-multicluster/clusters/frontend/main.tf
@@ -1,0 +1,258 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 8.2"
+    }
+  }
+}
+
+provider "google" {
+  project = local.project_id
+  region  = local.region
+}
+
+provider "aviatrix" {
+  controller_ip           = var.aviatrix_controller_ip
+  username                = var.aviatrix_username
+  password                = var.aviatrix_password
+  skip_version_validation = true
+}
+
+locals {
+  cluster_name   = data.terraform_remote_state.network.outputs.frontend_cluster_name
+  project_id     = data.terraform_remote_state.network.outputs.gcp_project_id
+  region         = data.terraform_remote_state.network.outputs.gcp_region
+  zone           = data.terraform_remote_state.network.outputs.gcp_zone
+  vpc_self_link  = data.terraform_remote_state.network.outputs.frontend_vpc_self_link
+  nodes_subnet   = data.terraform_remote_state.network.outputs.frontend_nodes_subnet_name
+  pods_range     = data.terraform_remote_state.network.outputs.frontend_pods_range_name
+  services_range = data.terraform_remote_state.network.outputs.frontend_services_range_name
+  master_cidr    = data.terraform_remote_state.network.outputs.frontend_master_cidr
+  spoke_gw_ip    = data.terraform_remote_state.network.outputs.frontend_spoke_gateway_public_ip
+
+  # GKE master authorized networks = user IPs ∪ {spoke GW egress IP} ∪ {controller IP if onboarding enabled}.
+  # Spoke GW egress is required because GKE node→master health checks egress
+  # via the spoke (the master endpoint is public). Controller IP is required
+  # because the onboarding flow has the controller call the GKE API server
+  # directly after fetching credentials via the GCP access account.
+  authorized_networks = concat(
+    [for cidr in var.master_authorized_cidr_blocks : { cidr_block = cidr, display_name = "user" }],
+    [{ cidr_block = "${local.spoke_gw_ip}/32", display_name = "aviatrix-spoke-egress" }],
+    var.enable_aviatrix_onboarding && var.aviatrix_controller_public_ip != null
+    ? [{ cidr_block = "${var.aviatrix_controller_public_ip}/32", display_name = "aviatrix-controller" }]
+    : [],
+  )
+}
+
+#####################
+# Service account for the GKE nodes
+#####################
+
+resource "google_service_account" "node" {
+  account_id   = "${local.cluster_name}-node-sa"
+  display_name = "GKE node SA for ${local.cluster_name}"
+  project      = local.project_id
+}
+
+# Minimum permissions for GKE nodes per
+# https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa
+resource "google_project_iam_member" "node_log_writer" {
+  project = local.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.node.email}"
+}
+
+resource "google_project_iam_member" "node_metric_writer" {
+  project = local.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.node.email}"
+}
+
+resource "google_project_iam_member" "node_monitoring_viewer" {
+  project = local.project_id
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${google_service_account.node.email}"
+}
+
+resource "google_project_iam_member" "node_resource_metadata" {
+  project = local.project_id
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.node.email}"
+}
+
+resource "google_project_iam_member" "node_artifact_reader" {
+  project = local.project_id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${google_service_account.node.email}"
+}
+
+#####################
+# GKE cluster
+#####################
+
+resource "google_container_cluster" "this" {
+  name     = local.cluster_name
+  project  = local.project_id
+  location = local.zone
+
+  # Manage the system node pool separately (best practice — lets us recreate
+  # node pools without destroying the cluster control plane).
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  network         = local.vpc_self_link
+  subnetwork      = local.nodes_subnet
+  networking_mode = "VPC_NATIVE"
+
+  # Dataplane V2 = Cilium-based eBPF. Replaces kube-proxy; provides network
+  # policy + observability. NetworkPolicy enforcement is enabled by default
+  # under DPV2, so the legacy network_policy block is omitted.
+  datapath_provider = "ADVANCED_DATAPATH"
+
+  release_channel {
+    channel = "REGULAR"
+  }
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = local.pods_range
+    services_secondary_range_name = local.services_range
+  }
+
+  # Private nodes (no public IPs) but public master endpoint with allowlist.
+  # Node egress flows through the Aviatrix spoke GW via the VPC's default
+  # route (programmed by Aviatrix 9.0).
+  private_cluster_config {
+    enable_private_nodes    = true
+    enable_private_endpoint = false
+    master_ipv4_cidr_block  = local.master_cidr
+  }
+
+  master_authorized_networks_config {
+    dynamic "cidr_blocks" {
+      for_each = local.authorized_networks
+      content {
+        cidr_block   = cidr_blocks.value.cidr_block
+        display_name = cidr_blocks.value.display_name
+      }
+    }
+  }
+
+  # Pod source IPs reach the spoke GW unmasqueraded — Aviatrix SNATs them.
+  # Equivalent to Cilium enableIPv4Masquerade=false in the AKS variant.
+  default_snat_status {
+    disabled = true
+  }
+
+  workload_identity_config {
+    workload_pool = "${local.project_id}.svc.id.goog"
+  }
+
+  # Enable Gateway API CRDs — backs `gke-l7-global-external-managed` Gateway
+  # provisioning by the GKE controller.
+  gateway_api_config {
+    channel = "CHANNEL_STANDARD"
+  }
+
+  # Required deletion-protection knob — explicit so destroy works in lab use.
+  deletion_protection = false
+
+  # Release channel advances master_version out of band — let it drift.
+  lifecycle {
+    ignore_changes = [min_master_version]
+  }
+}
+
+#####################
+# Node pool
+#####################
+
+resource "google_container_node_pool" "primary" {
+  name       = "primary"
+  project    = local.project_id
+  location   = local.zone
+  cluster    = google_container_cluster.this.name
+  node_count = var.node_pool_config.initial_count
+
+  autoscaling {
+    min_node_count = var.node_pool_config.min_count
+    max_node_count = var.node_pool_config.max_count
+  }
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  upgrade_settings {
+    strategy        = "SURGE"
+    max_surge       = 1
+    max_unavailable = 0
+  }
+
+  node_config {
+    machine_type = var.node_pool_config.machine_type
+    disk_size_gb = var.node_pool_config.disk_size_gb
+    disk_type    = "pd-balanced"
+
+    service_account = google_service_account.node.email
+    oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+
+    # Workload Identity for pod-level IAM (used by ExternalDNS in nodes/).
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+
+    shielded_instance_config {
+      enable_secure_boot          = true
+      enable_integrity_monitoring = true
+    }
+
+    labels = {
+      environment = "demo"
+      blueprint   = "gcp-gke-multicluster"
+      cluster     = "frontend"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+}
+
+#####################
+# Service account for ExternalDNS (Workload Identity Federation for GKE)
+#
+# Bound to KSA `kube-system/external-dns` via roles/iam.workloadIdentityUser.
+# The KSA is created by the ExternalDNS Helm chart in nodes/frontend.
+#####################
+
+resource "google_service_account" "external_dns" {
+  account_id   = "${local.cluster_name}-edns"
+  display_name = "ExternalDNS for ${local.cluster_name}"
+  project      = local.project_id
+}
+
+# Manage records in the private Cloud DNS zone.
+resource "google_project_iam_member" "external_dns_admin" {
+  project = local.project_id
+  role    = "roles/dns.admin"
+  member  = "serviceAccount:${google_service_account.external_dns.email}"
+}
+
+# Bind the KSA to the GSA — Workload Identity Federation for GKE.
+# The pool `<project>.svc.id.goog` only exists once a cluster with
+# workload_identity_config has been created — explicit dep avoids the race.
+resource "google_service_account_iam_member" "external_dns_wif" {
+  service_account_id = google_service_account.external_dns.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${local.project_id}.svc.id.goog[kube-system/external-dns]"
+
+  depends_on = [google_container_cluster.this]
+}

--- a/blueprints/gcp-gke-multicluster/clusters/frontend/onboarding.tf
+++ b/blueprints/gcp-gke-multicluster/clusters/frontend/onboarding.tf
@@ -1,0 +1,34 @@
+#####################
+# Aviatrix Controller Onboarding
+#
+# Registers the GKE cluster with the Aviatrix Controller so DCF SmartGroups
+# can target Kubernetes-typed selectors (cluster, namespace, service, pod)
+# instead of just VPC selectors.
+#
+# Auth flow:
+#   1. Controller calls GKE container.googleapis.com via the Aviatrix GCP
+#      access account's service account to fetch a kubeconfig.
+#   2. Controller connects to the cluster's public master endpoint with that
+#      kubeconfig (the master endpoint must allow the controller's egress IP
+#      via master_authorized_networks).
+#
+# Requirements (NOT enforced by Terraform — pre-checks for the operator):
+#   - Aviatrix GCP access account onboarded (see network/, var.aviatrix_gcp_account_name).
+#   - That account's service account has roles/container.viewer (read kubeconfig)
+#     and roles/container.admin or equivalent (lookup cluster details). The
+#     "Kubernetes Engine Admin" predefined role works.
+#   - Controller's public egress IP is in the cluster's master_authorized_networks
+#     (see var.aviatrix_controller_public_ip).
+#####################
+
+resource "aviatrix_kubernetes_cluster" "this" {
+  count = var.enable_aviatrix_onboarding ? 1 : 0
+
+  cluster_id          = google_container_cluster.this.self_link
+  use_csp_credentials = true
+
+  depends_on = [
+    google_container_cluster.this,
+    google_container_node_pool.primary,
+  ]
+}

--- a/blueprints/gcp-gke-multicluster/clusters/frontend/outputs.tf
+++ b/blueprints/gcp-gke-multicluster/clusters/frontend/outputs.tf
@@ -1,0 +1,32 @@
+output "cluster_name" {
+  value = google_container_cluster.this.name
+}
+
+output "cluster_self_link" {
+  description = "GKE cluster self_link — used as cluster_id by aviatrix_kubernetes_cluster and K8s SmartGroups"
+  value       = google_container_cluster.this.self_link
+}
+
+output "cluster_endpoint" {
+  description = "Public master endpoint (for kubectl after master_authorized_networks allowlists your IP)"
+  value       = google_container_cluster.this.endpoint
+}
+
+output "cluster_ca_certificate" {
+  description = "Cluster CA cert (base64) — consumed by the kubernetes/helm providers in nodes/"
+  value       = google_container_cluster.this.master_auth[0].cluster_ca_certificate
+  sensitive   = true
+}
+
+output "node_service_account_email" {
+  value = google_service_account.node.email
+}
+
+output "external_dns_service_account_email" {
+  description = "GSA email bound to KSA kube-system/external-dns via Workload Identity Federation"
+  value       = google_service_account.external_dns.email
+}
+
+output "workload_identity_pool" {
+  value = "${data.terraform_remote_state.network.outputs.gcp_project_id}.svc.id.goog"
+}

--- a/blueprints/gcp-gke-multicluster/clusters/frontend/outputs.tf
+++ b/blueprints/gcp-gke-multicluster/clusters/frontend/outputs.tf
@@ -1,5 +1,6 @@
 output "cluster_name" {
-  value = google_container_cluster.this.name
+  description = "Name of the GKE cluster (matches network layer's frontend_cluster_name)."
+  value       = google_container_cluster.this.name
 }
 
 output "cluster_self_link" {
@@ -19,7 +20,8 @@ output "cluster_ca_certificate" {
 }
 
 output "node_service_account_email" {
-  value = google_service_account.node.email
+  description = "GSA email used by the GKE node pool (least-privilege; consumed by IAM bindings in this layer)."
+  value       = google_service_account.node.email
 }
 
 output "external_dns_service_account_email" {
@@ -28,5 +30,6 @@ output "external_dns_service_account_email" {
 }
 
 output "workload_identity_pool" {
-  value = "${data.terraform_remote_state.network.outputs.gcp_project_id}.svc.id.goog"
+  description = "Workload Identity pool for the project (<project-id>.svc.id.goog); used by KSA→GSA bindings in nodes/frontend."
+  value       = "${data.terraform_remote_state.network.outputs.gcp_project_id}.svc.id.goog"
 }

--- a/blueprints/gcp-gke-multicluster/clusters/frontend/terraform.tfvars.example
+++ b/blueprints/gcp-gke-multicluster/clusters/frontend/terraform.tfvars.example
@@ -1,0 +1,14 @@
+# Aviatrix Controller credentials should be exported as env vars (not in this file):
+#   export AVIATRIX_CONTROLLER_IP=...
+#   export AVIATRIX_USERNAME=...
+#   export AVIATRIX_PASSWORD=...
+
+# Add your IP or 0.0.0.0/0 (lab); the spoke GW + controller IP are appended automatically.
+# master_authorized_cidr_blocks = ["0.0.0.0/0"]
+
+# Tighten if you restrict master_authorized_cidr_blocks; otherwise null is fine.
+# aviatrix_controller_public_ip = null
+
+# Onboarding requires the Aviatrix GCP access account's SA to have at least
+# roles/container.clusterViewer in the project. See onboarding.tf header.
+# enable_aviatrix_onboarding = true

--- a/blueprints/gcp-gke-multicluster/clusters/frontend/variables.tf
+++ b/blueprints/gcp-gke-multicluster/clusters/frontend/variables.tf
@@ -1,0 +1,75 @@
+variable "node_pool_config" {
+  description = "Sizing for the primary GKE node pool"
+  type = object({
+    machine_type  = string
+    disk_size_gb  = number
+    initial_count = number
+    min_count     = number
+    max_count     = number
+  })
+  default = {
+    # 2 vCPU, 8 GB — comfortable for Cilium + system pods + Gatus + DCF agent.
+    machine_type  = "e2-standard-2"
+    disk_size_gb  = 50
+    initial_count = 2
+    min_count     = 1
+    max_count     = 3
+  }
+}
+
+variable "master_authorized_cidr_blocks" {
+  description = <<-EOT
+    User CIDR blocks allowed to reach the GKE master endpoint.
+    Add your current public IP (e.g., ["1.2.3.4/32"]).
+    Use ["0.0.0.0/0"] to allow all (lab only).
+    The Aviatrix spoke GW egress IP and (when enable_aviatrix_onboarding=true)
+    the Aviatrix Controller IP are appended automatically.
+  EOT
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+#####################
+# Aviatrix Cluster Onboarding
+#####################
+
+variable "enable_aviatrix_onboarding" {
+  description = <<-EOT
+    Register this GKE cluster with the Aviatrix Controller so DCF SmartGroups
+    can target k8s clusters, namespaces, services, and pods.
+    When true, the Aviatrix GCP access account's service account needs at
+    minimum roles/container.clusterViewer on the project (for getKubeconfig).
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "aviatrix_controller_ip" {
+  description = "Aviatrix Controller IP/hostname (or set AVIATRIX_CONTROLLER_IP env var)"
+  type        = string
+  default     = null
+}
+
+variable "aviatrix_username" {
+  description = "Aviatrix Controller username (or set AVIATRIX_USERNAME env var)"
+  type        = string
+  default     = null
+}
+
+variable "aviatrix_password" {
+  description = "Aviatrix Controller password (or set AVIATRIX_PASSWORD env var)"
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "aviatrix_controller_public_ip" {
+  description = <<-EOT
+    Public egress IP of the Aviatrix Controller, appended to GKE
+    master_authorized_networks when enable_aviatrix_onboarding = true.
+    Required only when master_authorized_cidr_blocks is restrictive; skip
+    if you used ["0.0.0.0/0"].
+  EOT
+  type        = string
+  default     = null
+}

--- a/blueprints/gcp-gke-multicluster/clusters/frontend/versions.tf
+++ b/blueprints/gcp-gke-multicluster/clusters/frontend/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 8.2"
+    }
+  }
+}

--- a/blueprints/gcp-gke-multicluster/k8s-apps/backend/gatus.yaml
+++ b/blueprints/gcp-gke-multicluster/k8s-apps/backend/gatus.yaml
@@ -1,0 +1,204 @@
+# Gatus health dashboard — backend cluster
+#
+# DNS hostnames assume var.private_dns_zone_name = "gcp.aviatrixdemo.local."
+# in the network layer. If you changed it, update both the configmap and the
+# external-dns hostname annotations below.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gatus
+  labels:
+    app.kubernetes.io/part-of: gke-demo
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backend
+  namespace: gatus
+data:
+  config.yaml: |
+    storage:
+      type: memory
+    metrics: true
+    endpoints:
+      # Internal Services — East-West through Aviatrix transit
+      - name: "Prod Database"
+        group: "Internal"
+        url: "http://db.gcp.aviatrixdemo.local"
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 300"
+      - name: "Frontend Service"
+        group: "Internal"
+        url: "http://frontend.gcp.aviatrixdemo.local:8080"
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 500"
+
+      # Egress — Allowed Traffic (governed by DCF WebGroups)
+      - name: "kubernetes.io"
+        group: "Egress"
+        url: "https://kubernetes.io"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      - name: "github.com/.../terraform-provider-aviatrix"
+        group: "Egress"
+        url: "https://github.com/AviatrixSystems/terraform-provider-aviatrix"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      - name: "registry.npmjs.org"
+        group: "Egress"
+        url: "https://registry.npmjs.org"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      # Threats — should be BLOCKED by DCF (GeoBlock + ThreatIQ)
+      - name: "GeoBlock - Iran"
+        group: "Threats"
+        url: "icmp://www.irna.ir"
+        interval: 60s
+        conditions: ["[CONNECTED] == true"]
+
+      - name: "Threat Feed - Malicious IP"
+        group: "Threats"
+        url: "icmp://185.38.148.2"
+        interval: 60s
+        conditions: ["[CONNECTED] == true"]
+
+    ui:
+      logo: "https://aviatrix.com/wp-content/uploads/2019/10/cropped-Aviatrix-Logo@2x-1-32x32.png"
+      header: "Backend Cluster - ${HOSTNAME}"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backend
+  namespace: gatus
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: gatus
+  labels:
+    app: backend
+    cluster: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      name: backend
+      labels:
+        app: backend
+        cluster: backend
+        aviatrix.com/app: backend
+    spec:
+      serviceAccountName: backend
+      terminationGracePeriodSeconds: 5
+      containers:
+        - image: twinproduction/gatus:v5.14.0
+          imagePullPolicy: IfNotPresent
+          name: backend
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 250m
+              memory: 100M
+            requests:
+              cpu: 50m
+              memory: 30M
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 5
+          volumeMounts:
+            - mountPath: /config
+              name: backend-config
+      volumes:
+        - configMap:
+            name: backend
+          name: backend-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: gatus
+  labels:
+    app: backend
+    service: backend
+  annotations:
+    networking.gke.io/load-balancer-type: "Internal"
+    external-dns.alpha.kubernetes.io/hostname: backend.gcp.aviatrixdemo.local
+    external-dns.alpha.kubernetes.io/ttl: "60"
+spec:
+  type: LoadBalancer
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: backend
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: backend-public
+  namespace: gatus
+  annotations:
+    networking.gke.io/addresses: gke-demo-backend-gateway-ip
+spec:
+  gatewayClassName: gke-l7-global-external-managed
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backend-public
+  namespace: gatus
+spec:
+  parentRefs:
+    - name: backend-public
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: backend
+          port: 8080

--- a/blueprints/gcp-gke-multicluster/k8s-apps/backend/gatus.yaml
+++ b/blueprints/gcp-gke-multicluster/k8s-apps/backend/gatus.yaml
@@ -71,7 +71,7 @@ data:
 
       - name: "Threat Feed - Malicious IP"
         group: "Threats"
-        url: "icmp://185.38.148.2"
+        url: "icmp://100.19.147.208"
         interval: 60s
         conditions: ["[CONNECTED] == true"]
 

--- a/blueprints/gcp-gke-multicluster/k8s-apps/dcf-crd/firewallpolicy-infosec.yaml
+++ b/blueprints/gcp-gke-multicluster/k8s-apps/dcf-crd/firewallpolicy-infosec.yaml
@@ -1,0 +1,48 @@
+#####################
+# FirewallPolicy CRD Example - InfoSec Namespace
+#
+# This policy demonstrates K8s-native DCF policy management.
+# Pods with label "app: infosec" can access security tools like VirusTotal.
+#
+# Prerequisites:
+#   helm install --repo https://aviatrixsystems.github.io/k8s-firewall-charts k8s-firewall k8s-firewall
+#
+# Apply:
+#   kubectl apply -f firewallpolicy-infosec.yaml
+#
+# Verify:
+#   kubectl get firewallpolicies -n gatus
+#   kubectl get events -n gatus
+#####################
+
+apiVersion: networking.aviatrix.com/v1alpha1
+kind: FirewallPolicy
+metadata:
+  name: infosec-egress
+  namespace: gatus
+spec:
+  rules:
+    - name: allow-virustotal
+      logging: true
+      selector:
+        matchLabels:
+          app: infosec
+      action: permit
+      protocol: tcp
+      port: 443
+      destinationSmartGroups:
+        - name: public-internet
+      webGroups:
+        - name: security-tools
+
+  webGroups:
+    - name: security-tools
+      domains:
+        - "www.virustotal.com"
+        - "virustotal.com"
+        - "*.virustotal.com"
+
+  smartGroups:
+    - name: public-internet
+      selectors:
+        - cidr: 0.0.0.0/0

--- a/blueprints/gcp-gke-multicluster/k8s-apps/dcf-crd/webgrouppolicy-dev.yaml
+++ b/blueprints/gcp-gke-multicluster/k8s-apps/dcf-crd/webgrouppolicy-dev.yaml
@@ -1,0 +1,41 @@
+#####################
+# WebgroupPolicy CRD Example - Dev Namespace
+#
+# Permits pods labeled environment=development to reach a curated set of
+# package-registry and code-host domains over HTTPS. The Aviatrix k8s-firewall
+# controller compiles this into a WebGroup on the Aviatrix Controller and
+# applies it to the spoke gateway data plane.
+#
+# Apply:
+#   kubectl create namespace dev
+#   kubectl apply -f webgrouppolicy-dev.yaml
+#
+# Verify:
+#   kubectl get webgrouppolicies -n dev
+#   kubectl describe webgrouppolicy dev-external-apis -n dev
+#####################
+
+apiVersion: networking.aviatrix.com/v1alpha1
+kind: WebgroupPolicy
+metadata:
+  name: dev-external-apis
+  namespace: dev
+spec:
+  selector:
+    matchLabels:
+      environment: development
+
+  allowedDomains:
+    # Package registries
+    - "pypi.org"
+    - "*.pypi.org"
+    - "files.pythonhosted.org"
+    # Docker Hub
+    - "hub.docker.com"
+    - "registry-1.docker.io"
+    - "*.docker.io"
+    # GitHub (broader access for dev)
+    - "github.com"
+    - "*.github.com"
+    - "raw.githubusercontent.com"
+    - "api.github.com"

--- a/blueprints/gcp-gke-multicluster/k8s-apps/frontend/gatus.yaml
+++ b/blueprints/gcp-gke-multicluster/k8s-apps/frontend/gatus.yaml
@@ -74,7 +74,7 @@ data:
       #   curl -s https://rules.emergingthreats.net/blockrules/compromised-ips.txt | grep -vE '^(#|$)' | head -1
       - name: "Threat Feed - Malicious IP"
         group: "Threats"
-        url: "icmp://185.38.148.2"
+        url: "icmp://100.19.147.208"
         interval: 60s
         conditions: ["[CONNECTED] == true"]
 

--- a/blueprints/gcp-gke-multicluster/k8s-apps/frontend/gatus.yaml
+++ b/blueprints/gcp-gke-multicluster/k8s-apps/frontend/gatus.yaml
@@ -1,0 +1,216 @@
+# Gatus health dashboard — frontend cluster
+#
+# DNS hostnames assume var.private_dns_zone_name = "gcp.aviatrixdemo.local."
+# in the network layer. If you changed it, update both the configmap and the
+# external-dns hostname annotations below.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gatus
+  labels:
+    app.kubernetes.io/part-of: gke-demo
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend
+  namespace: gatus
+data:
+  config.yaml: |
+    storage:
+      type: memory
+    metrics: true
+    endpoints:
+      # Internal Services — East-West through Aviatrix transit
+      - name: "Prod Database"
+        group: "Internal"
+        url: "http://db.gcp.aviatrixdemo.local"
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 300"
+      - name: "Backend Service"
+        group: "Internal"
+        url: "http://backend.gcp.aviatrixdemo.local:8080"
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 500"
+
+      # Egress — Allowed Traffic (governed by DCF WebGroups)
+      - name: "kubernetes.io"
+        group: "Egress"
+        url: "https://kubernetes.io"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      - name: "github.com/.../terraform-provider-aviatrix"
+        group: "Egress"
+        url: "https://github.com/AviatrixSystems/terraform-provider-aviatrix"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      - name: "registry.npmjs.org"
+        group: "Egress"
+        url: "https://registry.npmjs.org"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      # Threats — should be BLOCKED by DCF (GeoBlock + ThreatIQ)
+      - name: "GeoBlock - Iran"
+        group: "Threats"
+        url: "icmp://www.irna.ir"
+        interval: 60s
+        conditions: ["[CONNECTED] == true"]
+
+      # NOTE: ThreatIQ pulls from the ET Open compromised-ips feed which rotates
+      # daily. If this shows CONNECTED (not blocked), refresh from:
+      #   curl -s https://rules.emergingthreats.net/blockrules/compromised-ips.txt | grep -vE '^(#|$)' | head -1
+      - name: "Threat Feed - Malicious IP"
+        group: "Threats"
+        url: "icmp://185.38.148.2"
+        interval: 60s
+        conditions: ["[CONNECTED] == true"]
+
+    ui:
+      logo: "https://aviatrix.com/wp-content/uploads/2019/10/cropped-Aviatrix-Logo@2x-1-32x32.png"
+      header: "Frontend Cluster - ${HOSTNAME}"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: frontend
+  namespace: gatus
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: gatus
+  labels:
+    app: frontend
+    cluster: frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      name: frontend
+      labels:
+        app: frontend
+        cluster: frontend
+        # Label used by Aviatrix k8s-firewall controller for DCF SmartGroup targeting
+        aviatrix.com/app: frontend
+    spec:
+      serviceAccountName: frontend
+      terminationGracePeriodSeconds: 5
+      containers:
+        - image: twinproduction/gatus:v5.14.0
+          imagePullPolicy: IfNotPresent
+          name: frontend
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 250m
+              memory: 100M
+            requests:
+              cpu: 50m
+              memory: 30M
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 5
+          volumeMounts:
+            - mountPath: /config
+              name: frontend-config
+      volumes:
+        - configMap:
+            name: frontend
+          name: frontend-config
+---
+# Internal regional TCP/UDP load balancer — gives the Service a private IP from
+# the node subnet that's reachable from the backend cluster via Aviatrix
+# transit. ExternalDNS publishes the LB IP to Cloud DNS as
+# frontend.gcp.aviatrixdemo.local.
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: gatus
+  labels:
+    app: frontend
+    service: frontend
+  annotations:
+    networking.gke.io/load-balancer-type: "Internal"
+    external-dns.alpha.kubernetes.io/hostname: frontend.gcp.aviatrixdemo.local
+    external-dns.alpha.kubernetes.io/ttl: "60"
+spec:
+  type: LoadBalancer
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: frontend
+---
+# GKE Gateway API — provisions a Google Global External ALB on the reserved IP
+# from the network layer. HTTPRoute attaches the Gatus Service as the backend.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: frontend-public
+  namespace: gatus
+  annotations:
+    # Pin to the reserved global address from the network layer. Replace if
+    # your name_prefix differs from the default "gke-demo".
+    networking.gke.io/addresses: gke-demo-frontend-gateway-ip
+spec:
+  gatewayClassName: gke-l7-global-external-managed
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: frontend-public
+  namespace: gatus
+spec:
+  parentRefs:
+    - name: frontend-public
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: frontend
+          port: 8080

--- a/blueprints/gcp-gke-multicluster/network/dcf-k8s.tf
+++ b/blueprints/gcp-gke-multicluster/network/dcf-k8s.tf
@@ -1,0 +1,70 @@
+#####################
+# K8s-Typed SmartGroups
+#
+# Once the GKE clusters are onboarded with the Aviatrix Controller (via the
+# clusters/{frontend,backend} layers), the controller resolves K8s-typed
+# selectors dynamically: pod IPs are listed from the cluster API and added to
+# the SmartGroup as members.
+#
+# Cluster IDs are constructed in main.tf locals (frontend_cluster_id,
+# backend_cluster_id) and must match google_container_cluster.this.self_link
+# in the clusters layer.
+#
+# Until the clusters are onboarded these SmartGroups have zero members and any
+# DCF rules referencing them are no-ops — safe to deploy in either order.
+#####################
+
+#####################
+# Cluster-scoped (analog of the VPC SmartGroup, but membership is pods+nodes
+# resolved from the cluster API instead of from VPC/IP)
+#####################
+
+resource "aviatrix_smart_group" "frontend_cluster" {
+  count = var.enable_k8s_smartgroup_demo ? 1 : 0
+  name  = "${var.name_prefix}-sg-frontend-cluster"
+  selector {
+    match_expressions {
+      type           = "k8s"
+      k8s_cluster_id = local.frontend_cluster_id
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "backend_cluster" {
+  count = var.enable_k8s_smartgroup_demo ? 1 : 0
+  name  = "${var.name_prefix}-sg-backend-cluster"
+  selector {
+    match_expressions {
+      type           = "k8s"
+      k8s_cluster_id = local.backend_cluster_id
+    }
+  }
+}
+
+#####################
+# Namespace-scoped — Gatus pods only
+#####################
+
+resource "aviatrix_smart_group" "frontend_gatus_ns" {
+  count = var.enable_k8s_smartgroup_demo ? 1 : 0
+  name  = "${var.name_prefix}-sg-frontend-gatus-ns"
+  selector {
+    match_expressions {
+      type           = "k8s"
+      k8s_cluster_id = local.frontend_cluster_id
+      k8s_namespace  = "gatus"
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "backend_gatus_ns" {
+  count = var.enable_k8s_smartgroup_demo ? 1 : 0
+  name  = "${var.name_prefix}-sg-backend-gatus-ns"
+  selector {
+    match_expressions {
+      type           = "k8s"
+      k8s_cluster_id = local.backend_cluster_id
+      k8s_namespace  = "gatus"
+    }
+  }
+}

--- a/blueprints/gcp-gke-multicluster/network/dcf.tf
+++ b/blueprints/gcp-gke-multicluster/network/dcf.tf
@@ -1,0 +1,451 @@
+#####################
+# Aviatrix Distributed Cloud Firewall (DCF)
+#
+# Architecture:
+#   - VPC SmartGroups   : match traffic by VPC name (post-SNAT, transit-level)
+#   - Hostname SGs      : match destination services by FQDN
+#   - WebGroups         : SNI/URL filters for HTTPS egress inspection
+#   - Rules (priority-ordered):
+#       0–9   : Threat prevention (geo-block, ThreatIQ)
+#       10–29 : East-west (inter-VPC service access)
+#       20–21 : GCP required services (GKE nodes/pods)
+#       30–49 : Explicit egress allows
+#       50–99 : Reserved for K8s CRD policies (FirewallPolicy / WebGroupPolicy)
+#
+# NOTES:
+#   - DCF inspects traffic at the Aviatrix spoke gateway BEFORE pod-to-spoke
+#     SNAT only when the policy's src is a K8s SmartGroup (the GW resolves pod
+#     IPs from the cluster API). VPC-typed SmartGroups match post-SNAT, so they
+#     see the spoke GW IP as the source for east-west between spokes.
+#   - Hostname SmartGroups resolve FQDNs via the Cloud DNS private zone (the
+#     spoke GW uses the GCP metadata resolver 169.254.169.254).
+#####################
+
+#####################
+# SmartGroups — VPC-based (transit-level)
+#####################
+
+resource "aviatrix_smart_group" "frontend_vpc" {
+  name = "${var.name_prefix}-sg-frontend-vpc"
+  selector {
+    match_expressions {
+      type = "vpc"
+      name = module.frontend_vpc.vpc_name
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "backend_vpc" {
+  name = "${var.name_prefix}-sg-backend-vpc"
+  selector {
+    match_expressions {
+      type = "vpc"
+      name = module.backend_vpc.vpc_name
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "db_vpc" {
+  name = "${var.name_prefix}-sg-db-vpc"
+  selector {
+    match_expressions {
+      type = "vpc"
+      name = google_compute_network.db.name
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "all_gke_clusters" {
+  name = "${var.name_prefix}-sg-all-gke"
+  selector {
+    match_expressions {
+      type = "vpc"
+      name = module.frontend_vpc.vpc_name
+    }
+    match_expressions {
+      type = "vpc"
+      name = module.backend_vpc.vpc_name
+    }
+  }
+}
+
+#####################
+# SmartGroups — Hostname-based (service FQDNs)
+#####################
+
+resource "aviatrix_smart_group" "backend_service" {
+  name = "${var.name_prefix}-sg-backend-service"
+  selector {
+    match_expressions {
+      fqdn = "backend.${trimsuffix(var.private_dns_zone_name, ".")}"
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "frontend_service" {
+  name = "${var.name_prefix}-sg-frontend-service"
+  selector {
+    match_expressions {
+      fqdn = "frontend.${trimsuffix(var.private_dns_zone_name, ".")}"
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "database" {
+  name = "${var.name_prefix}-sg-database"
+  selector {
+    match_expressions {
+      fqdn = "db.${trimsuffix(var.private_dns_zone_name, ".")}"
+    }
+  }
+}
+
+#####################
+# SmartGroups — External feeds (threat intelligence)
+#####################
+
+resource "aviatrix_smart_group" "geo_blocked" {
+  name = "${var.name_prefix}-sg-geo-blocked"
+  selector {
+    match_expressions {
+      external = "geo"
+      ext_args = { country_iso_code = "IR" }
+    }
+    match_expressions {
+      external = "geo"
+      ext_args = { country_iso_code = "KP" }
+    }
+    match_expressions {
+      external = "geo"
+      ext_args = { country_iso_code = "RU" }
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "threat_intel" {
+  name = "${var.name_prefix}-sg-threat-intel"
+  selector {
+    match_expressions {
+      external = "threatiq"
+      ext_args = { severity = "major" }
+    }
+    match_expressions {
+      external = "threatiq"
+      ext_args = { severity = "critical" }
+    }
+  }
+}
+
+#####################
+# Built-in SmartGroups
+#####################
+
+locals {
+  # Built-in "Public Internet" SmartGroup UUID (system-defined, matches all non-RFC1918)
+  public_internet_uuid = "def000ad-0000-0000-0000-000000000001"
+}
+
+#####################
+# WebGroups — SNI/URL filters for HTTPS egress
+#
+# GCP/GKE nodes need to reach a different set of cloud-control endpoints than
+# AWS/Azure: googleapis.com (most APIs), gcr.io / pkg.dev (container images),
+# packages.cloud.google.com (gke-node-image apt), accounts.google.com (auth).
+#####################
+
+resource "aviatrix_web_group" "gcp_required" {
+  name = "${var.name_prefix}-wg-gcp-required"
+  selector {
+    match_expressions { snifilter = "*.googleapis.com" } # most GCP APIs
+    match_expressions { snifilter = "*.googleusercontent.com" }
+    match_expressions { snifilter = "accounts.google.com" } # OAuth
+    match_expressions { snifilter = "oauth2.googleapis.com" }
+    match_expressions { snifilter = "metadata.google.internal" } # via private path; redundant but harmless
+
+    # Container Registry / Artifact Registry
+    match_expressions { snifilter = "gcr.io" }
+    match_expressions { snifilter = "*.gcr.io" }
+    match_expressions { snifilter = "*.pkg.dev" }
+
+    # GKE node-image apt repos
+    match_expressions { snifilter = "packages.cloud.google.com" }
+    match_expressions { snifilter = "storage.googleapis.com" } # used by COS/Ubuntu node images
+
+    # OS package repos for node bootstrap
+    match_expressions { snifilter = "security.ubuntu.com" }
+    match_expressions { snifilter = "archive.ubuntu.com" }
+  }
+}
+
+resource "aviatrix_web_group" "kubernetes_io" {
+  name = "${var.name_prefix}-wg-kubernetes-io"
+  selector {
+    match_expressions { snifilter = "kubernetes.io" }
+    match_expressions { snifilter = "*.kubernetes.io" }
+    match_expressions { snifilter = "registry.k8s.io" }
+    match_expressions { snifilter = "*.k8s.io" }
+  }
+}
+
+resource "aviatrix_web_group" "docker_hub" {
+  name = "${var.name_prefix}-wg-docker-hub"
+  selector {
+    match_expressions { snifilter = "registry-1.docker.io" }
+    match_expressions { snifilter = "auth.docker.io" }
+    match_expressions { snifilter = "index.docker.io" }
+    match_expressions { snifilter = "*.docker.com" }
+  }
+}
+
+resource "aviatrix_web_group" "npm_registry" {
+  name = "${var.name_prefix}-wg-npm-registry"
+  selector {
+    match_expressions { snifilter = "registry.npmjs.org" }
+    match_expressions { snifilter = "npmjs.org" }
+    match_expressions { snifilter = "www.npmjs.com" }
+  }
+}
+
+resource "aviatrix_web_group" "github_aviatrix" {
+  name = "${var.name_prefix}-wg-github-aviatrix"
+  selector {
+    match_expressions { snifilter = "github.com" }
+    match_expressions { snifilter = "*.github.com" }
+    match_expressions { snifilter = "*.githubusercontent.com" }
+    match_expressions { snifilter = "aviatrixsystems.github.io" }
+  }
+}
+
+#####################
+# Enable Distributed Cloud Firewall
+#####################
+
+resource "aviatrix_distributed_firewalling_config" "enable" {
+  enable_distributed_firewalling = true
+}
+
+#####################
+# DCF Ruleset
+#####################
+
+resource "aviatrix_dcf_ruleset" "gke_demo" {
+  name      = "${var.name_prefix}-gke-multicluster"
+  attach_to = "defa11a1-3000-4001-0000-000000000000"
+
+  #############################
+  # THREAT PREVENTION (Priority 0-9)
+  #############################
+
+  rules {
+    name             = "Block GeoBlocked Countries"
+    action           = "DENY"
+    priority         = 0
+    protocol         = "ANY"
+    logging          = true
+    src_smart_groups = [aviatrix_smart_group.all_gke_clusters.uuid]
+    dst_smart_groups = [aviatrix_smart_group.geo_blocked.uuid]
+  }
+
+  rules {
+    name             = "Block Threat Intel IPs"
+    action           = "DENY"
+    priority         = 1
+    protocol         = "ANY"
+    logging          = true
+    src_smart_groups = [aviatrix_smart_group.all_gke_clusters.uuid]
+    dst_smart_groups = [aviatrix_smart_group.threat_intel.uuid]
+  }
+
+  #############################
+  # INTER-VPC EAST-WEST (Priority 10-29)
+  #############################
+
+  rules {
+    name             = "Frontend to Database"
+    action           = "PERMIT"
+    priority         = 10
+    protocol         = "TCP"
+    logging          = true
+    src_smart_groups = [aviatrix_smart_group.frontend_vpc.uuid]
+    dst_smart_groups = [aviatrix_smart_group.database.uuid]
+    port_ranges {
+      lo = 80
+    }
+  }
+
+  rules {
+    name             = "Backend to Database"
+    action           = "PERMIT"
+    priority         = 11
+    protocol         = "TCP"
+    logging          = true
+    src_smart_groups = [aviatrix_smart_group.backend_vpc.uuid]
+    dst_smart_groups = [aviatrix_smart_group.database.uuid]
+    port_ranges {
+      lo = 80
+    }
+  }
+
+  rules {
+    name             = "Frontend to Backend Services"
+    action           = "PERMIT"
+    priority         = 14
+    protocol         = "TCP"
+    logging          = true
+    src_smart_groups = [aviatrix_smart_group.frontend_vpc.uuid]
+    dst_smart_groups = [aviatrix_smart_group.backend_service.uuid]
+    port_ranges {
+      lo = 8080
+    }
+  }
+
+  rules {
+    name             = "Backend to Frontend Services"
+    action           = "PERMIT"
+    priority         = 15
+    protocol         = "TCP"
+    logging          = true
+    src_smart_groups = [aviatrix_smart_group.backend_vpc.uuid]
+    dst_smart_groups = [aviatrix_smart_group.frontend_service.uuid]
+    port_ranges {
+      lo = 8080
+    }
+  }
+
+  #############################
+  # EGRESS — GCP Required (Priority 20-21)
+  #############################
+
+  rules {
+    name                 = "GKE Required GCP Services"
+    action               = "PERMIT"
+    priority             = 20
+    protocol             = "TCP"
+    logging              = true
+    src_smart_groups     = [aviatrix_smart_group.all_gke_clusters.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.gcp_required.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  rules {
+    name                 = "GKE Required GCP Services HTTP"
+    action               = "PERMIT"
+    priority             = 21
+    protocol             = "TCP"
+    logging              = false
+    src_smart_groups     = [aviatrix_smart_group.all_gke_clusters.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.gcp_required.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 80
+    }
+  }
+
+  #############################
+  # EGRESS — Allowed Destinations (Priority 30-49)
+  #############################
+
+  rules {
+    name                 = "Allow Kubernetes-io"
+    action               = "PERMIT"
+    priority             = 30
+    protocol             = "TCP"
+    logging              = true
+    src_smart_groups     = [aviatrix_smart_group.all_gke_clusters.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.kubernetes_io.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  rules {
+    name                 = "Allow Docker Hub"
+    action               = "PERMIT"
+    priority             = 31
+    protocol             = "TCP"
+    logging              = true
+    src_smart_groups     = [aviatrix_smart_group.all_gke_clusters.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.docker_hub.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  rules {
+    name                 = "Allow npm Registry"
+    action               = "PERMIT"
+    priority             = 32
+    protocol             = "TCP"
+    logging              = true
+    src_smart_groups     = [aviatrix_smart_group.all_gke_clusters.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.npm_registry.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  rules {
+    name                 = "Allow GitHub Aviatrix Repos"
+    action               = "PERMIT"
+    priority             = 33
+    protocol             = "TCP"
+    logging              = true
+    watch                = true
+    src_smart_groups     = [aviatrix_smart_group.all_gke_clusters.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.github_aviatrix.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  #############################
+  # K8s-TYPED DEMO (Priority 50)
+  # See dcf-k8s.tf — gated by var.enable_k8s_smartgroup_demo so the rule + the
+  # SmartGroups it references can be removed in a single apply before
+  # destroying the clusters layer.
+  #############################
+
+  dynamic "rules" {
+    for_each = var.enable_k8s_smartgroup_demo ? [1] : []
+    content {
+      name             = "Frontend Gatus to Backend Gatus k8s ns selector"
+      action           = "PERMIT"
+      priority         = 50
+      protocol         = "TCP"
+      logging          = true
+      src_smart_groups = [aviatrix_smart_group.frontend_gatus_ns[0].uuid]
+      dst_smart_groups = [aviatrix_smart_group.backend_gatus_ns[0].uuid]
+      port_ranges {
+        lo = 8080
+      }
+    }
+  }
+
+  # Sequence priority-50 rule removal before the SmartGroup destroy when
+  # enable_k8s_smartgroup_demo flips true → false. Without this, the dynamic
+  # rules block disappears from the plan graph and the controller rejects the
+  # SG destroy with [AVXERR-SMARTGROUP-0003].
+  depends_on = [
+    aviatrix_distributed_firewalling_config.enable,
+    module.frontend_spoke,
+    module.backend_spoke,
+    module.db_spoke,
+    aviatrix_smart_group.frontend_gatus_ns,
+    aviatrix_smart_group.backend_gatus_ns,
+    aviatrix_smart_group.frontend_cluster,
+    aviatrix_smart_group.backend_cluster,
+  ]
+}

--- a/blueprints/gcp-gke-multicluster/network/main.tf
+++ b/blueprints/gcp-gke-multicluster/network/main.tf
@@ -1,0 +1,334 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 8.2"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aviatrix" {
+  controller_ip           = var.aviatrix_controller_ip
+  username                = var.aviatrix_username
+  password                = var.aviatrix_password
+  skip_version_validation = true
+}
+
+provider "google" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+}
+
+#####################
+# Project APIs
+#
+# Enable required GCP services up front so downstream layers (clusters/, etc.)
+# don't fail with "API has not been used in project ... before or it is
+# disabled". `disable_on_destroy = false` keeps these on after destroy — they
+# may be shared with other workloads in the project.
+#####################
+
+resource "google_project_service" "required" {
+  for_each = toset([
+    "compute.googleapis.com",
+    "container.googleapis.com",
+    "dns.googleapis.com",
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+  ])
+  project            = var.gcp_project_id
+  service            = each.key
+  disable_on_destroy = false
+}
+
+locals {
+  clusters = {
+    frontend = {
+      name     = "${var.name_prefix}-frontend"
+      vpc_cidr = var.frontend_vpc_cidr
+    }
+    backend = {
+      name     = "${var.name_prefix}-backend"
+      vpc_cidr = var.backend_vpc_cidr
+    }
+  }
+
+  common_labels = {
+    environment = "demo"
+    terraform   = "true"
+    blueprint   = "gcp-gke-multicluster"
+  }
+
+  # GKE self_link cluster_id, constructed locally so the network layer can build
+  # K8s-typed SmartGroups before the clusters layer runs. Format must match
+  # google_container_cluster.this.self_link in clusters/* — for ZONAL clusters
+  # the path is `/zones/<zone>/`, for REGIONAL it is `/locations/<region>/`.
+  # This blueprint uses zonal clusters; flip if you change the cluster scope.
+  frontend_cluster_id = "https://container.googleapis.com/v1/projects/${var.gcp_project_id}/zones/${var.gcp_zone}/clusters/${local.clusters.frontend.name}"
+  backend_cluster_id  = "https://container.googleapis.com/v1/projects/${var.gcp_project_id}/zones/${var.gcp_zone}/clusters/${local.clusters.backend.name}"
+
+  # The Aviatrix mc-* modules want a region (e.g., "us-central1") and build the
+  # zone internally as "${region}-${az1}". Pass the AZ letter extracted from
+  # gcp_zone so the gateway lands in the same zone as the GKE clusters/DB VM.
+  gcp_az = trimprefix(var.gcp_zone, "${var.gcp_region}-")
+}
+
+#####################
+# Aviatrix Transit Gateway
+#
+# In GCP the gateway is zonal (vpc_reg expects a zone, not a region). We pass
+# the user's chosen zone to mc-transit; the Aviatrix-managed transit VPC's
+# subnet is created in that zone's region implicitly by the controller.
+#####################
+
+module "gcp_transit" {
+  source  = "terraform-aviatrix-modules/mc-transit/aviatrix"
+  version = "~> 8.0"
+
+  name    = "${var.name_prefix}-transit"
+  cloud   = "GCP"
+  account = var.aviatrix_gcp_account_name
+  region  = var.gcp_region
+  az1     = local.gcp_az
+  cidr    = var.transit_cidr
+  ha_gw   = false
+
+  # Lab sizing — N1 standard 1 is supported for GCP transit GW.
+  instance_size = "n1-standard-1"
+
+  # Non-overlapping pod CIDRs: frontend uses 100.64.0.0/17, backend
+  # 100.64.128.0/17. Both are non-RFC1918 CGNAT space; we exclude the parent
+  # /16 from BGP advertisements so non-pod traffic doesn't pull these into
+  # peer routing tables.
+  excluded_advertised_spoke_routes = "100.64.0.0/16"
+}
+
+#####################
+# Frontend VPC + Spoke Gateway
+#####################
+
+module "frontend_vpc" {
+  source = "./modules/gke-vpc"
+
+  name                     = "frontend"
+  name_prefix              = var.name_prefix
+  project_id               = var.gcp_project_id
+  region                   = var.gcp_region
+  vpc_cidr                 = var.frontend_vpc_cidr
+  nodes_cidr               = var.frontend_nodes_cidr
+  pods_cidr                = var.frontend_pods_cidr
+  services_cidr            = var.services_cidr
+  avx_gw_cidr              = var.frontend_avx_gw_cidr
+  master_ipv4_cidr_block   = var.frontend_master_cidr
+  create_proxy_only_subnet = true
+  proxy_only_cidr          = var.frontend_proxy_only_cidr
+}
+
+module "frontend_spoke" {
+  source  = "terraform-aviatrix-modules/mc-spoke/aviatrix"
+  version = "~> 8.0"
+
+  cloud      = "GCP"
+  name       = "${var.name_prefix}-frontend-spoke"
+  account    = var.aviatrix_gcp_account_name
+  region     = var.gcp_region
+  az1        = local.gcp_az
+  transit_gw = module.gcp_transit.transit_gateway.gw_name
+
+  instance_size = "n1-standard-1"
+  ha_gw         = false
+
+  # Bring the existing GCP VPC created by gke-vpc.
+  use_existing_vpc = true
+  vpc_id           = module.frontend_vpc.aviatrix_vpc_id
+  gw_subnet        = module.frontend_vpc.avx_gw_subnet_cidr
+
+  # Primary-mode SNAT — required on GCP for spoke egress to internet AND
+  # for the controller to auto-program 0.0.0.0/0 → spoke GW (priority 991)
+  # in the VPC route table. Per Aviatrix 9.0.10 codebase, customized_snat
+  # withdraws the 991 route by design and the priority-500 avx-gws-igw-rt
+  # short-circuits forwarded pod traffic past iptables, so customized_snat
+  # is not a workable substitute on GCP. AWS/Azure variants don't hit this.
+  single_ip_snat = true
+}
+
+#####################
+# Backend VPC + Spoke Gateway
+#####################
+
+module "backend_vpc" {
+  source = "./modules/gke-vpc"
+
+  name                     = "backend"
+  name_prefix              = var.name_prefix
+  project_id               = var.gcp_project_id
+  region                   = var.gcp_region
+  vpc_cidr                 = var.backend_vpc_cidr
+  nodes_cidr               = var.backend_nodes_cidr
+  pods_cidr                = var.backend_pods_cidr
+  services_cidr            = var.services_cidr
+  avx_gw_cidr              = var.backend_avx_gw_cidr
+  master_ipv4_cidr_block   = var.backend_master_cidr
+  create_proxy_only_subnet = true
+  proxy_only_cidr          = var.backend_proxy_only_cidr
+}
+
+module "backend_spoke" {
+  source  = "terraform-aviatrix-modules/mc-spoke/aviatrix"
+  version = "~> 8.0"
+
+  cloud      = "GCP"
+  name       = "${var.name_prefix}-backend-spoke"
+  account    = var.aviatrix_gcp_account_name
+  region     = var.gcp_region
+  az1        = local.gcp_az
+  transit_gw = module.gcp_transit.transit_gateway.gw_name
+
+  instance_size = "n1-standard-1"
+  ha_gw         = false
+
+  use_existing_vpc = true
+  vpc_id           = module.backend_vpc.aviatrix_vpc_id
+  gw_subnet        = module.backend_vpc.avx_gw_subnet_cidr
+
+  single_ip_snat = true
+}
+
+#####################
+# DB Spoke (test VM for east-west traffic demo)
+#####################
+
+resource "google_compute_network" "db" {
+  name                    = "${var.name_prefix}-db-vpc"
+  project                 = var.gcp_project_id
+  auto_create_subnetworks = false
+  routing_mode            = "REGIONAL"
+}
+
+resource "google_compute_subnetwork" "db_vms" {
+  name                     = "${var.name_prefix}-db-vms"
+  project                  = var.gcp_project_id
+  region                   = var.gcp_region
+  network                  = google_compute_network.db.id
+  ip_cidr_range            = var.db_subnet_cidr
+  private_ip_google_access = true
+}
+
+resource "google_compute_subnetwork" "db_avx_gw" {
+  name                     = "${var.name_prefix}-db-avx-gw"
+  project                  = var.gcp_project_id
+  region                   = var.gcp_region
+  network                  = google_compute_network.db.id
+  ip_cidr_range            = var.db_avx_gw_cidr
+  private_ip_google_access = true
+}
+
+resource "google_compute_firewall" "db_internal" {
+  name    = "${var.name_prefix}-db-allow-internal"
+  project = var.gcp_project_id
+  network = google_compute_network.db.name
+
+  allow { protocol = "tcp" }
+  allow { protocol = "udp" }
+  allow { protocol = "icmp" }
+
+  # Allow traffic from any spoke that's reachable through transit (RFC1918).
+  source_ranges = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+}
+
+module "db_spoke" {
+  source  = "terraform-aviatrix-modules/mc-spoke/aviatrix"
+  version = "~> 8.0"
+
+  cloud      = "GCP"
+  name       = "${var.name_prefix}-db-spoke"
+  account    = var.aviatrix_gcp_account_name
+  region     = var.gcp_region
+  az1        = local.gcp_az
+  transit_gw = module.gcp_transit.transit_gateway.gw_name
+
+  instance_size = "n1-standard-1"
+  ha_gw         = false
+
+  use_existing_vpc = true
+  vpc_id           = "${google_compute_network.db.name}~-~${var.gcp_project_id}"
+  gw_subnet        = google_compute_subnetwork.db_avx_gw.ip_cidr_range
+
+  single_ip_snat = true
+}
+
+module "db_vm" {
+  source = "./modules/linux-vm"
+
+  name_prefix   = var.name_prefix
+  project_id    = var.gcp_project_id
+  zone          = var.gcp_zone
+  subnet_id     = google_compute_subnetwork.db_vms.id
+  dns_zone_name = trimsuffix(var.private_dns_zone_name, ".")
+
+  depends_on = [module.db_spoke]
+}
+
+#####################
+# Reserved Global External IPs for GKE Gateway API
+#
+# Each cluster's external Gateway resource (in nodes/*) attaches via the
+# `networking.gke.io/addresses` annotation referencing these IP names. Reserving
+# them here keeps DNS and downstream wiring stable across nodes layer rebuilds.
+#####################
+
+resource "google_compute_global_address" "frontend_gateway" {
+  name         = "${var.name_prefix}-frontend-gateway-ip"
+  project      = var.gcp_project_id
+  address_type = "EXTERNAL"
+  ip_version   = "IPV4"
+}
+
+resource "google_compute_global_address" "backend_gateway" {
+  name         = "${var.name_prefix}-backend-gateway-ip"
+  project      = var.gcp_project_id
+  address_type = "EXTERNAL"
+  ip_version   = "IPV4"
+}
+
+#####################
+# Cloud DNS — Private Zone
+#
+# Visible inside all three VPCs (frontend, backend, db). Pod DNS resolves via
+# kube-dns → Cloud DNS, so service FQDNs from ExternalDNS are reachable.
+#####################
+
+resource "google_dns_managed_zone" "main" {
+  name        = "${var.name_prefix}-private-zone"
+  project     = var.gcp_project_id
+  dns_name    = var.private_dns_zone_name
+  description = "Private zone for ${var.name_prefix} GKE multicluster blueprint"
+  visibility  = "private"
+
+  private_visibility_config {
+    networks {
+      network_url = module.frontend_vpc.vpc_self_link
+    }
+    networks {
+      network_url = module.backend_vpc.vpc_self_link
+    }
+    networks {
+      network_url = google_compute_network.db.self_link
+    }
+  }
+}
+
+resource "google_dns_record_set" "db" {
+  project      = var.gcp_project_id
+  managed_zone = google_dns_managed_zone.main.name
+  name         = "db.${var.private_dns_zone_name}"
+  type         = "A"
+  ttl          = 300
+  rrdatas      = [module.db_vm.vm_private_ip]
+}

--- a/blueprints/gcp-gke-multicluster/network/main.tf
+++ b/blueprints/gcp-gke-multicluster/network/main.tf
@@ -1,18 +1,3 @@
-terraform {
-  required_version = ">= 1.5"
-
-  required_providers {
-    aviatrix = {
-      source  = "AviatrixSystems/aviatrix"
-      version = "~> 8.2"
-    }
-    google = {
-      source  = "hashicorp/google"
-      version = "~> 6.0"
-    }
-  }
-}
-
 provider "aviatrix" {
   controller_ip           = var.aviatrix_controller_ip
   username                = var.aviatrix_username
@@ -99,8 +84,7 @@ module "gcp_transit" {
   cidr    = var.transit_cidr
   ha_gw   = false
 
-  # Lab sizing — N1 standard 1 is supported for GCP transit GW.
-  instance_size = "n1-standard-1"
+  instance_size = var.gw_instance_size
 
   # Non-overlapping pod CIDRs: frontend uses 100.64.0.0/17, backend
   # 100.64.128.0/17. Both are non-RFC1918 CGNAT space; we exclude the parent
@@ -141,21 +125,56 @@ module "frontend_spoke" {
   az1        = local.gcp_az
   transit_gw = module.gcp_transit.transit_gateway.gw_name
 
-  instance_size = "n1-standard-1"
+  instance_size = var.gw_instance_size
   ha_gw         = false
 
   # Bring the existing GCP VPC created by gke-vpc.
   use_existing_vpc = true
   vpc_id           = module.frontend_vpc.aviatrix_vpc_id
   gw_subnet        = module.frontend_vpc.avx_gw_subnet_cidr
+}
 
-  # Primary-mode SNAT — required on GCP for spoke egress to internet AND
-  # for the controller to auto-program 0.0.0.0/0 → spoke GW (priority 991)
-  # in the VPC route table. Per Aviatrix 9.0.10 codebase, customized_snat
-  # withdraws the 991 route by design and the priority-500 avx-gws-igw-rt
-  # short-circuits forwarded pod traffic past iptables, so customized_snat
-  # is not a workable substitute on GCP. AWS/Azure variants don't hit this.
-  single_ip_snat = true
+# Customized SNAT mirrors aws-eks-multicluster — pod CIDR (transit + eth0)
+# plus node subnet (eth0). On GCP this hits a controller bug:
+# validate_dst_cidr rejects pod-CIDR src because gw_obj.vpc_cidr does not
+# enumerate subnet secondaryIpRanges, so the 991 route → spoke-GW is never
+# programmed. Workaround: program the route manually via gcloud (untagged,
+# priority 991). Tracked in AVX bug ticket; see GCP_GKE_MULTICLUSTER_SNAT_GAP.md.
+resource "aviatrix_gateway_snat" "frontend_spoke_snat" {
+  gw_name   = module.frontend_spoke.spoke_gateway.gw_name
+  snat_mode = "customized_snat"
+
+  # Pod CIDR → all destinations via transit
+  snat_policy {
+    src_cidr   = var.frontend_pods_cidr
+    dst_cidr   = "0.0.0.0/0"
+    protocol   = "all"
+    interface  = ""
+    connection = module.gcp_transit.transit_gateway.gw_name
+    snat_ips   = module.frontend_spoke.spoke_gateway.private_ip
+  }
+
+  # Pod CIDR → internet via eth0
+  snat_policy {
+    src_cidr   = var.frontend_pods_cidr
+    dst_cidr   = "0.0.0.0/0"
+    protocol   = "all"
+    interface  = "eth0"
+    connection = ""
+    snat_ips   = module.frontend_spoke.spoke_gateway.private_ip
+  }
+
+  # GKE node subnet → internet via eth0
+  snat_policy {
+    src_cidr   = var.frontend_nodes_cidr
+    dst_cidr   = "0.0.0.0/0"
+    protocol   = "all"
+    interface  = "eth0"
+    connection = ""
+    snat_ips   = module.frontend_spoke.spoke_gateway.private_ip
+  }
+
+  depends_on = [module.frontend_spoke]
 }
 
 #####################
@@ -190,14 +209,46 @@ module "backend_spoke" {
   az1        = local.gcp_az
   transit_gw = module.gcp_transit.transit_gateway.gw_name
 
-  instance_size = "n1-standard-1"
+  instance_size = var.gw_instance_size
   ha_gw         = false
 
   use_existing_vpc = true
   vpc_id           = module.backend_vpc.aviatrix_vpc_id
   gw_subnet        = module.backend_vpc.avx_gw_subnet_cidr
+}
 
-  single_ip_snat = true
+resource "aviatrix_gateway_snat" "backend_spoke_snat" {
+  gw_name   = module.backend_spoke.spoke_gateway.gw_name
+  snat_mode = "customized_snat"
+
+  snat_policy {
+    src_cidr   = var.backend_pods_cidr
+    dst_cidr   = "0.0.0.0/0"
+    protocol   = "all"
+    interface  = ""
+    connection = module.gcp_transit.transit_gateway.gw_name
+    snat_ips   = module.backend_spoke.spoke_gateway.private_ip
+  }
+
+  snat_policy {
+    src_cidr   = var.backend_pods_cidr
+    dst_cidr   = "0.0.0.0/0"
+    protocol   = "all"
+    interface  = "eth0"
+    connection = ""
+    snat_ips   = module.backend_spoke.spoke_gateway.private_ip
+  }
+
+  snat_policy {
+    src_cidr   = var.backend_nodes_cidr
+    dst_cidr   = "0.0.0.0/0"
+    protocol   = "all"
+    interface  = "eth0"
+    connection = ""
+    snat_ips   = module.backend_spoke.spoke_gateway.private_ip
+  }
+
+  depends_on = [module.backend_spoke]
 }
 
 #####################
@@ -253,7 +304,7 @@ module "db_spoke" {
   az1        = local.gcp_az
   transit_gw = module.gcp_transit.transit_gateway.gw_name
 
-  instance_size = "n1-standard-1"
+  instance_size = var.gw_instance_size
   ha_gw         = false
 
   use_existing_vpc = true

--- a/blueprints/gcp-gke-multicluster/network/modules/gke-vpc/main.tf
+++ b/blueprints/gcp-gke-multicluster/network/modules/gke-vpc/main.tf
@@ -1,0 +1,99 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}
+
+# Custom-mode VPC: subnets are explicit, no auto-created subnets.
+resource "google_compute_network" "this" {
+  name                            = "${var.name_prefix}-${var.name}-vpc"
+  project                         = var.project_id
+  auto_create_subnetworks         = false
+  routing_mode                    = "REGIONAL"
+  delete_default_routes_on_create = false
+}
+
+# Node subnet — primary range for nodes, secondary ranges for pods and services.
+# Aliasing the secondary ranges into the subnet is GKE's VPC-native (alias IP) requirement.
+resource "google_compute_subnetwork" "nodes" {
+  name          = "${var.name_prefix}-${var.name}-nodes"
+  project       = var.project_id
+  region        = var.region
+  network       = google_compute_network.this.id
+  ip_cidr_range = var.nodes_cidr
+
+  secondary_ip_range {
+    range_name    = "pods"
+    ip_cidr_range = var.pods_cidr
+  }
+
+  secondary_ip_range {
+    range_name    = "services"
+    ip_cidr_range = var.services_cidr
+  }
+
+  private_ip_google_access = true
+}
+
+# Aviatrix spoke GW subnet — small dedicated /28 in the GW's zone region.
+resource "google_compute_subnetwork" "avx_gw" {
+  name                     = "${var.name_prefix}-${var.name}-avx-gw"
+  project                  = var.project_id
+  region                   = var.region
+  network                  = google_compute_network.this.id
+  ip_cidr_range            = var.avx_gw_cidr
+  private_ip_google_access = true
+}
+
+# Required by GCP Standard ALB (Gateway API) — each region needs at most one
+# proxy-only subnet shared by all L7 LBs in the region. Reserve here so the
+# nodes layer can request a Gateway without a chicken-and-egg ordering problem.
+resource "google_compute_subnetwork" "proxy_only" {
+  count         = var.create_proxy_only_subnet ? 1 : 0
+  name          = "${var.name_prefix}-${var.name}-proxy-only"
+  project       = var.project_id
+  region        = var.region
+  network       = google_compute_network.this.id
+  ip_cidr_range = var.proxy_only_cidr
+  purpose       = "REGIONAL_MANAGED_PROXY"
+  role          = "ACTIVE"
+}
+
+# Allow internal traffic within the VPC, from the GKE master CIDR, and from
+# any other Aviatrix-attached spoke (post-SNAT, traffic arrives with a source
+# from the other spoke's GW subnet — also RFC1918). Without 10/8 + 192.168/16
+# + 172.16/12 in source_ranges, east-west between spokes is silently dropped
+# at the destination VPC even though the Aviatrix DCF rule permits it.
+resource "google_compute_firewall" "allow_internal" {
+  name    = "${var.name_prefix}-${var.name}-allow-internal"
+  project = var.project_id
+  network = google_compute_network.this.name
+
+  allow { protocol = "tcp" }
+  allow { protocol = "udp" }
+  allow { protocol = "icmp" }
+
+  source_ranges = concat(
+    ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"],
+    [var.pods_cidr, var.services_cidr],
+    var.master_ipv4_cidr_block != null ? [var.master_ipv4_cidr_block] : [],
+  )
+}
+
+# Allow Google's health-check + LB infrastructure to probe pods/nodes.
+# https://cloud.google.com/load-balancing/docs/health-check-concepts#ip-ranges
+resource "google_compute_firewall" "allow_health_checks" {
+  name    = "${var.name_prefix}-${var.name}-allow-hc"
+  project = var.project_id
+  network = google_compute_network.this.name
+
+  allow {
+    protocol = "tcp"
+  }
+
+  source_ranges = ["35.191.0.0/16", "130.211.0.0/22"]
+}

--- a/blueprints/gcp-gke-multicluster/network/modules/gke-vpc/outputs.tf
+++ b/blueprints/gcp-gke-multicluster/network/modules/gke-vpc/outputs.tf
@@ -1,0 +1,50 @@
+output "vpc_name" {
+  description = "GCP VPC name (matches Aviatrix controller's discovered VPC inventory name)"
+  value       = google_compute_network.this.name
+}
+
+output "vpc_id" {
+  description = "GCP VPC self_link (RFC1035 resource id)"
+  value       = google_compute_network.this.id
+}
+
+output "vpc_self_link" {
+  description = "GCP VPC self_link"
+  value       = google_compute_network.this.self_link
+}
+
+# Aviatrix expects vpc_id in the form "<vpc_name>~-~<project_id>" for GCP.
+output "aviatrix_vpc_id" {
+  description = "Composite VPC id consumed by aviatrix_spoke_gateway / mc-spoke for GCP"
+  value       = "${google_compute_network.this.name}~-~${var.project_id}"
+}
+
+output "nodes_subnet_id" {
+  description = "GKE node subnet self_link"
+  value       = google_compute_subnetwork.nodes.id
+}
+
+output "nodes_subnet_name" {
+  description = "GKE node subnet name (used by google_container_cluster.subnetwork)"
+  value       = google_compute_subnetwork.nodes.name
+}
+
+output "pods_range_name" {
+  description = "Secondary range name for pods (used by ip_allocation_policy)"
+  value       = "pods"
+}
+
+output "services_range_name" {
+  description = "Secondary range name for services (used by ip_allocation_policy)"
+  value       = "services"
+}
+
+output "avx_gw_subnet_cidr" {
+  description = "Aviatrix spoke gateway subnet CIDR (consumed by mc-spoke gw_subnet)"
+  value       = google_compute_subnetwork.avx_gw.ip_cidr_range
+}
+
+output "proxy_only_subnet_id" {
+  description = "Regional proxy-only subnet id (null if not created)"
+  value       = try(google_compute_subnetwork.proxy_only[0].id, null)
+}

--- a/blueprints/gcp-gke-multicluster/network/modules/gke-vpc/variables.tf
+++ b/blueprints/gcp-gke-multicluster/network/modules/gke-vpc/variables.tf
@@ -1,0 +1,62 @@
+variable "name" {
+  description = "Short name for this VPC (e.g., 'frontend', 'backend')"
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "Prefix for all resource names"
+  type        = string
+}
+
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for subnets"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "Documentation-only aggregate CIDR for the VPC (used in firewall internal source_ranges)"
+  type        = string
+}
+
+variable "nodes_cidr" {
+  description = "Primary CIDR of the GKE node subnet"
+  type        = string
+}
+
+variable "pods_cidr" {
+  description = "Secondary CIDR (alias range) for GKE pod IPs"
+  type        = string
+}
+
+variable "services_cidr" {
+  description = "Secondary CIDR (alias range) for GKE Services"
+  type        = string
+}
+
+variable "avx_gw_cidr" {
+  description = "CIDR for the dedicated Aviatrix spoke gateway subnet (/28 is enough)"
+  type        = string
+}
+
+variable "master_ipv4_cidr_block" {
+  description = "GKE control-plane CIDR (/28). Added to internal firewall source_ranges so nodes can talk to the master."
+  type        = string
+  default     = null
+}
+
+variable "create_proxy_only_subnet" {
+  description = "Reserve a regional proxy-only subnet for GCP-managed L7 ALBs (Gateway API)"
+  type        = bool
+  default     = true
+}
+
+variable "proxy_only_cidr" {
+  description = "CIDR for the regional proxy-only subnet (must not overlap nodes/pods/services)"
+  type        = string
+  default     = ""
+}

--- a/blueprints/gcp-gke-multicluster/network/modules/linux-vm/main.tf
+++ b/blueprints/gcp-gke-multicluster/network/modules/linux-vm/main.tf
@@ -1,0 +1,45 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}
+
+resource "google_compute_instance" "this" {
+  project      = var.project_id
+  name         = "${var.name_prefix}-db-vm"
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
+      size  = 20
+    }
+  }
+
+  network_interface {
+    subnetwork = var.subnet_id
+    # No access_config block → no external IP. Egress flows through the
+    # Aviatrix spoke GW (default route from Aviatrix 9.0).
+  }
+
+  metadata_startup_script = <<-EOT
+    #!/bin/bash
+    set -eux
+    apt-get update
+    apt-get install -y apache2
+    echo "<h1>db.${var.dns_zone_name} — east-west test target</h1>" > /var/www/html/index.html
+    systemctl enable --now apache2
+  EOT
+
+  service_account {
+    email  = var.service_account_email
+    scopes = ["cloud-platform"]
+  }
+
+  tags = ["aviatrix-db-vm"]
+}

--- a/blueprints/gcp-gke-multicluster/network/modules/linux-vm/outputs.tf
+++ b/blueprints/gcp-gke-multicluster/network/modules/linux-vm/outputs.tf
@@ -1,0 +1,9 @@
+output "vm_private_ip" {
+  description = "Private IP of the test VM"
+  value       = google_compute_instance.this.network_interface[0].network_ip
+}
+
+output "vm_name" {
+  description = "Compute instance name"
+  value       = google_compute_instance.this.name
+}

--- a/blueprints/gcp-gke-multicluster/network/modules/linux-vm/variables.tf
+++ b/blueprints/gcp-gke-multicluster/network/modules/linux-vm/variables.tf
@@ -1,0 +1,36 @@
+variable "name_prefix" {
+  description = "Prefix for resource names"
+  type        = string
+}
+
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "zone" {
+  description = "GCP zone for the VM"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Self-link of the subnet to deploy the VM into"
+  type        = string
+}
+
+variable "machine_type" {
+  description = "Compute machine type"
+  type        = string
+  default     = "e2-small"
+}
+
+variable "dns_zone_name" {
+  description = "Private DNS zone (used in the index.html banner)"
+  type        = string
+}
+
+variable "service_account_email" {
+  description = "Service account attached to the VM (use the project default compute SA if unsure)"
+  type        = string
+  default     = null
+}

--- a/blueprints/gcp-gke-multicluster/network/outputs.tf
+++ b/blueprints/gcp-gke-multicluster/network/outputs.tf
@@ -1,0 +1,178 @@
+#####################
+# Identifiers consumed by clusters/* and nodes/*
+#####################
+
+output "name_prefix" {
+  value = var.name_prefix
+}
+
+output "gcp_project_id" {
+  value = var.gcp_project_id
+}
+
+output "gcp_region" {
+  value = var.gcp_region
+}
+
+output "gcp_zone" {
+  value = var.gcp_zone
+}
+
+output "private_dns_zone_name" {
+  description = "Cloud DNS private zone name (with trailing dot — Cloud DNS native form)"
+  value       = var.private_dns_zone_name
+}
+
+output "private_dns_zone_resource_name" {
+  description = "Cloud DNS managed-zone resource name (used by ExternalDNS Workload Identity policy bindings)"
+  value       = google_dns_managed_zone.main.name
+}
+
+#####################
+# Frontend
+#####################
+
+output "frontend_cluster_name" {
+  value = local.clusters.frontend.name
+}
+
+output "frontend_cluster_id" {
+  description = "Constructed GKE cluster self_link for K8s SmartGroups (matches what clusters/frontend onboards)"
+  value       = local.frontend_cluster_id
+}
+
+output "frontend_vpc_name" {
+  value = module.frontend_vpc.vpc_name
+}
+
+output "frontend_vpc_self_link" {
+  value = module.frontend_vpc.vpc_self_link
+}
+
+output "frontend_nodes_subnet_name" {
+  value = module.frontend_vpc.nodes_subnet_name
+}
+
+output "frontend_pods_range_name" {
+  value = module.frontend_vpc.pods_range_name
+}
+
+output "frontend_services_range_name" {
+  value = module.frontend_vpc.services_range_name
+}
+
+output "frontend_master_cidr" {
+  value = var.frontend_master_cidr
+}
+
+output "frontend_spoke_gateway_public_ip" {
+  description = "Public egress IP of the frontend spoke GW (must be allowlisted on the GKE master_authorized_networks)"
+  value       = nonsensitive(module.frontend_spoke.spoke_gateway.public_ip)
+}
+
+output "frontend_gateway_global_ip_name" {
+  description = "Reserved global address name for the GKE Gateway (referenced by HTTPRoute / Gateway annotations in nodes/frontend)"
+  value       = google_compute_global_address.frontend_gateway.name
+}
+
+output "frontend_gateway_global_ip_address" {
+  description = "Reserved IPv4 address for the frontend Gateway"
+  value       = google_compute_global_address.frontend_gateway.address
+}
+
+#####################
+# Backend
+#####################
+
+output "backend_cluster_name" {
+  value = local.clusters.backend.name
+}
+
+output "backend_cluster_id" {
+  description = "Constructed GKE cluster self_link for K8s SmartGroups (matches what clusters/backend onboards)"
+  value       = local.backend_cluster_id
+}
+
+output "backend_vpc_name" {
+  value = module.backend_vpc.vpc_name
+}
+
+output "backend_vpc_self_link" {
+  value = module.backend_vpc.vpc_self_link
+}
+
+output "backend_nodes_subnet_name" {
+  value = module.backend_vpc.nodes_subnet_name
+}
+
+output "backend_pods_range_name" {
+  value = module.backend_vpc.pods_range_name
+}
+
+output "backend_services_range_name" {
+  value = module.backend_vpc.services_range_name
+}
+
+output "backend_master_cidr" {
+  value = var.backend_master_cidr
+}
+
+output "backend_spoke_gateway_public_ip" {
+  value = nonsensitive(module.backend_spoke.spoke_gateway.public_ip)
+}
+
+output "backend_gateway_global_ip_name" {
+  value = google_compute_global_address.backend_gateway.name
+}
+
+output "backend_gateway_global_ip_address" {
+  value = google_compute_global_address.backend_gateway.address
+}
+
+#####################
+# Pod / service ranges (shared)
+#####################
+
+output "frontend_pods_cidr" {
+  value = var.frontend_pods_cidr
+}
+
+output "backend_pods_cidr" {
+  value = var.backend_pods_cidr
+}
+
+output "services_cidr" {
+  value = var.services_cidr
+}
+
+#####################
+# DCF outputs (validation / cross-references)
+#####################
+
+output "dcf_ruleset_uuid" {
+  value = aviatrix_dcf_ruleset.gke_demo.id
+}
+
+output "smartgroup_frontend_vpc_uuid" {
+  value = aviatrix_smart_group.frontend_vpc.uuid
+}
+
+output "smartgroup_backend_vpc_uuid" {
+  value = aviatrix_smart_group.backend_vpc.uuid
+}
+
+output "webgroup_gcp_required_uuid" {
+  value = aviatrix_web_group.gcp_required.uuid
+}
+
+output "webgroup_github_aviatrix_uuid" {
+  value = aviatrix_web_group.github_aviatrix.uuid
+}
+
+output "smartgroup_frontend_gatus_ns_uuid" {
+  value = try(aviatrix_smart_group.frontend_gatus_ns[0].uuid, null)
+}
+
+output "smartgroup_backend_gatus_ns_uuid" {
+  value = try(aviatrix_smart_group.backend_gatus_ns[0].uuid, null)
+}

--- a/blueprints/gcp-gke-multicluster/network/outputs.tf
+++ b/blueprints/gcp-gke-multicluster/network/outputs.tf
@@ -3,19 +3,23 @@
 #####################
 
 output "name_prefix" {
-  value = var.name_prefix
+  description = "Blueprint name prefix (e.g., 'gke-demo'); reused by downstream layers when naming resources."
+  value       = var.name_prefix
 }
 
 output "gcp_project_id" {
-  value = var.gcp_project_id
+  description = "GCP project ID owning the VPCs, GKE clusters, and DB VM."
+  value       = var.gcp_project_id
 }
 
 output "gcp_region" {
-  value = var.gcp_region
+  description = "GCP region for subnets and zonal resources (e.g., 'us-central1')."
+  value       = var.gcp_region
 }
 
 output "gcp_zone" {
-  value = var.gcp_zone
+  description = "GCP zone for zonal GKE clusters and the DB VM (e.g., 'us-central1-a')."
+  value       = var.gcp_zone
 }
 
 output "private_dns_zone_name" {
@@ -33,7 +37,8 @@ output "private_dns_zone_resource_name" {
 #####################
 
 output "frontend_cluster_name" {
-  value = local.clusters.frontend.name
+  description = "Name of the frontend GKE cluster (e.g., '<name_prefix>-frontend')."
+  value       = local.clusters.frontend.name
 }
 
 output "frontend_cluster_id" {
@@ -42,27 +47,33 @@ output "frontend_cluster_id" {
 }
 
 output "frontend_vpc_name" {
-  value = module.frontend_vpc.vpc_name
+  description = "Name of the frontend GKE spoke VPC."
+  value       = module.frontend_vpc.vpc_name
 }
 
 output "frontend_vpc_self_link" {
-  value = module.frontend_vpc.vpc_self_link
+  description = "Frontend VPC self_link, consumed by clusters/frontend when creating the GKE cluster."
+  value       = module.frontend_vpc.vpc_self_link
 }
 
 output "frontend_nodes_subnet_name" {
-  value = module.frontend_vpc.nodes_subnet_name
+  description = "Frontend node subnet name (primary range hosts GKE node IPs)."
+  value       = module.frontend_vpc.nodes_subnet_name
 }
 
 output "frontend_pods_range_name" {
-  value = module.frontend_vpc.pods_range_name
+  description = "Secondary range alias for frontend pod IPs."
+  value       = module.frontend_vpc.pods_range_name
 }
 
 output "frontend_services_range_name" {
-  value = module.frontend_vpc.services_range_name
+  description = "Secondary range alias for frontend ClusterIP services."
+  value       = module.frontend_vpc.services_range_name
 }
 
 output "frontend_master_cidr" {
-  value = var.frontend_master_cidr
+  description = "GKE control-plane CIDR (/28) for the frontend cluster."
+  value       = var.frontend_master_cidr
 }
 
 output "frontend_spoke_gateway_public_ip" {
@@ -85,7 +96,8 @@ output "frontend_gateway_global_ip_address" {
 #####################
 
 output "backend_cluster_name" {
-  value = local.clusters.backend.name
+  description = "Name of the backend GKE cluster (e.g., '<name_prefix>-backend')."
+  value       = local.clusters.backend.name
 }
 
 output "backend_cluster_id" {
@@ -94,39 +106,48 @@ output "backend_cluster_id" {
 }
 
 output "backend_vpc_name" {
-  value = module.backend_vpc.vpc_name
+  description = "Name of the backend GKE spoke VPC."
+  value       = module.backend_vpc.vpc_name
 }
 
 output "backend_vpc_self_link" {
-  value = module.backend_vpc.vpc_self_link
+  description = "Backend VPC self_link, consumed by clusters/backend when creating the GKE cluster."
+  value       = module.backend_vpc.vpc_self_link
 }
 
 output "backend_nodes_subnet_name" {
-  value = module.backend_vpc.nodes_subnet_name
+  description = "Backend node subnet name (primary range hosts GKE node IPs)."
+  value       = module.backend_vpc.nodes_subnet_name
 }
 
 output "backend_pods_range_name" {
-  value = module.backend_vpc.pods_range_name
+  description = "Secondary range alias for backend pod IPs."
+  value       = module.backend_vpc.pods_range_name
 }
 
 output "backend_services_range_name" {
-  value = module.backend_vpc.services_range_name
+  description = "Secondary range alias for backend ClusterIP services."
+  value       = module.backend_vpc.services_range_name
 }
 
 output "backend_master_cidr" {
-  value = var.backend_master_cidr
+  description = "GKE control-plane CIDR (/28) for the backend cluster."
+  value       = var.backend_master_cidr
 }
 
 output "backend_spoke_gateway_public_ip" {
-  value = nonsensitive(module.backend_spoke.spoke_gateway.public_ip)
+  description = "Public egress IP of the backend spoke GW (must be allowlisted on the GKE master_authorized_networks)."
+  value       = nonsensitive(module.backend_spoke.spoke_gateway.public_ip)
 }
 
 output "backend_gateway_global_ip_name" {
-  value = google_compute_global_address.backend_gateway.name
+  description = "Reserved global address name for the GKE Gateway (referenced by HTTPRoute / Gateway annotations in nodes/backend)."
+  value       = google_compute_global_address.backend_gateway.name
 }
 
 output "backend_gateway_global_ip_address" {
-  value = google_compute_global_address.backend_gateway.address
+  description = "Reserved IPv4 address for the backend Gateway."
+  value       = google_compute_global_address.backend_gateway.address
 }
 
 #####################
@@ -134,15 +155,18 @@ output "backend_gateway_global_ip_address" {
 #####################
 
 output "frontend_pods_cidr" {
-  value = var.frontend_pods_cidr
+  description = "CIDR of the frontend pod alias range (echoes var.frontend_pods_cidr)."
+  value       = var.frontend_pods_cidr
 }
 
 output "backend_pods_cidr" {
-  value = var.backend_pods_cidr
+  description = "CIDR of the backend pod alias range (echoes var.backend_pods_cidr)."
+  value       = var.backend_pods_cidr
 }
 
 output "services_cidr" {
-  value = var.services_cidr
+  description = "CIDR of the GKE services secondary range (shared across both clusters; never leaves the cluster)."
+  value       = var.services_cidr
 }
 
 #####################
@@ -150,29 +174,36 @@ output "services_cidr" {
 #####################
 
 output "dcf_ruleset_uuid" {
-  value = aviatrix_dcf_ruleset.gke_demo.id
+  description = "UUID of the gke-demo DCF ruleset created by this layer."
+  value       = aviatrix_dcf_ruleset.gke_demo.id
 }
 
 output "smartgroup_frontend_vpc_uuid" {
-  value = aviatrix_smart_group.frontend_vpc.uuid
+  description = "UUID of the SmartGroup matching the frontend VPC CIDR."
+  value       = aviatrix_smart_group.frontend_vpc.uuid
 }
 
 output "smartgroup_backend_vpc_uuid" {
-  value = aviatrix_smart_group.backend_vpc.uuid
+  description = "UUID of the SmartGroup matching the backend VPC CIDR."
+  value       = aviatrix_smart_group.backend_vpc.uuid
 }
 
 output "webgroup_gcp_required_uuid" {
-  value = aviatrix_web_group.gcp_required.uuid
+  description = "UUID of the WebGroup matching GCP-required egress endpoints (storage, container registry, etc.)."
+  value       = aviatrix_web_group.gcp_required.uuid
 }
 
 output "webgroup_github_aviatrix_uuid" {
-  value = aviatrix_web_group.github_aviatrix.uuid
+  description = "UUID of the WebGroup matching the AviatrixSystems GitHub org (used by Helm chart fetches)."
+  value       = aviatrix_web_group.github_aviatrix.uuid
 }
 
 output "smartgroup_frontend_gatus_ns_uuid" {
-  value = try(aviatrix_smart_group.frontend_gatus_ns[0].uuid, null)
+  description = "UUID of the K8s-typed SmartGroup matching the gatus namespace on the frontend cluster (null when enable_k8s_smartgroup_demo = false)."
+  value       = try(aviatrix_smart_group.frontend_gatus_ns[0].uuid, null)
 }
 
 output "smartgroup_backend_gatus_ns_uuid" {
-  value = try(aviatrix_smart_group.backend_gatus_ns[0].uuid, null)
+  description = "UUID of the K8s-typed SmartGroup matching the gatus namespace on the backend cluster (null when enable_k8s_smartgroup_demo = false)."
+  value       = try(aviatrix_smart_group.backend_gatus_ns[0].uuid, null)
 }

--- a/blueprints/gcp-gke-multicluster/network/terraform.tfvars.example
+++ b/blueprints/gcp-gke-multicluster/network/terraform.tfvars.example
@@ -1,0 +1,48 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# gcp-gke-multicluster / network — variable reference
+#
+# Aviatrix Controller credentials are NOT in this file. Export them as env
+# vars (the standard pattern across blueprints):
+#   export AVIATRIX_CONTROLLER_IP="<controller-ip>"
+#   export AVIATRIX_USERNAME="admin"
+#   export AVIATRIX_PASSWORD="..."
+# Or `source ~/Documents/Scripting/chris-avx-lab/controller_env_ga.sh`
+#
+# GCP authentication: use Application Default Credentials.
+#   gcloud auth application-default login
+#   gcloud config set project cmchenry-01
+# ─────────────────────────────────────────────────────────────────────────────
+
+name_prefix              = "gke-demo"
+aviatrix_gcp_account_name = "Google"
+gcp_project_id           = "cmchenry-01"
+gcp_region               = "us-central1"
+gcp_zone                 = "us-central1-a"
+
+# CIDR plan (defaults are sane; change only if they collide with peered networks)
+# transit_cidr             = "10.2.0.0/24"
+# frontend_vpc_cidr        = "10.10.0.0/20"
+# frontend_nodes_cidr      = "10.10.0.0/22"
+# frontend_avx_gw_cidr     = "10.10.4.0/28"
+# frontend_proxy_only_cidr = "10.10.5.0/24"
+# frontend_master_cidr     = "172.20.0.0/28"
+# backend_vpc_cidr         = "10.20.0.0/20"
+# backend_nodes_cidr       = "10.20.0.0/22"
+# backend_avx_gw_cidr      = "10.20.4.0/28"
+# backend_proxy_only_cidr  = "10.20.5.0/24"
+# backend_master_cidr      = "172.20.1.0/28"
+# db_vpc_cidr              = "10.5.0.0/22"
+# db_subnet_cidr           = "10.5.0.0/24"
+# db_avx_gw_cidr           = "10.5.1.0/28"
+
+# Pod/Services secondary ranges — overlapping by design across clusters.
+# Aviatrix spoke GWs SNAT pod source IPs before forwarding to transit.
+# pods_cidr     = "100.64.0.0/16"
+# services_cidr = "172.16.0.0/20"
+
+# Cloud DNS private zone (must end with '.')
+# private_dns_zone_name = "gcp.aviatrixdemo.local."
+
+# Toggle K8s-typed SmartGroups + the priority-50 demo rule. Keep true for
+# normal use; flip to false and apply BEFORE destroying the clusters layer.
+# enable_k8s_smartgroup_demo = true

--- a/blueprints/gcp-gke-multicluster/network/variables.tf
+++ b/blueprints/gcp-gke-multicluster/network/variables.tf
@@ -9,19 +9,22 @@ variable "name_prefix" {
 # these empty in tfvars and export AVIATRIX_CONTROLLER_IP / AVIATRIX_USERNAME /
 # AVIATRIX_PASSWORD env vars instead.
 variable "aviatrix_controller_ip" {
-  type    = string
-  default = null
+  description = "Aviatrix Controller IP/hostname. Leave null and export AVIATRIX_CONTROLLER_IP instead."
+  type        = string
+  default     = null
 }
 
 variable "aviatrix_username" {
-  type    = string
-  default = null
+  description = "Aviatrix Controller username. Leave null and export AVIATRIX_USERNAME instead."
+  type        = string
+  default     = null
 }
 
 variable "aviatrix_password" {
-  type      = string
-  sensitive = true
-  default   = null
+  description = "Aviatrix Controller password. Leave null and export AVIATRIX_PASSWORD instead."
+  type        = string
+  sensitive   = true
+  default     = null
 }
 
 variable "aviatrix_gcp_account_name" {
@@ -50,6 +53,17 @@ variable "transit_cidr" {
   description = "CIDR for the Aviatrix Transit VPC"
   type        = string
   default     = "10.2.0.0/24"
+}
+
+variable "gw_instance_size" {
+  description = <<-EOT
+    GCE machine type for the Aviatrix transit + spoke gateways. Default
+    n1-standard-1 (~1 Gbps) is sized for lab demos. Step up to n1-standard-4 or
+    higher for bandwidth-heavy workloads. Same size is applied to all four GWs
+    (transit + frontend + backend + db spokes).
+  EOT
+  type        = string
+  default     = "n1-standard-1"
 }
 
 variable "frontend_vpc_cidr" {

--- a/blueprints/gcp-gke-multicluster/network/variables.tf
+++ b/blueprints/gcp-gke-multicluster/network/variables.tf
@@ -1,0 +1,180 @@
+variable "name_prefix" {
+  description = "Prefix for all resource names (e.g., 'gke-demo')"
+  type        = string
+  default     = "gke-demo"
+}
+
+# Aviatrix Controller credentials. Referenced by the aviatrix provider block so
+# `terraform validate` passes without env vars set. At plan/apply time, leave
+# these empty in tfvars and export AVIATRIX_CONTROLLER_IP / AVIATRIX_USERNAME /
+# AVIATRIX_PASSWORD env vars instead.
+variable "aviatrix_controller_ip" {
+  type    = string
+  default = null
+}
+
+variable "aviatrix_username" {
+  type    = string
+  default = null
+}
+
+variable "aviatrix_password" {
+  type      = string
+  sensitive = true
+  default   = null
+}
+
+variable "aviatrix_gcp_account_name" {
+  description = "Aviatrix access account name for GCP (configured in Controller — typically 'Google')"
+  type        = string
+}
+
+variable "gcp_project_id" {
+  description = "GCP project that owns the VPCs, GKE clusters, and DB VM"
+  type        = string
+}
+
+variable "gcp_region" {
+  description = "GCP region for subnets and zonal resources (e.g., 'us-central1')"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "gcp_zone" {
+  description = "GCP zone for zonal GKE clusters and the DB VM (e.g., 'us-central1-a')"
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "transit_cidr" {
+  description = "CIDR for the Aviatrix Transit VPC"
+  type        = string
+  default     = "10.2.0.0/24"
+}
+
+variable "frontend_vpc_cidr" {
+  description = "Aggregate CIDR documented for the frontend VPC (used in firewall rules; subnets are carved from it)"
+  type        = string
+  default     = "10.10.0.0/20"
+}
+
+variable "frontend_nodes_cidr" {
+  description = "Primary CIDR for the frontend GKE node subnet"
+  type        = string
+  default     = "10.10.0.0/22"
+}
+
+variable "frontend_avx_gw_cidr" {
+  description = "Aviatrix spoke GW subnet CIDR for frontend"
+  type        = string
+  default     = "10.10.4.0/28"
+}
+
+variable "frontend_proxy_only_cidr" {
+  description = "Regional proxy-only subnet CIDR for frontend (used by GCP-managed L7 ALB / Gateway API)"
+  type        = string
+  default     = "10.10.5.0/24"
+}
+
+variable "frontend_master_cidr" {
+  description = "GKE control-plane CIDR (/28) for the frontend cluster"
+  type        = string
+  default     = "172.20.0.0/28"
+}
+
+variable "backend_vpc_cidr" {
+  description = "Aggregate CIDR documented for the backend VPC"
+  type        = string
+  default     = "10.20.0.0/20"
+}
+
+variable "backend_nodes_cidr" {
+  description = "Primary CIDR for the backend GKE node subnet"
+  type        = string
+  default     = "10.20.0.0/22"
+}
+
+variable "backend_avx_gw_cidr" {
+  description = "Aviatrix spoke GW subnet CIDR for backend"
+  type        = string
+  default     = "10.20.4.0/28"
+}
+
+variable "backend_proxy_only_cidr" {
+  description = "Regional proxy-only subnet CIDR for backend"
+  type        = string
+  default     = "10.20.5.0/24"
+}
+
+variable "backend_master_cidr" {
+  description = "GKE control-plane CIDR (/28) for the backend cluster"
+  type        = string
+  default     = "172.20.1.0/28"
+}
+
+variable "db_vpc_cidr" {
+  description = "Aggregate CIDR for the DB test VPC"
+  type        = string
+  default     = "10.5.0.0/22"
+}
+
+variable "db_subnet_cidr" {
+  description = "Primary subnet CIDR for the DB test VM"
+  type        = string
+  default     = "10.5.0.0/24"
+}
+
+variable "db_avx_gw_cidr" {
+  description = "Aviatrix spoke GW subnet CIDR for the DB VPC"
+  type        = string
+  default     = "10.5.1.0/28"
+}
+
+variable "frontend_pods_cidr" {
+  description = <<-EOT
+    Pod alias range for the frontend GKE cluster. Defaults to 100.64.0.0/16
+    (overlaps with backend by design — Aviatrix spoke GW SNATs pod IPs at the
+    transit edge so the overlap is invisible east-west).
+
+    NOTE: pod-CIDR-overlap east-west between clusters does NOT currently work
+    on GCP with `single_ip_snat = true` (which only SNATs internet egress; the
+    transit path leaves pod source IPs unchanged, colliding with the
+    destination cluster's identical /16). For working east-west between two
+    GKE clusters, set non-overlapping CIDRs here and in backend_pods_cidr
+    BEFORE first apply (existing alias ranges cannot be modified in-place
+    once GKE pods have allocated IPs from them).
+  EOT
+  type        = string
+  default     = "100.64.0.0/16"
+}
+
+variable "backend_pods_cidr" {
+  description = "Pod alias range for the backend GKE cluster. See frontend_pods_cidr docstring."
+  type        = string
+  default     = "100.64.0.0/16"
+}
+
+variable "services_cidr" {
+  description = "GKE Services secondary range — overlapping by design (kube-internal, never leaves the cluster)"
+  type        = string
+  default     = "172.16.0.0/20"
+}
+
+variable "private_dns_zone_name" {
+  description = "Cloud DNS private zone DNS name (must end with '.')"
+  type        = string
+  default     = "gcp.aviatrixdemo.local."
+}
+
+variable "enable_k8s_smartgroup_demo" {
+  description = <<-EOT
+    Create K8s-typed SmartGroups (per-cluster + per-namespace) and the
+    priority-50 demo DCF rule that references them.
+
+    DESTROY WORKFLOW: set this to false and `terraform apply` BEFORE destroying
+    clusters/{frontend,backend}. The aviatrix_kubernetes_cluster registration
+    cannot be deleted while these SmartGroups reference its cluster_id.
+  EOT
+  type        = bool
+  default     = true
+}

--- a/blueprints/gcp-gke-multicluster/network/versions.tf
+++ b/blueprints/gcp-gke-multicluster/network/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 8.2"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/blueprints/gcp-gke-multicluster/nodes/backend/data.tf
+++ b/blueprints/gcp-gke-multicluster/nodes/backend/data.tf
@@ -1,0 +1,13 @@
+data "terraform_remote_state" "network" {
+  backend = "local"
+  config = {
+    path = "../../network/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "cluster" {
+  backend = "local"
+  config = {
+    path = "../../clusters/backend/terraform.tfstate"
+  }
+}

--- a/blueprints/gcp-gke-multicluster/nodes/backend/helm.tf
+++ b/blueprints/gcp-gke-multicluster/nodes/backend/helm.tf
@@ -1,0 +1,73 @@
+#####################
+# ExternalDNS — Cloud DNS provider via Workload Identity Federation
+#
+# The ExternalDNS Helm chart creates KSA `kube-system/external-dns`. The
+# `iam.gke.io/gcp-service-account` annotation links it to the Google service
+# account created in clusters/frontend (which already has roles/dns.admin
+# bound). The KSA → GSA Workload Identity binding is also in clusters/frontend.
+#
+# `gateway-httproute` is included in `sources` so ExternalDNS publishes
+# A records for HTTPRoute hostnames once the Gateway API resources land in
+# k8s-apps/.
+#####################
+
+resource "helm_release" "external_dns" {
+  name             = "external-dns"
+  repository       = "https://kubernetes-sigs.github.io/external-dns/"
+  chart            = "external-dns"
+  version          = var.external_dns_chart_version
+  namespace        = "kube-system"
+  create_namespace = false
+
+  values = [
+    yamlencode({
+      provider = {
+        name = "google"
+      }
+
+      google = {
+        project = local.project_id
+      }
+
+      serviceAccount = {
+        create = true
+        name   = "external-dns"
+        annotations = {
+          "iam.gke.io/gcp-service-account" = local.external_dns_gsa
+        }
+      }
+
+      sources = [
+        "service",
+        "ingress",
+        "gateway-httproute",
+      ]
+
+      domainFilters = [local.dns_zone_name]
+
+      policy = "sync"
+
+      txtOwnerId = local.cluster_name
+      txtPrefix  = "${local.cluster_name}-"
+
+      logLevel = "info"
+    })
+  ]
+}
+
+#####################
+# Aviatrix K8s Firewall (DCF CRD Controller)
+#
+# Installs FirewallPolicy and WebGroupPolicy CRDs. The controller syncs pod
+# label/namespace selectors to Aviatrix SmartGroups, allowing per-pod DCF rules
+# to be defined as Kubernetes resources.
+#####################
+
+resource "helm_release" "k8s_firewall" {
+  name             = "k8s-firewall"
+  repository       = "https://aviatrixsystems.github.io/k8s-firewall-charts"
+  chart            = "k8s-firewall"
+  version          = var.k8s_firewall_chart_version
+  namespace        = "aviatrix-firewall"
+  create_namespace = true
+}

--- a/blueprints/gcp-gke-multicluster/nodes/backend/main.tf
+++ b/blueprints/gcp-gke-multicluster/nodes/backend/main.tf
@@ -1,22 +1,3 @@
-terraform {
-  required_version = ">= 1.5"
-
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = "~> 6.0"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.30"
-    }
-    helm = {
-      source  = "hashicorp/helm"
-      version = "~> 2.16"
-    }
-  }
-}
-
 provider "google" {
   project = data.terraform_remote_state.network.outputs.gcp_project_id
   region  = data.terraform_remote_state.network.outputs.gcp_region

--- a/blueprints/gcp-gke-multicluster/nodes/backend/main.tf
+++ b/blueprints/gcp-gke-multicluster/nodes/backend/main.tf
@@ -1,0 +1,50 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.30"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.16"
+    }
+  }
+}
+
+provider "google" {
+  project = data.terraform_remote_state.network.outputs.gcp_project_id
+  region  = data.terraform_remote_state.network.outputs.gcp_region
+}
+
+# Use the active gcloud credentials' OAuth token to authenticate against the
+# GKE API server. This requires `gcloud auth application-default login` to
+# have been run (or the operator's environment provides an ADC token).
+data "google_client_config" "default" {}
+
+provider "kubernetes" {
+  host                   = "https://${data.terraform_remote_state.cluster.outputs.cluster_endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(data.terraform_remote_state.cluster.outputs.cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = "https://${data.terraform_remote_state.cluster.outputs.cluster_endpoint}"
+    token                  = data.google_client_config.default.access_token
+    cluster_ca_certificate = base64decode(data.terraform_remote_state.cluster.outputs.cluster_ca_certificate)
+  }
+}
+
+locals {
+  cluster_name     = data.terraform_remote_state.cluster.outputs.cluster_name
+  project_id       = data.terraform_remote_state.network.outputs.gcp_project_id
+  dns_zone_name    = trimsuffix(data.terraform_remote_state.network.outputs.private_dns_zone_name, ".")
+  external_dns_gsa = data.terraform_remote_state.cluster.outputs.external_dns_service_account_email
+  name_prefix      = data.terraform_remote_state.network.outputs.name_prefix
+}

--- a/blueprints/gcp-gke-multicluster/nodes/backend/outputs.tf
+++ b/blueprints/gcp-gke-multicluster/nodes/backend/outputs.tf
@@ -1,7 +1,9 @@
 output "external_dns_namespace" {
-  value = helm_release.external_dns.namespace
+  description = "Kubernetes namespace where the ExternalDNS Helm release was installed."
+  value       = helm_release.external_dns.namespace
 }
 
 output "k8s_firewall_namespace" {
-  value = helm_release.k8s_firewall.namespace
+  description = "Kubernetes namespace where the Aviatrix k8s-firewall Helm release was installed."
+  value       = helm_release.k8s_firewall.namespace
 }

--- a/blueprints/gcp-gke-multicluster/nodes/backend/outputs.tf
+++ b/blueprints/gcp-gke-multicluster/nodes/backend/outputs.tf
@@ -1,0 +1,7 @@
+output "external_dns_namespace" {
+  value = helm_release.external_dns.namespace
+}
+
+output "k8s_firewall_namespace" {
+  value = helm_release.k8s_firewall.namespace
+}

--- a/blueprints/gcp-gke-multicluster/nodes/backend/terraform.tfvars.example
+++ b/blueprints/gcp-gke-multicluster/nodes/backend/terraform.tfvars.example
@@ -1,0 +1,2 @@
+# external_dns_chart_version = "1.15.0"
+# k8s_firewall_chart_version = "1.0.0"

--- a/blueprints/gcp-gke-multicluster/nodes/backend/variables.tf
+++ b/blueprints/gcp-gke-multicluster/nodes/backend/variables.tf
@@ -1,0 +1,11 @@
+variable "external_dns_chart_version" {
+  description = "ExternalDNS Helm chart version (must support gateway-httproute source — chart >= 1.14)"
+  type        = string
+  default     = "1.15.0"
+}
+
+variable "k8s_firewall_chart_version" {
+  description = "Aviatrix k8s-firewall Helm chart version (8.2.0 or 9.0.0 — published in https://aviatrixsystems.github.io/k8s-firewall-charts/index.yaml)"
+  type        = string
+  default     = "9.0.0"
+}

--- a/blueprints/gcp-gke-multicluster/nodes/backend/versions.tf
+++ b/blueprints/gcp-gke-multicluster/nodes/backend/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.30"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.16"
+    }
+  }
+}

--- a/blueprints/gcp-gke-multicluster/nodes/frontend/data.tf
+++ b/blueprints/gcp-gke-multicluster/nodes/frontend/data.tf
@@ -1,0 +1,13 @@
+data "terraform_remote_state" "network" {
+  backend = "local"
+  config = {
+    path = "../../network/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "cluster" {
+  backend = "local"
+  config = {
+    path = "../../clusters/frontend/terraform.tfstate"
+  }
+}

--- a/blueprints/gcp-gke-multicluster/nodes/frontend/helm.tf
+++ b/blueprints/gcp-gke-multicluster/nodes/frontend/helm.tf
@@ -1,0 +1,73 @@
+#####################
+# ExternalDNS — Cloud DNS provider via Workload Identity Federation
+#
+# The ExternalDNS Helm chart creates KSA `kube-system/external-dns`. The
+# `iam.gke.io/gcp-service-account` annotation links it to the Google service
+# account created in clusters/frontend (which already has roles/dns.admin
+# bound). The KSA → GSA Workload Identity binding is also in clusters/frontend.
+#
+# `gateway-httproute` is included in `sources` so ExternalDNS publishes
+# A records for HTTPRoute hostnames once the Gateway API resources land in
+# k8s-apps/.
+#####################
+
+resource "helm_release" "external_dns" {
+  name             = "external-dns"
+  repository       = "https://kubernetes-sigs.github.io/external-dns/"
+  chart            = "external-dns"
+  version          = var.external_dns_chart_version
+  namespace        = "kube-system"
+  create_namespace = false
+
+  values = [
+    yamlencode({
+      provider = {
+        name = "google"
+      }
+
+      google = {
+        project = local.project_id
+      }
+
+      serviceAccount = {
+        create = true
+        name   = "external-dns"
+        annotations = {
+          "iam.gke.io/gcp-service-account" = local.external_dns_gsa
+        }
+      }
+
+      sources = [
+        "service",
+        "ingress",
+        "gateway-httproute",
+      ]
+
+      domainFilters = [local.dns_zone_name]
+
+      policy = "sync"
+
+      txtOwnerId = local.cluster_name
+      txtPrefix  = "${local.cluster_name}-"
+
+      logLevel = "info"
+    })
+  ]
+}
+
+#####################
+# Aviatrix K8s Firewall (DCF CRD Controller)
+#
+# Installs FirewallPolicy and WebGroupPolicy CRDs. The controller syncs pod
+# label/namespace selectors to Aviatrix SmartGroups, allowing per-pod DCF rules
+# to be defined as Kubernetes resources.
+#####################
+
+resource "helm_release" "k8s_firewall" {
+  name             = "k8s-firewall"
+  repository       = "https://aviatrixsystems.github.io/k8s-firewall-charts"
+  chart            = "k8s-firewall"
+  version          = var.k8s_firewall_chart_version
+  namespace        = "aviatrix-firewall"
+  create_namespace = true
+}

--- a/blueprints/gcp-gke-multicluster/nodes/frontend/main.tf
+++ b/blueprints/gcp-gke-multicluster/nodes/frontend/main.tf
@@ -1,22 +1,3 @@
-terraform {
-  required_version = ">= 1.5"
-
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = "~> 6.0"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.30"
-    }
-    helm = {
-      source  = "hashicorp/helm"
-      version = "~> 2.16"
-    }
-  }
-}
-
 provider "google" {
   project = data.terraform_remote_state.network.outputs.gcp_project_id
   region  = data.terraform_remote_state.network.outputs.gcp_region

--- a/blueprints/gcp-gke-multicluster/nodes/frontend/main.tf
+++ b/blueprints/gcp-gke-multicluster/nodes/frontend/main.tf
@@ -1,0 +1,50 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.30"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.16"
+    }
+  }
+}
+
+provider "google" {
+  project = data.terraform_remote_state.network.outputs.gcp_project_id
+  region  = data.terraform_remote_state.network.outputs.gcp_region
+}
+
+# Use the active gcloud credentials' OAuth token to authenticate against the
+# GKE API server. This requires `gcloud auth application-default login` to
+# have been run (or the operator's environment provides an ADC token).
+data "google_client_config" "default" {}
+
+provider "kubernetes" {
+  host                   = "https://${data.terraform_remote_state.cluster.outputs.cluster_endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(data.terraform_remote_state.cluster.outputs.cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = "https://${data.terraform_remote_state.cluster.outputs.cluster_endpoint}"
+    token                  = data.google_client_config.default.access_token
+    cluster_ca_certificate = base64decode(data.terraform_remote_state.cluster.outputs.cluster_ca_certificate)
+  }
+}
+
+locals {
+  cluster_name     = data.terraform_remote_state.cluster.outputs.cluster_name
+  project_id       = data.terraform_remote_state.network.outputs.gcp_project_id
+  dns_zone_name    = trimsuffix(data.terraform_remote_state.network.outputs.private_dns_zone_name, ".")
+  external_dns_gsa = data.terraform_remote_state.cluster.outputs.external_dns_service_account_email
+  name_prefix      = data.terraform_remote_state.network.outputs.name_prefix
+}

--- a/blueprints/gcp-gke-multicluster/nodes/frontend/outputs.tf
+++ b/blueprints/gcp-gke-multicluster/nodes/frontend/outputs.tf
@@ -1,7 +1,9 @@
 output "external_dns_namespace" {
-  value = helm_release.external_dns.namespace
+  description = "Kubernetes namespace where the ExternalDNS Helm release was installed."
+  value       = helm_release.external_dns.namespace
 }
 
 output "k8s_firewall_namespace" {
-  value = helm_release.k8s_firewall.namespace
+  description = "Kubernetes namespace where the Aviatrix k8s-firewall Helm release was installed."
+  value       = helm_release.k8s_firewall.namespace
 }

--- a/blueprints/gcp-gke-multicluster/nodes/frontend/outputs.tf
+++ b/blueprints/gcp-gke-multicluster/nodes/frontend/outputs.tf
@@ -1,0 +1,7 @@
+output "external_dns_namespace" {
+  value = helm_release.external_dns.namespace
+}
+
+output "k8s_firewall_namespace" {
+  value = helm_release.k8s_firewall.namespace
+}

--- a/blueprints/gcp-gke-multicluster/nodes/frontend/terraform.tfvars.example
+++ b/blueprints/gcp-gke-multicluster/nodes/frontend/terraform.tfvars.example
@@ -1,0 +1,2 @@
+# external_dns_chart_version = "1.15.0"
+# k8s_firewall_chart_version = "1.0.0"

--- a/blueprints/gcp-gke-multicluster/nodes/frontend/variables.tf
+++ b/blueprints/gcp-gke-multicluster/nodes/frontend/variables.tf
@@ -1,0 +1,11 @@
+variable "external_dns_chart_version" {
+  description = "ExternalDNS Helm chart version (must support gateway-httproute source — chart >= 1.14)"
+  type        = string
+  default     = "1.15.0"
+}
+
+variable "k8s_firewall_chart_version" {
+  description = "Aviatrix k8s-firewall Helm chart version (8.2.0 or 9.0.0 — published in https://aviatrixsystems.github.io/k8s-firewall-charts/index.yaml)"
+  type        = string
+  default     = "9.0.0"
+}

--- a/blueprints/gcp-gke-multicluster/nodes/frontend/versions.tf
+++ b/blueprints/gcp-gke-multicluster/nodes/frontend/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.30"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.16"
+    }
+  }
+}


### PR DESCRIPTION
# QA run: gcp-gke-multicluster

- Branch: gcp-gke-multicluster (stacked on existing feature branch, not a fresh `qa/...` branch)
- Date: 2026-05-01
- Wall-clock: ~80 min (deploy 35 min, scenarios 10 min, destroy 30 min, fixes 5 min)
- Test scenarios: 7/8 PASS as written, 1 PASS with workaround (Scenario 1 — see gap #3)
- Resources: 80 added during deploy (network 56 + clusters 24 + nodes 4), 80 destroyed cleanly

## Gaps found and fixed (6)

| # | Category | File | Summary |
|---|---|---|---|
| 1 | copy-paste-failure | README.md | GCP quota check used jmespath `[?metric=='X']` filter — gcloud doesn't support that; replaced with `regions describe` + value-format. |
| 2 | ambiguous-wording | README.md | "Optional: Rename kubectl Contexts" was actually mandatory (Step 8 + scenarios all assume the short aliases). Heading + intro corrected. |
| 3 | readme-code-mismatch | README.md, gatus.yaml × 2 | Reserved global IP from `network/` not bound by GKE Gateway controller — `terraform output …_global_ip_address` returned an unused IP and Scenario 1 timed out. README now reads ALB IP from `kubectl get gateway` (always live), with an IMPORTANT callout explaining the binding gotcha. Annotation-format fix in gatus.yaml deferred (needs GKE-side validation). |
| 4 | copy-paste-failure | README.md | Troubleshooting "Check the GKE Gateway controller logs" referenced `kubectl logs -n gke-system deployment/gke-l7-global-external-managed` — but that controller is GKE-managed (no in-cluster pod). Replaced with `kubectl get events` on the Gateway plus `gcloud logging read`. |
| 5 | stale-value | gatus.yaml × 2 | ThreatIQ test IP `185.38.148.2` rotated out of Emerging Threats Open feed; endpoint showed CONNECTED instead of blocked. Synced both gatus.yaml files to current head of feed (`100.19.147.208` as of QA run). Recurring stale-value source — feed rotates daily. |
| 6 | readme-code-mismatch | README.md | Prereqs table said `roles/container.clusterViewer` is the minimum SA role; Troubleshooting (1130 lines later) said `clusterViewer` alone is **not** sufficient and watch-loop reconciliation breaks. CR-injected SmartGroups + policy lists were empty after Phase 4 confirming the Troubleshooting position. Prereqs table now matches Troubleshooting. |

## Test scenarios

| # | Scenario | Result | Notes |
|---|---|---|---|
| 1 | Internet → ALB | PASS (with workaround) | Per gap #3 — reserved IP from tf output unused; live IP from Gateway returns 200. |
| 2 | Pod → internet egress via Aviatrix `customized_snat` | PASS | Pod 100.64.1.19 → spoke GW pub 35.224.238.56, HTTP 200 in 268ms. |
| 3 | East-west cross-cluster via Aviatrix transit | PASS | fe→backend 200 in 43ms, fe→DB 200 in 33ms over private DNS. |
| 4 | DCF egress allow (kubernetes.io, github.com/AviatrixSystems, npm) | PASS | All three return 200. |
| 5 | DCF threat blocking (GeoBlock + ThreatIQ) | PASS | After threat-IP refresh per gap #5: GeoBlock-Iran blocked, Threat-Feed blocked. |
| 6 | K8s-typed SmartGroup membership | PASS (CLI) / MANUAL (CoPilot) | Controller API confirms both clusters registered with `use_csp_credentials=true`. CoPilot pod-IP membership = MANUAL per skill rules. |
| 7 | DCF CRD-based policies (kubectl-level) | PASS | Both `firewallpolicies/infosec-egress` and `webgrouppolicies/dev-external-apis` accepted. |
|  | …Scenario 7 secondary (CR-injected SmartGroups in CoPilot) | FAIL | Watch loop never reconciled; root cause = under-privileged Aviatrix SA per gap #6. |
| 8 | Private DNS resolution (Cloud DNS via ExternalDNS) | PASS | All 3 expected A records present; `nslookup backend.gcp.aviatrixdemo.local` → 10.20.0.5. |

## Phase 5 destroy notes
- Step 3 (`terraform apply -var enable_k8s_smartgroup_demo=false`) failed with `[AVXERR-SMARTGROUP-0003]` on first run — the IMPORTANT-callout recovery (PUT pruned policy list, then re-apply) succeeded. The README warns this is "in some controller builds"; on Controller 9.0.10-1000.116 it happens reliably (not a code gap, but the wording could be tightened in a follow-up).
- Steps 1c/1f (orphan SmartGroups + Cloud DNS verification) clean immediately: 0 orphans, only Terraform-managed `db.*` DNS record remained.
- Cluster destroys (parallel): both Destroy complete, 12 resources each.
- Network destroy: 52 resources, exit 0.

## Resources verified clean
- GCP project `cmchenry-01`: 0 VPCs / 0 global addresses / 0 instances / 0 DNS zones with name~gke-demo
- Terraform state: `terraform state list` returns 0 rows in network/, clusters/{frontend,backend}/, nodes/{frontend,backend}/
- Controller k8s clusters API: `[]` (both registrations cleared)

## Out of scope (follow-ups)
- Gap #3 deeper fix: change gatus.yaml annotation from short name to `projects/<P>/global/addresses/<name>` and validate on a current GKE version. README workaround (kubectl-based lookup) makes scenarios robust either way.
- Step-3 disable-K8s-SG recovery wording tightening (it's "always" not "sometimes" on 9.0.10).
- Threat IP in gatus.yaml will rotate again — running `/qa-blueprint gcp-gke-multicluster` should auto-refresh it each pass.
