### PR TITLE
azure-aks-multicluster: QA pass 2026-05-01

### DIFF
--- a/blueprints/azure-aks-multicluster/README.md
+++ b/blueprints/azure-aks-multicluster/README.md
@@ -343,7 +343,7 @@ terraform apply
 - Aviatrix Transit Gateway (transit VNet `10.2.0.0/20`)
 - Frontend AKS VNet — **two address spaces**: routable `10.10.0.0/23` (nodes, system, AppGW, Aviatrix spoke GW subnets) + pod `100.64.0.0/16` (pod subnet); UDR `0.0.0.0/0 → spoke GW` on the nodes/system/pod subnets; spoke GW in `customized_snat` mode
 - Backend AKS VNet — same shape with `10.20.0.0/23` routable + `100.64.0.0/16` pod (intentionally same pod CIDR as frontend; never advertised to transit)
-- DB spoke VNet (`10.5.0.0/22`) with Linux test VM (Apache)
+- DB spoke VNet (`10.5.0.0/22`) with Linux test VM (nginx)
 - Frontend Application Gateway (Standard_v2, public IP, backend pool targets `10.10.0.200`)
 - Backend Application Gateway (Standard_v2, public IP, backend pool targets `10.20.0.200`)
 - Azure Private DNS zone (`azure.aviatrixdemo.local`) linked to all VNets
@@ -600,6 +600,7 @@ Gatus monitors several allowed egress endpoints. Verify these show green:
 
 - `https://kubernetes.io` (kubernetes_io WebGroup)
 - `https://github.com/AviatrixSystems/terraform-provider-aviatrix` (github_aviatrix WebGroup)
+- `https://github.com/AviatrixSystems/avxlabs-docs` (github_aviatrix WebGroup)
 - `https://registry.npmjs.org` (npm_registry WebGroup)
 
 ### Scenario 4: DCF Threat Blocking — GeoBlock and ThreatIQ
@@ -1286,7 +1287,7 @@ ls -la clusters/frontend/terraform.tfstate
 | Frontend Node Pool | Azure VMSS | 2 (desired) | Standard_B2s | min=1, max=3 |
 | Backend Node Pool | Azure VMSS | 2 (desired) | Standard_B2s | min=1, max=3 |
 | **Test VM** | | | | |
-| DB Linux VM | Azure VM | 1 | Standard_B1s | DB spoke, Apache |
+| DB Linux VM | Azure VM | 1 | Standard_B1s | DB spoke, nginx |
 
 **Total VMs (at desired state):** 10
 

--- a/blueprints/azure-aks-multicluster/network/modules/linux-vm/main.tf
+++ b/blueprints/azure-aks-multicluster/network/modules/linux-vm/main.tf
@@ -48,14 +48,16 @@ resource "azurerm_linux_virtual_machine" "vm" {
     version   = "latest"
   }
 
-  # Install nginx web server on boot — used as east-west test target
+  # Install nginx web server on boot — used as east-west test target.
+  # The Aviatrix spoke GW SNAT may not be ready when cloud-init first runs,
+  # so DNS / apt egress can fail for several minutes. Retry until they work.
   custom_data = base64encode(<<-EOF
     #!/bin/bash
-    apt-get update -y
-    apt-get install -y nginx
+    until getent hosts archive.ubuntu.com >/dev/null; do sleep 30; done
+    until apt-get update -y; do sleep 15; done
+    until apt-get install -y nginx; do sleep 15; done
     systemctl enable nginx
     systemctl start nginx
-    # Return hostname in response body for easy identification
     echo "<h1>DB Test VM: $(hostname)</h1><p>Private IP: $(hostname -I | awk '{print $1}')</p>" \
       > /var/www/html/index.html
   EOF


### PR DESCRIPTION
# QA run: azure-aks-multicluster

- Branch: `qa/azure-aks-multicluster-2026-05-01-1`
- Cloud target: Azure (`csp_azure_cmchenry`, eastus2)
- Aviatrix Controller: 3.131.22.171 (account `Azure`)
- Wall-clock: ~70m total — network ~9m, clusters ~7m, nodes ~3m, tests ~5m, destroy ~25m
- Test scenarios: **7/7 pass** (1 worked-around — Scenario 2 DB connectivity, see gap #1)

## Gaps found and fixed (2)

- **#1** [copy-paste-failure] `network/modules/linux-vm/main.tf` — DB VM nginx install races spoke-GW SNAT readiness; cloud-init runs apt-get before DNS works, fails permanently. Result: customer Gatus dashboards show "Prod Database" red, README never explains why. Fix: retry-until-DNS-works in `custom_data`. Also corrects two README spots that say "Apache" — the VM actually runs nginx.
- **#2** [readme-code-mismatch] `README.md` Scenario 3 — lists 3 allowed-egress endpoints, gatus YAML probes 4. Adds the missing `github.com/AviatrixSystems/avxlabs-docs` bullet so the documented list matches what the dashboard actually shows.

## Test scenarios

| # | Scenario | Result |
|---|---|---|
| 1 | Internet → AppGW (HTTP) | PASS — both AppGWs return 200 first try |
| 2 | East-west cross-cluster (Aviatrix transit) | PASS — pod-to-`backend.azure.aviatrixdemo.local:8080` returned 200 first try; `Prod Database` failed initially due to gap #1, passed after manual nginx install on DB VM |
| 3 | DCF egress allowed (kubernetes.io / github / npm / avxlabs-docs) | PASS — all 4 endpoints `success=True` in Gatus |
| 4 | DCF threat blocking (GeoBlock + ThreatGuard) | PASS — both `success=False` (correctly blocked); threat IP `185.38.148.2` confirmed live in ET Open feed |
| 5 | K8s SmartGroup membership | PASS-API + MANUAL — Controller `/v2.5/api/k8s/clusters` shows both `aks-demo-frontend` and `aks-demo-backend` registered with `use_csp_credentials=true`. CoPilot membership tab requires manual UI verification per README. |
| 6 | DCF CRD-based policies | PASS — both `infosec-egress` (FirewallPolicy) and `dev-external-apis` (WebGroupPolicy) applied cleanly; `kubectl create namespace dev` from README executed without issue |
| 7 | Private DNS resolution | PASS — `backend.azure.aviatrixdemo.local` → 10.20.1.6, `backend-web.azure.aviatrixdemo.local` → 10.20.0.200; all 5 records (db, frontend, frontend-web, backend, backend-web) present in zone |

## Destroy notes

- README's documented `AVXERR-SMARTGROUP-0003` recovery procedure executed exactly as written — pruned the priority-50 rule from the policy list via Controller API, re-ran `terraform apply -var enable_k8s_smartgroup_demo=false`, K8s SmartGroups destroyed cleanly. Recovery is well-documented; no gap.
- `AVXERR-NAT-0012` benign noise on `aviatrix_gateway_snat.{frontend,backend}` surfaced as the README NOTE warns. Did not block destroy progression. README is correct.
- The prior-run `SubnetMissingRequiredDelegation` issue (recorded in QA memory from earlier walkthrough) did **not** surface this run, suggesting commit `0936813` (pod-subnet mode) addressed it.

## Resources verified clean

- 0 orphan resource groups in `csp_azure_cmchenry` matching `aks-demo-*`
- 0 stale state entries across all 5 layers (`network`, `clusters/{frontend,backend}`, `nodes/{frontend,backend}`)
- 0 stale K8s cluster registrations on Aviatrix Controller

## Method

Single QA pass driven only by README. Variable values pulled from `terraform.tfvars.example` defaults plus the project memory's `aviatrix_azure_account_name = "Azure"`. README's documented retry/recovery paths followed verbatim.

🤖 Generated with [Claude Code](https://claude.ai/code)
