### PR TITLE
chore: reposition voice to Cloud Native Security Fabric

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code when working with the Aviatrix Bluepr
 
 ## Repository Overview
 
-This repository contains production-ready Terraform lab environments ("blueprints") for learning, demonstrating, and testing Aviatrix cloud networking solutions. Each blueprint is a self-contained, deployable environment.
+This repository contains production-ready Terraform lab environments ("blueprints") for learning, demonstrating, and testing the Aviatrix Cloud Native Security Fabric (CNSF) — Distributed Cloud Firewall (DCF), workload segmentation, and Zero Trust enforcement. Each blueprint is a self-contained, deployable environment.
 
 ## Project Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to Aviatrix Blueprints! This documen
 
 ## Code of Conduct
 
-Please be respectful and constructive in all interactions. We're building a community resource for cloud networking professionals.
+Please be respectful and constructive in all interactions. We're building a community resource for cloud security and platform teams.
 
 ## Recommended Development Environment
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aviatrix Blueprints
 
-Production-ready Terraform lab environments for learning, demonstrating, and testing Aviatrix cloud networking solutions.
+Production-ready Terraform lab environments — Infrastructure as Code for learning, demonstrating, and testing the **Aviatrix Cloud Native Security Fabric**: Distributed Cloud Firewall, workload segmentation, and Zero Trust enforcement across AWS, Azure, and GCP.
 
 ![Aviatrix Blueprints](aviatrix_blueprints_logo.svg)
 

--- a/aviatrix_blueprints_logo.svg
+++ b/aviatrix_blueprints_logo.svg
@@ -59,7 +59,7 @@
 
   <!-- Sheet header strip -->
   <line x1="80" y1="74" x2="1320" y2="74" stroke="#2A4A8A" stroke-width="0.6"/>
-  <text x="80" y="64" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="11" fill="#7AB8FF" letter-spacing="3">SHEET 01 / 01  ·  AVIATRIX SYSTEMS  ·  CLOUD NETWORK SECURITY</text>
+  <text x="80" y="64" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="11" fill="#7AB8FF" letter-spacing="3">SHEET 01 / 01  ·  AVIATRIX SYSTEMS  ·  CLOUD NATIVE SECURITY FABRIC</text>
   <text x="1320" y="64" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="11" fill="#7AB8FF" letter-spacing="3" text-anchor="end">PROJ. AVX-BP  ·  REF QUALITY LAB ENVIRONMENTS</text>
 
   <!--
@@ -134,7 +134,7 @@
   <text x="540" y="475" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="130" font-weight="800" letter-spacing="-3" fill="#F5F8FF">BLUEPRINTS</text>
 
   <line x1="540" y1="505" x2="1320" y2="505" stroke="#2A4A8A" stroke-width="0.6"/>
-  <text x="540" y="532" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="14" fill="#A0B4D8" letter-spacing="4">REFERENCE-QUALITY  ·  CLOUD NETWORK SECURITY  ·  LAB ENVIRONMENTS</text>
+  <text x="540" y="532" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="14" fill="#A0B4D8" letter-spacing="4">REFERENCE-QUALITY  ·  CLOUD NATIVE SECURITY FABRIC  ·  LAB ENVIRONMENTS</text>
 
   <!-- ============= Bottom-left: Notes ============= -->
   <g transform="translate(80, 600)">

--- a/blueprints/aws-eks-multicluster/README.md
+++ b/blueprints/aws-eks-multicluster/README.md
@@ -1,6 +1,6 @@
-# Multi-Cluster EKS with Aviatrix Transit Architecture
+# Multi-Cluster EKS Secured by the Aviatrix Cloud Native Security Fabric
 
-This repository deploys a multi-cluster Kubernetes environment with Aviatrix transit networking, demonstrating Distributed Cloud Firewall (DCF) for Kubernetes capabilities.
+This repository deploys a multi-cluster Kubernetes environment on AWS, demonstrating the **Aviatrix Cloud Native Security Fabric (CNSF)** for Kubernetes — Distributed Cloud Firewall (DCF), workload segmentation, and Zero Trust enforcement across clusters.
 
 > [!TIP]
 > **🤖 Optimized for Claude Code** — Run `/deploy-blueprint` for AI-guided deployment with prerequisite checks and automated orchestration, or `/analyze-blueprint` for resource and cost details. [Get Claude Code](https://claude.ai/code)

--- a/blueprints/azure-aks-multicluster/README.md
+++ b/blueprints/azure-aks-multicluster/README.md
@@ -1,6 +1,6 @@
-# Multi-Cluster AKS with Aviatrix Transit Architecture
+# Multi-Cluster AKS Secured by the Aviatrix Cloud Native Security Fabric
 
-This blueprint deploys a multi-cluster Kubernetes environment on Azure with Aviatrix transit networking, demonstrating Distributed Cloud Firewall (DCF) for Kubernetes capabilities.
+This blueprint deploys a multi-cluster Kubernetes environment on Azure, demonstrating the **Aviatrix Cloud Native Security Fabric (CNSF)** for Kubernetes — Distributed Cloud Firewall (DCF), workload segmentation, and Zero Trust enforcement across clusters.
 
 > [!TIP]
 > **Optimized for Claude Code** — Run `/deploy-blueprint` for AI-guided deployment with prerequisite checks and automated orchestration, or `/analyze-blueprint` for resource and cost details. [Get Claude Code](https://claude.ai/code)

--- a/blueprints/gcp-gke-multicluster/README.md
+++ b/blueprints/gcp-gke-multicluster/README.md
@@ -1,6 +1,6 @@
-# Multi-Cluster GKE with Aviatrix Transit Architecture
+# Multi-Cluster GKE Secured by the Aviatrix Cloud Native Security Fabric
 
-This blueprint deploys a multi-cluster Kubernetes environment on Google Cloud with Aviatrix transit networking, demonstrating Distributed Cloud Firewall (DCF) for Kubernetes — the GCP counterpart to `aws-eks-multicluster` and `azure-aks-multicluster`.
+This blueprint deploys a multi-cluster Kubernetes environment on Google Cloud, demonstrating the **Aviatrix Cloud Native Security Fabric (CNSF)** for Kubernetes — Distributed Cloud Firewall (DCF), workload segmentation, and Zero Trust enforcement across clusters. GCP counterpart to `aws-eks-multicluster` and `azure-aks-multicluster`.
 
 > [!TIP]
 > **Optimized for Claude Code** — Run `/deploy-blueprint` for AI-guided deployment with prerequisite checks and automated orchestration, or `/analyze-blueprint` for resource and cost details. [Get Claude Code](https://claude.ai/code)

--- a/blueprints/k8s-cluster-aas/README.md
+++ b/blueprints/k8s-cluster-aas/README.md
@@ -1,6 +1,6 @@
 # k8s-cluster-aas — Cluster-as-a-Service
 
-Each team gets a **dedicated EKS cluster in its own VPC**. Network isolation is enforced by Aviatrix DCF at the VPC boundary — no team can reach another team's cluster without an explicit PERMIT rule.
+Each team gets a **dedicated EKS cluster in its own VPC**. Workload isolation is enforced by the **Aviatrix Cloud Native Security Fabric** — Distributed Cloud Firewall (DCF) at the VPC boundary — so no team can reach another team's cluster without an explicit PERMIT rule.
 
 ## Architecture
 

--- a/blueprints/k8s-namespace-aas/README.md
+++ b/blueprints/k8s-namespace-aas/README.md
@@ -1,6 +1,6 @@
 # k8s-namespace-aas — Namespace-as-a-Service
 
-All teams share a **single EKS cluster** with namespace-level isolation enforced by Aviatrix DCF (transit-level) and Calico NetworkPolicy (intra-cluster). Kubernetes RBAC prevents accidental cross-namespace access but is **not a network security boundary** — DCF and NetworkPolicy are the enforcement mechanisms.
+All teams share a **single EKS cluster** with namespace-level workload isolation enforced by the **Aviatrix Cloud Native Security Fabric** — Distributed Cloud Firewall (DCF) at the transit layer — paired with Calico NetworkPolicy intra-cluster. Kubernetes RBAC prevents accidental cross-namespace access but is **not a security boundary** — DCF and NetworkPolicy are the enforcement mechanisms.
 
 ## Architecture
 

--- a/blueprints/k8s-prod-nonprod-hybrid/README.md
+++ b/blueprints/k8s-prod-nonprod-hybrid/README.md
@@ -1,6 +1,6 @@
 # k8s-prod-nonprod-hybrid — Prod/Non-Prod Hybrid (Recommended)
 
-Separate production and non-production EKS clusters with **two-layer DCF isolation**: environment-level (VPC SmartGroups) and namespace-level (K8s SmartGroups). Combines the strong isolation of cluster-aas with the team self-service of namespace-aas. HA enabled by default.
+Separate production and non-production EKS clusters secured by the **Aviatrix Cloud Native Security Fabric** with **two-layer DCF isolation**: environment-level (VPC SmartGroups) and namespace-level (K8s SmartGroups). Combines the strong workload isolation of cluster-aas with the team self-service of namespace-aas. HA enabled by default.
 
 ## Architecture
 

--- a/blueprints/prevent-lateral-movement-vm-tags/README.md
+++ b/blueprints/prevent-lateral-movement-vm-tags/README.md
@@ -1,6 +1,6 @@
 # Prevent Lateral Movement - VM Tags
 
-Deploy **Zero Trust microsegmentation** in 15 minutes using Aviatrix Distributed Cloud Firewall (DCF) and SmartGroups. This blueprint enforces tag-based network segmentation across AWS VPCs — preventing lateral movement, accelerating compliance, and eliminating security group sprawl.
+Deploy **Zero Trust workload microsegmentation** in 15 minutes with the **Aviatrix Cloud Native Security Fabric** — Distributed Cloud Firewall (DCF) and SmartGroups. This blueprint enforces tag-based workload segmentation across AWS VPCs — preventing lateral movement, accelerating compliance, and eliminating security group sprawl.
 
 > [!TIP]
 > **🤖 Optimized for Claude Code** — Run `/deploy-blueprint prevent-lateral-movement-vm-tags` for AI-guided deployment with prerequisite checks, or `/analyze-blueprint prevent-lateral-movement-vm-tags` for resource and cost details. [Get Claude Code](https://claude.ai/code)

--- a/blueprints/zero-trust-segmentation/README.md
+++ b/blueprints/zero-trust-segmentation/README.md
@@ -1,6 +1,6 @@
-# Zero Trust Network Segmentation
+# Zero Trust Workload Segmentation
 
-Demonstrates Zero Trust Network Segmentation using Aviatrix Distributed Cloud Firewall (DCF) with SmartGroups. This blueprint creates a simple three-tier architecture (Dev, Prod, Database) with policy-based segmentation that prevents lateral movement while allowing authorized traffic flows.
+Demonstrates Zero Trust workload segmentation with the **Aviatrix Cloud Native Security Fabric** — Distributed Cloud Firewall (DCF) and SmartGroups. This blueprint creates a simple three-tier architecture (Dev, Prod, Database) with policy-based segmentation that prevents lateral movement while allowing authorized traffic flows.
 
 > [!TIP]
 > **🤖 Optimized for Claude Code** — Run `/deploy-blueprint zero-trust-segmentation` for AI-guided deployment with prerequisite checks, or `/analyze-blueprint zero-trust-segmentation` for resource and cost details. [Get Claude Code](https://claude.ai/code)

--- a/docs/blueprint-standards.md
+++ b/docs/blueprint-standards.md
@@ -12,7 +12,7 @@ Each blueprint's README.md must include the following sections:
 # Blueprint Name
 
 Brief description of what this blueprint deploys and demonstrates.
-One to three sentences covering the use case and key Aviatrix features.
+One to three sentences covering the use case and the Aviatrix Cloud Native Security Fabric capabilities it showcases (e.g., Distributed Cloud Firewall, workload segmentation, Zero Trust enforcement).
 ```
 
 ### 2. Architecture Diagram


### PR DESCRIPTION
## Summary

Shifts the repo's positioning from "Aviatrix cloud networking solutions" to the **Aviatrix Cloud Native Security Fabric (CNSF)** — with Distributed Cloud Firewall (DCF), workload segmentation, and Zero Trust enforcement as the named capabilities. Lead copy and titles only; technical bodies untouched.

### Hierarchy established

```
Aviatrix Cloud Native Security Fabric (CNSF)   ← product/category
├── Distributed Cloud Firewall (DCF)            ← feature
├── Workload security / segmentation            ← feature
├── Zero Trust enforcement                      ← feature
└── Secure transit / connectivity               ← feature
```

### What changed

**Top-of-funnel (5 files):**
- `README.md` — tagline rewritten to lead with CNSF
- `CONTRIBUTING.md` — "cloud networking professionals" → "cloud security and platform teams"
- `CLAUDE.md` — repo overview repositioned around CNSF
- `docs/blueprint-standards.md` — template guides future blueprints to lead with CNSF capabilities
- `aviatrix_blueprints_logo.svg` — header + tagline strips: "CLOUD NETWORK SECURITY" → "CLOUD NATIVE SECURITY FABRIC"

**Blueprint READMEs (8 files):** lead paragraphs and titles reframed.
- AWS/Azure/GCP multicluster titles: "with Aviatrix Transit Architecture" → "Secured by the Aviatrix Cloud Native Security Fabric"
- `k8s-cluster-aas`, `k8s-namespace-aas`, `k8s-prod-nonprod-hybrid`: "network isolation" → "workload isolation"; DCF nested under CNSF
- `zero-trust-segmentation`: "Zero Trust Network Segmentation" → "Zero Trust Workload Segmentation"
- `prevent-lateral-movement-vm-tags`: "microsegmentation" → "workload microsegmentation"

### What was intentionally **not** touched

- K8s CRD API groups (`firewallpolicies.networking.aviatrix.com`) — real K8s API, immutable
- Cloud-provider platform terms (Workload Identity, `networking.gke.io/...`)
- Cost-table "Networking" subtotals — real cloud-provider cost categories
- Variable/output descriptions referencing actual networking resources
- Section headings like "Pod Networking" describing CNI behavior
- Anything inside `.terraform/` (vendored)

Repo grep for "cloud networking" returns zero matches after this change.

## Test plan

- [ ] Verify the rebranded tagline reads cleanly on the GitHub repo home page
- [ ] Verify the SVG logo renders correctly (text strips updated, no other geometry changed)
- [ ] Spot-check that no blueprint README's body content (cost tables, technical sections, troubleshooting) was inadvertently touched
- [ ] `git log -p` on the 13 files to confirm the diff is positioning-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)