### PR TITLE
gcp-gke-multicluster: QA pass 2026-05-01

### DIFF
--- a/blueprints/gcp-gke-multicluster/README.md
+++ b/blueprints/gcp-gke-multicluster/README.md
@@ -71,8 +71,9 @@ Check current usage:
 ```bash
 gcloud compute regions describe us-central1 \
   --project=<YOUR_PROJECT_ID> \
-  --format="value(quotas.metric,quotas.usage,quotas.limit)" \
-  | tr ';' '\n' | paste -d'|' - - - | grep -E "^(CPUS|IN_USE_ADDRESSES)\b"
+  --flatten="quotas[]" \
+  --format="table(quotas.metric,quotas.usage,quotas.limit)" \
+  | grep -E "^(CPUS|IN_USE_ADDRESSES)\b"
 ```
 
 If you need an increase, file the request via Console → IAM & Admin → Quotas. Up to ~50 vCPUs is generally auto-approved.
@@ -291,7 +292,10 @@ terraform apply
 ```
 
 > [!TIP]
-> If `terraform apply` fails partway through with a transient controller error like `connection reset by peer` or `502 Bad Gateway` (most often during `aviatrix_spoke_transit_attachment` or `aviatrix_gateway_snat`), simply re-run `terraform apply`. Terraform picks up where it left off and the controller normally accepts the retry. This is not a configuration bug.
+> If `terraform apply` fails partway through with a transient error, simply re-run `terraform apply`. Terraform picks up where it left off and the retry normally succeeds. This is not a configuration bug. Common transients on this blueprint:
+>
+> - **Aviatrix Controller** — `connection reset by peer` / `502 Bad Gateway` (most often during `aviatrix_spoke_transit_attachment` or `aviatrix_gateway_snat`).
+> - **GCP** — `Error waiting for instance to create: Internal error.` on `module.db_vm.google_compute_instance.this`.
 
 **What's created:**
 
@@ -326,6 +330,9 @@ vim terraform.tfvars   # only needed if you customized any of the above
 # Deploy cluster (~10-15 minutes)
 terraform apply
 ```
+
+> [!TIP]
+> GKE control-plane creation occasionally fails fast (~30-60s) with `Error waiting for creating GKE cluster: Failed to create cluster` (a generic GCP `INTERNAL` error). The cluster is left in `STATUS=ERROR`; re-run `terraform apply` and Terraform will plan a destroy of the ERROR cluster and recreate it — the retry typically succeeds. No manual `gcloud container clusters delete` is required. Same advice applies to Step 4.
 
 **What's created:**
 
@@ -1183,7 +1190,7 @@ After `clusters/*` and `nodes/*` apply succeed and you've applied DCF CRs from `
 
 4. **Confirm the watch loop is actually reconciling.** The fastest way is to look for CR-injected SmartGroups + system-list rules:
    ```bash
-   echo "=== CR-injected SmartGroups (should appear within ~60s of CR apply) ==="
+   echo "=== CR-injected SmartGroups (subsequent CR applies on an already-onboarded cluster reconcile within ~60s; the first reconcile after a fresh onboarding can take up to ~10-15 minutes) ==="
    curl -sk -H "Authorization: cid ${CID}" "https://${AVIATRIX_CONTROLLER_IP}/v2.5/api/app-domains" \
      | python3 -c "
    import sys, json
@@ -1218,7 +1225,9 @@ After `clusters/*` and `nodes/*` apply succeed and you've applied DCF CRs from `
    terraform taint 'aviatrix_kubernetes_cluster.this[0]'
    terraform apply
    ```
-   The taint causes Terraform to delete and re-create the registration, which re-triggers the controller's onboarding handshake. Wait ~60s after apply for the watch loop to spin up, then re-check step 4. **Note:** if there are already CR-injected SmartGroups present, the destroy half of the taint will fail with `cluster is still used in smart groups` — that's expected; it confirms the watch loop IS working. In that case the registration was healthy all along; check CoPilot UI directly.
+   The taint causes Terraform to delete and re-create the registration, which re-triggers the controller's onboarding handshake. Wait ~60s after apply for the watch loop to spin up, then re-check step 4.
+
+   **Note:** if the destroy half of the taint fails with `cluster is still used in smart groups: <name1>, <name2>, ...`, inspect the names. If any start with `firewallpolicysource-` or `webgrouppolicy-target-`, the watch loop IS reconciling CRs — registration is healthy, check CoPilot UI for member resolution. If only template-level SGs (e.g. `${name_prefix}-sg-*-cluster`, `${name_prefix}-sg-*-gatus-ns`) appear, the test is **inconclusive** — those are created by `network/dcf-k8s.tf` (when `enable_k8s_smartgroup_demo = true`), not by the watch loop. In that case, set `enable_k8s_smartgroup_demo = false` on `network/`, apply, then retry the taint to isolate watch-loop behavior.
 
 5. **Check CoPilot directly.** The controller API only confirms registration; CoPilot is the only surface that exposes resolved pod-IP membership for K8s-typed SmartGroups. Cloud Workloads → Kubernetes Clusters should show **Onboarded: Yes** with namespace and pod counts. First-time sync after onboarding can take up to ~10 minutes.
 


### PR DESCRIPTION
# QA run: gcp-gke-multicluster

- Branch: `qa/gcp-gke-multicluster-2026-05-01-1`
- Wall-clock: ~75 min
- Test scenarios: **8/8 pass** (Scenario 7 partial — see gap #4)

## Gaps found and fixed (4)

- **#1** [wrong-expected-output] README.md:71-76 — `gcloud compute regions describe` quota pipeline emitted garbage (`CPUS|DISKS_TOTAL_GB|SNAPSHOTS`) because the `value(...) | tr ';' '\n' | paste -d'|' - - -` chain misinterprets gcloud's tab-separated record structure. Replaced with the idiomatic `--flatten="quotas[]" --format="table(...)"` form.
- **#2** [missing-recovery] README.md:293-294 — Step 2 `[!TIP]` block listed only Aviatrix-side transients (`connection reset by peer` / `502 Bad Gateway`). A first-time deploy in this run hit a GCP-side transient (`Error waiting for instance to create: Internal error.` on `module.db_vm.google_compute_instance.this`) that the same retry-once heuristic resolves. Expanded the TIP to call out both classes.
- **#3** [missing-recovery] README.md:308-356 — Steps 3 + 4 had no transient-retry guidance. Both cluster applies in this run failed at ~40s with `Error waiting for creating GKE cluster: Failed to create cluster` (generic GCP `INTERNAL` error, code 13), leaving the clusters in `STATUS=ERROR`. A second `terraform apply` self-healed both (planned 1-destroy + 4-add). Added a `[!TIP]` after Step 3's apply line documenting the self-heal behavior; one-line cross-reference for Step 4.
- **#4** [wrong-expected-output] README.md:625-639, 1186, 1221 — Two contradictory expectations and one misleading taint-recovery note. Scenario 6 says "First-time sync after onboarding can take ~10 minutes"; troubleshooting L1186 said "should appear within ~60s of CR apply". On Controller 9.0.10 in this run, mirror SmartGroups (`firewallpolicysource-*` / `webgrouppolicy-target-*`) had not appeared after 16+ min — neither bound matched. Reworded L1186 to distinguish first-reconcile (~10-15min) from subsequent CR applies (~60s). Also fixed L1221's misleading note: when the taint is blocked by template-level K8s-typed SGs (e.g., `gke-demo-sg-frontend-cluster`) rather than CR-injected mirrors, the test is inconclusive; replaced "blocked = healthy" with a name-based discriminator.

## Test scenarios

| # | Scenario | Result |
|---|---|---|
| 1 | Internet → ALB | PASS (both ALBs serve 200; minor 30-60s warm-up flap right after `PROGRAMMED=True` is normal ALB behavior) |
| 2 | Pod → Internet (SNAT to spoke GW) | PASS (`ifconfig.io` returned 35.225.115.160 = frontend spoke GW pub IP; `kubernetes.io` 200 in 0.166s) |
| 3 | East-West cross-cluster | PASS (cross-cluster gatus 200 in 33ms; DB VM 200 in 30ms — well under README's "<100ms" expectation) |
| 4 | DCF Egress Allow | PASS (kubernetes.io / github/AviatrixSystems / npmjs all 200) |
| 5 | DCF Threat Blocking | PASS (Gatus JSON: Egress 6/6 success, Internal 4/4 success, Threats 0/4 success — both threat endpoints blocked as designed) |
| 6 | K8s SmartGroup Membership (CLI portion) | PASS (controller API confirms both clusters registered with `use_csp_credentials=true`); CoPilot UI portion = MANUAL |
| 7 | DCF CRD Policies | **PARTIAL** — CRDs accepted in both clusters; controller-side mirror SmartGroups did not appear within 16 min on this run (gap #4). Functional DCF behavior unaffected because lower-priority VPC-based rules carry the cross-cluster traffic. |
| 8 | Private DNS Resolution | PASS (all A records present; `nslookup` from pod resolves `backend.gcp.aviatrixdemo.local → 10.20.0.5`) |

## Resources verified clean

- 0 Terraform state entries across all 5 layers (network, clusters/{f,b}, nodes/{f,b}).
- 0 GCP-side orphans: no `gke-demo-*` GKE clusters, VPCs, instances, service accounts, reserved global IPs, or DNS zones remained.
- 0 Aviatrix Controller K8s cluster registrations remained (`/v2.5/api/k8s/clusters` returned `[]`).
- 0 CR-injected SmartGroups orphaned.
- Documented destroy-Step-3 recovery (`[AVXERR-SMARTGROUP-0003]`) was triggered exactly as the README warned; the README's verbatim curl-based recovery procedure worked first try.

## Notes for the human reviewer

- Gap #2 (GCP transient) and gap #3 (GKE control-plane transient) both manifested on a project that has run 4 prior deploy/destroy cycles in the past 24h (per `gcloud container operations list`). May be project-specific rate-limiting; the proposed wording ("simply re-run") is conservative and won't mislead a customer in a clean project.
- Gap #4's underlying behavior (watch loop not reconciling within the documented window on Controller 9.0.10) deserves a Controller-side investigation independent of this doc fix. The fix here only updates the README's expectations; it does not address the root cause.
- Scenario 1's brief 30-60s flap after `PROGRAMMED=True` is a known GKE Gateway / ALB behavior. Not logged as a gap because customer self-heals via a single retry, but worth considering whether to add `--retry 3 --retry-delay 5 --retry-all-errors` to the Scenario 1 curl command for resilience.
