### PR TITLE
feat: add obot-mcp-egress blueprints for AWS (EKS) and Azure (AKS)

### DIFF
--- a/blueprints/obot-mcp-egress-aws/.gitignore
+++ b/blueprints/obot-mcp-egress-aws/.gitignore
@@ -1,0 +1,2 @@
+*.png
+*.drawio

--- a/blueprints/obot-mcp-egress-aws/CHANGELOG.md
+++ b/blueprints/obot-mcp-egress-aws/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 2026-05-12
+
+- Initial release
+- Tested with Controller 8.2.x, Aviatrix provider 8.2.0, Obot 0.21.0, EKS 1.32
+- AWS / EKS implementation of the obot-mcp-egress pattern (companion to obot-mcp-egress-azure)
+- Known limitation: K8s label SmartGroups register as Partial on EKS; V1 CIDR /32 workaround required for per-pod deny enforcement. Tracked in docs/stp-eks-dcf-per-pod-enforcement.md.

--- a/blueprints/obot-mcp-egress-aws/README.md
+++ b/blueprints/obot-mcp-egress-aws/README.md
@@ -1,0 +1,353 @@
+# Zero-Trust MCP Egress: Obot on EKS with Aviatrix DCF
+
+Deploy [Obot](https://obot.ai) onto a new EKS cluster with network-layer zero-trust egress enforcement for all MCP server pods. An Aviatrix spoke gateway intercepts outbound traffic; MCPNetworkPolicy CRDs (reconciled by Obot's bundled aviatrix-network-policy-controller) translate per-server allowlists into live FirewallPolicy rules. No sidecars, no service mesh, no code changes required.
+
+## Architecture
+
+Architecture diagram coming soon.
+
+Traffic flow:
+
+1. Obot user creates an MCP server and configures its allowed egress domains via the Obot UI or API.
+2. Obot's bundled `aviatrix-network-policy-controller` reconciles the server's `MCPNetworkPolicy` into an Aviatrix `FirewallPolicy` CRD.
+3. The Aviatrix controller pushes the policy to the spoke gateway.
+4. The spoke gateway enforces FQDN-based egress: permitted domains pass, everything else is dropped and logged.
+
+The vpc-cni addon is configured with `EXTERNALSNAT=true`, which disables per-node SNAT and ensures the spoke gateway sees original pod IPs. SmartGroups resolve pod identities via Kubernetes label selectors; however, see the EKS Limitation section below.
+
+## Scope and Limitations
+
+- **Supported MCP runtimes:** `npx`, `uvx`, and containerized servers only. Stdio-mode servers are not covered.
+- **Protocol and port:** Enforcement applies to HTTPS egress on TCP 443 only. MCP servers requiring non-443 outbound connections are not protected by this feature.
+- **Remote MCP servers:** Out of scope. This feature applies only to Kubernetes-hosted MCP servers deployed by Obot. Remote (SSE/HTTP) MCP server connections are not subject to these policies.
+- **Domain format:** `egressDomains` entries must be bare hostnames. No protocols (`https://`), paths, ports, or IP addresses. `localhost` and `*.svc` cluster-local names are rejected by Obot at admission. Wildcard prefix notation is supported (e.g., `*.anthropic.com`).
+- **EKS known limitation: K8s label-based SmartGroups register as Partial.** The Aviatrix controller registers EKS clusters as Partial (assetd watcher subscriptions lost on controller restart; custom resource watchers return 404). K8s namespace SmartGroups cannot be used as V1 policy sources for per-pod enforcement. **Workaround:** `obot_system_pod_cidrs` and `obot_mcp_pod_cidrs` take lists of `/32` CIDRs corresponding to running pods. These drive V1 CIDR-based SmartGroups that enforce correctly. **You must update these variables after any pod restart.** See the two-step and three-step deploy procedures below. This is a platform limitation pending an upstream fix; the CIDR workaround is the current supported path.
+- **Obot-specific domains are scoped to obot-system pods via /32 CIDRs.** `var.obot_system_pod_cidrs` drives a dedicated V1 permit rule covering `api.anthropic.com`, GitHub, and `charts.obot.ai`. MCP server pods in `obot-mcp` do not match this rule and cannot reach those domains unless declared in `egressDomains`.
+- **`npx` runtime servers require `registry.npmjs.org` in `egressDomains`.** The npx shim downloads the package from npm at pod startup. A server deployed without `registry.npmjs.org` in its `egressDomains` will have its `mcp` container fail (package download blocked) while the `shim` container stays running. This is intentional: zero-trust requires explicit declaration of every outbound dependency, including package registries.
+- **Node bootstrap requires spoke gateway routes first.** `node_desired_size` defaults to `0`. EKS nodes that start before the Aviatrix spoke gateway programs the VPC route tables fail to bootstrap (CSE exit 50, unreachable API server). Scale up after first apply using the command in the `next_steps` output.
+
+## Prerequisites
+
+### Required Tools
+
+- [Aviatrix Control Plane](../../docs/prerequisites/aviatrix-controller.md) (v8.2+) with CoPilot; Controller and CoPilot public IPs required
+- [Terraform](../../docs/prerequisites/terraform.md) (v1.5+)
+- [AWS CLI](../../docs/prerequisites/aws-cli.md), authenticated (`aws configure` or equivalent)
+- [kubectl](../../docs/prerequisites/kubectl.md), configured for your cluster (EKS authentication uses the AWS CLI exec plugin)
+
+### Required Access
+
+- AWS account with permissions to create VPCs, subnets, IAM roles, EKS clusters, and managed node groups
+- Aviatrix Controller with an AWS access account (`aws_access_account`) already onboarded
+- IAM permissions: `eks:*`, `ec2:*`, `iam:CreateRole`, `iam:AttachRolePolicy`, `iam:PassRole`
+
+### Blueprint-Specific Requirements
+
+- Obot >= 0.21.0 (the MCPNetworkPolicy egress provider was introduced in this release)
+- `vpc_cidr` must not overlap any existing VPCs in the same region if you plan to peer or connect them later
+- AWS CLI must be installed and on `PATH`; kubectl uses it as the exec credential plugin for EKS
+
+## Resources Created
+
+| Resource | Description | Quantity |
+|----------|-------------|----------|
+| AWS VPC | VPC for EKS nodes and spoke gateway | 1 |
+| AWS Subnet (private) | EKS node subnets, one per AZ (/24 each) | 3 |
+| AWS Subnet (public) | Aviatrix spoke gateway subnet (/24) | 1 |
+| AWS Internet Gateway | Provides outbound path for spoke gateway | 1 |
+| AWS Route Table | Public RT for spoke gateway subnet | 1 |
+| AWS Route Table | Private RT for EKS node subnets (routes pod egress via spoke) | 1 |
+| EKS Cluster | EKS cluster with vpc-cni (EXTERNALSNAT=true) | 1 |
+| EKS Managed Node Group | EC2 managed node group (scaled to 0 on first apply) | 1 |
+| IAM Role | vpc-cni IRSA role (EXTERNALSNAT=true requires IRSA) | 1 |
+| aws_eks_addon (vpc-cni) | Manages pod networking with EXTERNALSNAT=true | 1 |
+| Aviatrix Spoke Gateway | DCF-enforced egress gateway (no transit required) | 1 |
+| Aviatrix Kubernetes Cluster | EKS onboarding for pod identity resolution (Partial on EKS) | 1 |
+| Aviatrix SmartGroup | MCP server pods (K8s label selector, Partial on EKS) | 1 |
+| Aviatrix SmartGroup | EKS VPC CIDR | 1 |
+| Aviatrix SmartGroup | obot-system pod /32 CIDRs | 1 |
+| Aviatrix SmartGroup | obot-mcp pod /32 CIDRs (conditional on var) | 1 |
+| Aviatrix WebGroup | EKS infrastructure egress domains (ECR, S3, SSM, EC2, EKS endpoints, charts.obot.ai) | 1 |
+| Aviatrix WebGroup | Obot application domains (Anthropic, GitHub) | 1 |
+| Aviatrix DCF Policy List | V1 infrastructure permits (P1: infra, P2: obot-system, P3: obot-mcp deny conditional) | 1 |
+| Aviatrix DCF Default Action | Deny-all at POST_RULES level | 1 |
+| CoPilot Association | null_resource to associate spoke with CoPilot | 1 |
+| Remote Syslog | Index 9, UDP 5000 to CoPilot private IP | 1 |
+| Kubernetes Namespace | Obot system namespace | 1 |
+| Kubernetes Namespace | Obot MCP server namespace | 1 |
+| Helm Release | Obot platform (embedded SQLite, NPC self-managed) | 1 |
+
+**Estimated Cost**: ~$0.15-0.25/hour for the spoke gateway EC2 instance plus EKS node costs (~$0.10-0.20/hour for m5.large at 2 nodes). EKS control plane: $0.10/hour.
+
+## Deployment
+
+### Step 1: Clone and Navigate
+
+```bash
+git clone https://github.com/AviatrixSystems/aviatrix-blueprints.git
+cd aviatrix-blueprints/blueprints/obot-mcp-egress-aws
+```
+
+### Step 2: Configure Variables
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars`. All fields marked `REQUIRED` must be set.
+
+### Step 3: First Apply (node_desired_size=0)
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+`node_desired_size` defaults to `0`. The EKS node group is created but no nodes start. This is intentional: nodes that start before the Aviatrix spoke gateway programs VPC routes fail to bootstrap (EKS API server unreachable, CSE exit 50). The spoke gateway provisions during this apply.
+
+Deployment takes approximately 20-30 minutes (EKS control plane + spoke gateway provisioning are the longest steps).
+
+### Step 4: Scale Up EKS Nodes
+
+After `terraform apply` completes, scale the node group:
+
+```bash
+aws eks update-nodegroup-config \
+  --cluster-name <cluster-name> \
+  --nodegroup-name system \
+  --scaling-config minSize=1,maxSize=4,desiredSize=2
+```
+
+Use the `eks_cluster_name` output for the cluster name. Wait for nodes to reach `Ready`:
+
+```bash
+kubectl get nodes -w
+```
+
+### Step 5: Enable K8s Enforcement in CoPilot
+
+These settings must be enabled manually after first deploy (controller UI only):
+
+1. **DCF Kubernetes Enforcement**: CoPilot -> DCF -> Settings -> Enforcement on Kubernetes -> Enable
+2. **Log Enrichment** (for pod-level FlowIQ identity): CoPilot -> Feature Previews -> Log Enrichment -> Enable
+
+### Step 6: Populate obot-system Pod CIDRs (Two-Step Deploy)
+
+Once Obot is running, retrieve pod IPs and re-apply to scope egress permits:
+
+```bash
+# Get obot-system pod IPs
+kubectl get pods -n obot-system -o jsonpath='{range .items[*]}{.status.podIP}{"\n"}{end}'
+```
+
+Add those IPs as `/32` CIDRs to `obot_system_pod_cidrs` in `terraform.tfvars`, then re-apply:
+
+```bash
+# Example entry in terraform.tfvars:
+# obot_system_pod_cidrs = ["10.10.1.45/32", "10.10.2.12/32"]
+
+terraform apply
+```
+
+Until this step is complete, obot-system pods reach Anthropic, GitHub, and `charts.obot.ai` via the broader infrastructure permit. After re-apply, only pods matching the `/32` SmartGroup are permitted to those domains.
+
+### Step 7: Verify Deployment
+
+```bash
+# Check Terraform outputs
+terraform output
+
+# Verify Obot is running
+kubectl get pods -n obot-system
+
+# Port-forward Obot UI (access at http://localhost:8080)
+kubectl port-forward -n obot-system svc/obot-obot 8080:80
+```
+
+## Variables
+
+| Variable | Description | Type | Default | Required |
+|----------|-------------|------|---------|----------|
+| `controller_ip` | Aviatrix Controller IP or hostname | `string` | n/a | yes |
+| `controller_username` | Controller admin username | `string` | `"admin"` | no |
+| `controller_password` | Controller admin password | `string` | n/a | yes |
+| `aws_access_account` | AWS access account name onboarded in Controller | `string` | n/a | yes |
+| `copilot_ip` | CoPilot private IP (syslog) | `string` | n/a | yes |
+| `copilot_public_ip` | CoPilot public IP (OTEL/DCF Monitor) | `string` | n/a | yes |
+| `obot_admin_password` | Obot admin password | `string` | n/a | yes |
+| `aws_region` | AWS region for all resources | `string` | `"us-east-1"` | no |
+| `vpc_cidr` | VPC CIDR block (private subnets are /24 slices; public subnet for spoke GW is /24) | `string` | `"10.10.0.0/16"` | no |
+| `cluster_version` | Kubernetes version for the EKS cluster | `string` | `"1.32"` | no |
+| `node_instance_type` | EC2 instance type for EKS managed node group | `string` | `"m5.large"` | no |
+| `node_desired_size` | Desired node count; set to 0 on first apply | `number` | `0` | no |
+| `node_max_size` | Maximum number of EKS nodes | `number` | `4` | no |
+| `obot_version` | Obot Helm chart version (>= 0.21.0) | `string` | `"0.21.0"` | no |
+| `npc_chart_version` | aviatrix-network-policy-controller chart version | `string` | `"v0.0.1"` | no |
+| `obot_namespace` | Kubernetes namespace for Obot | `string` | `"obot-system"` | no |
+| `obot_mcp_namespace` | Kubernetes namespace for MCP server pods | `string` | `"obot-mcp"` | no |
+| `obot_system_pod_cidrs` | /32 CIDRs for obot-system pods (two-step deploy) | `list(string)` | `[]` | no |
+| `obot_mcp_pod_cidrs` | /32 CIDRs for obot-mcp pods (three-step deploy; EKS CIDR workaround) | `list(string)` | `[]` | no |
+| `name_prefix` | Prefix for all created resource names | `string` | `"obot-mcp"` | no |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `eks_cluster_name` | Name of the deployed EKS cluster |
+| `spoke_gateway_name` | Name of the deployed Aviatrix spoke gateway |
+| `spoke_gateway_public_ip` | Public IP of the spoke gateway (all pod egress SNATs to this) |
+| `next_steps` | Post-deployment instructions |
+
+## Test Scenarios
+
+### Scenario 1: Verify Default Deny
+
+Confirm that a newly deployed MCP server with no `egressDomains` configured has no outbound access:
+
+```bash
+# Get the MCP server pod name (replace <server-name> as appropriate)
+kubectl get pods -n obot-mcp -l app=<server-name>
+
+# Attempt an outbound connection from inside the pod
+kubectl exec -n obot-mcp <pod-name> -- curl -s --max-time 5 https://api.openai.com
+
+# Expected result: connection times out (blocked by DCF default deny)
+```
+
+Check CoPilot -> DCF -> Monitor to see the denied flow logged.
+
+> **Note:** Per-pod enforcement requires `obot_mcp_pod_cidrs` to be populated with the pod's `/32` CIDR and a `terraform apply` to have been run. Until `obot_mcp_pod_cidrs` is set, the deny-all SmartGroup is not created and enforcement is not active for obot-mcp pods. This is the three-step deploy sequence for the EKS CIDR workaround.
+
+### Scenario 2: Configure egressDomains and Verify Allow
+
+`MCPNetworkPolicy` is an internal Obot concept; there is no user-facing Kubernetes CRD to apply.
+Configure `egressDomains` via the Obot API or UI. Obot creates the MCPNetworkPolicy internally;
+the `aviatrix-network-policy-controller` reconciles it into a `FirewallPolicy` CRD.
+
+```bash
+# Update the MCP server to allow specific egress domains (replace <server-id>)
+curl -X PUT http://localhost:8080/api/mcp-servers/<server-id> \
+  -H "Content-Type: application/json" \
+  -d '{
+    "manifest": {
+      "name": "my-server",
+      "runtime": "npx",
+      "npxConfig": {
+        "package": "@modelcontextprotocol/server-github",
+        "egressDomains": ["api.openai.com"]
+      }
+    }
+  }'
+
+# Verify the FirewallPolicy CRD was created or updated
+kubectl get firewallpolicies -n obot-mcp
+
+# Retry the outbound connection (no sleep needed; policy exists before pod starts)
+kubectl exec -n obot-mcp <pod-name> -- curl -s --max-time 10 https://api.openai.com
+
+# Expected result: connection succeeds
+```
+
+> **Note:** The `aviatrix-network-policy-controller` creates the FirewallPolicy at server-definition
+> time, not at launch time. By the time the pod starts, the policy is already enforced.
+> See `k8s-apps/example-mcpnetworkpolicy.yaml` for the shape of the generated `FirewallPolicy`.
+
+### Scenario 3: Verify Unlisted Domain is Blocked
+
+```bash
+# This domain is not in the egressDomains allowlist
+kubectl exec -n obot-mcp <pod-name> -- curl -s --max-time 5 https://example.com
+
+# Expected result: connection times out (blocked by DCF, not in approved domains)
+```
+
+## Cleanup
+
+```bash
+terraform destroy
+```
+
+If destroy hangs, delete LoadBalancer services first:
+
+```bash
+kubectl delete svc -n obot-system --all
+```
+
+Then retry `terraform destroy`. EKS node group scale-down can take several minutes; the destroy will wait.
+
+## Troubleshooting
+
+### EKS nodes fail to bootstrap (CSE exit 50)
+
+This happens when nodes start before the spoke gateway programs VPC routes. Terminate the affected node instances; EKS will replace them once routes are in place:
+
+```bash
+aws ec2 terminate-instances --instance-ids <instance-id>
+```
+
+If nodes were started before the first `terraform apply` completed, re-image via the AWS console or wait for the managed node group to replace them automatically.
+
+### Spoke gateway creation fails or times out
+
+Verify the public subnet has an Internet Gateway route:
+
+```bash
+aws ec2 describe-route-tables \
+  --filters "Name=tag:Name,Values=<name_prefix>-rt-public" \
+  --query 'RouteTables[*].Routes'
+```
+
+A `0.0.0.0/0` route with `GatewayId` pointing to an IGW must be present.
+
+### DCF Monitor is empty but FlowIQ works
+
+The spoke gateway OTEL exporter is not reaching CoPilot. This happens when `copilot_public_ip` is wrong or missing. Verify:
+
+```bash
+terraform output spoke_gateway_public_ip
+# This IP must be permitted in the CoPilot security group for TCP 31284 inbound.
+```
+
+### egressDomains configured but traffic still blocked
+
+1. Verify DCF Kubernetes Enforcement is enabled in CoPilot -> DCF -> Settings.
+2. Check `obot_mcp_pod_cidrs` is populated with current pod IPs and `terraform apply` has been run.
+3. Confirm a `FirewallPolicy` exists for the server: `kubectl get firewallpolicies -n obot-mcp`
+4. Verify Log Enrichment is enabled: CoPilot -> Feature Previews -> Log Enrichment.
+5. Re-check pod IPs have not changed since last apply (pod restarts change IPs; re-apply required).
+
+### K8s label SmartGroups show "Partial" status
+
+This is expected on EKS. The controller cannot maintain assetd watcher subscriptions for EKS custom resources. The CIDR-based SmartGroups (`obot_system_pod_cidrs`, `obot_mcp_pod_cidrs`) are the active enforcement path. "Partial" status on the label-based SmartGroup does not break enforcement; the CIDR SmartGroups are what the V1 policy rules use.
+
+### kubectl cannot authenticate to the cluster
+
+EKS uses the AWS CLI as a credential exec plugin. Ensure:
+
+1. AWS CLI is installed and on `PATH`.
+2. The IAM identity used by the CLI has `eks:DescribeCluster` permission.
+3. Run `aws eks update-kubeconfig --name <cluster-name> --region <region>` to refresh the kubeconfig.
+
+## Tested With
+
+| Component | Version |
+|-----------|---------|
+| Aviatrix Controller | 8.2.x |
+| Aviatrix Terraform Provider | 8.2.0 |
+| Terraform | 1.9.x |
+| AWS Provider | 5.x |
+| EKS | 1.32 |
+| Obot | 0.21.0 |
+
+## Built With
+
+This blueprint was developed by [Nick Davitashvili](https://github.com/nickda) (Aviatrix) in collaboration with [Grant Linville](https://github.com/g-linville) (Obot AI), who built the MCPNetworkPolicy egress provider in Obot.
+
+## Contributing
+
+See the [Contributing Guide](../../CONTRIBUTING.md) for information on how to contribute to this blueprint.
+
+## License
+
+Apache 2.0. See [LICENSE](../../LICENSE)

--- a/blueprints/obot-mcp-egress-aws/README.md
+++ b/blueprints/obot-mcp-egress-aws/README.md
@@ -4,6 +4,8 @@ Deploy [Obot](https://obot.ai) onto a new EKS cluster with network-layer zero-tr
 
 ## Architecture
 
+![Architecture Diagram](architecture.svg)
+
 Architecture diagram coming soon.
 
 Traffic flow:
@@ -34,6 +36,7 @@ The vpc-cni addon is configured with `EXTERNALSNAT=true`, which disables per-nod
 - [Terraform](../../docs/prerequisites/terraform.md) (v1.5+)
 - [AWS CLI](../../docs/prerequisites/aws-cli.md), authenticated (`aws configure` or equivalent)
 - [kubectl](../../docs/prerequisites/kubectl.md), configured for your cluster (EKS authentication uses the AWS CLI exec plugin)
+- **Python 3** — required by `local-exec` provisioners for JSON parsing (`curl | python3 -c`)
 
 ### Required Access
 
@@ -173,7 +176,7 @@ kubectl port-forward -n obot-system svc/obot-obot 8080:80
 | `controller_username` | Controller admin username | `string` | `"admin"` | no |
 | `controller_password` | Controller admin password | `string` | n/a | yes |
 | `aws_access_account` | AWS access account name onboarded in Controller | `string` | n/a | yes |
-| `copilot_ip` | CoPilot private IP (syslog) | `string` | n/a | yes |
+| `copilot_private_ip` | CoPilot private IP (syslog) | `string` | n/a | yes |
 | `copilot_public_ip` | CoPilot public IP (OTEL/DCF Monitor) | `string` | n/a | yes |
 | `obot_admin_password` | Obot admin password | `string` | n/a | yes |
 | `aws_region` | AWS region for all resources | `string` | `"us-east-1"` | no |
@@ -189,6 +192,7 @@ kubectl port-forward -n obot-system svc/obot-obot 8080:80
 | `obot_system_pod_cidrs` | /32 CIDRs for obot-system pods (two-step deploy) | `list(string)` | `[]` | no |
 | `obot_mcp_pod_cidrs` | /32 CIDRs for obot-mcp pods (three-step deploy; EKS CIDR workaround) | `list(string)` | `[]` | no |
 | `name_prefix` | Prefix for all created resource names | `string` | `"obot-mcp"` | no |
+| `copilot_syslog_index` | Remote syslog index slot on the Controller (0-9); must be free | `number` | `9` | no |
 
 ## Outputs
 

--- a/blueprints/obot-mcp-egress-aws/architecture.svg
+++ b/blueprints/obot-mcp-egress-aws/architecture.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400">
+  <rect width="800" height="400" fill="#f8f9fa" rx="8"/>
+  <text x="400" y="180" font-family="sans-serif" font-size="24" fill="#6c757d" text-anchor="middle">Architecture diagram coming soon</text>
+  <text x="400" y="220" font-family="sans-serif" font-size="14" fill="#adb5bd" text-anchor="middle">obot-mcp-egress-aws</text>
+</svg>

--- a/blueprints/obot-mcp-egress-aws/dcf.tf
+++ b/blueprints/obot-mcp-egress-aws/dcf.tf
@@ -1,0 +1,250 @@
+# =============================================================================
+# Distributed Cloud Firewall (DCF) Configuration
+# =============================================================================
+#
+# KNOWN LIMITATION — EKS per-pod K8s label enforcement:
+# EKS clusters register as "Partial" (controller cannot list custom resources).
+# K8s label-based SmartGroups never resolve pod IPs, so FirewallPolicy CRDs
+# created by NPC are not enforced at the spoke gateway.
+# Workaround: V1 CIDR /32 SmartGroups (var.obot_system_pod_cidrs,
+# var.obot_mcp_pod_cidrs) provide enforcement until Aviatrix resolves the
+# EKS kubeconfig exec-plugin or assetd watcher re-subscription issue.
+# See docs/stp-eks-dcf-per-pod-enforcement.md for full root cause.
+# =============================================================================
+#
+# SINGLETON RESOURCES: aviatrix_distributed_firewalling_policy_list and
+# aviatrix_distributed_firewalling_default_action_rule are controller-level
+# singletons. If applying multiple blueprints against the same Aviatrix
+# controller, only one blueprint should own these resources; the second apply
+# will overwrite the first's policy rules. Merge rules into a shared module or
+# use separate controllers per blueprint deployment.
+
+resource "aviatrix_kubernetes_cluster" "obot" {
+  cluster_id          = module.eks.cluster_arn
+  use_csp_credentials = true
+}
+
+resource "time_sleep" "cai_sync" {
+  depends_on = [
+    module.spoke,
+    aviatrix_kubernetes_cluster.obot,
+  ]
+  create_duration = "30s"
+}
+
+resource "aviatrix_distributed_firewalling_config" "enabled" {
+  enable_distributed_firewalling = true
+}
+
+# Re-enable 5 DCF feature flags (reset on controller reboot).
+resource "null_resource" "k8s_dcf_features" {
+  triggers = { controller_ip = var.controller_ip }
+
+  provisioner "local-exec" {
+    command     = <<-EOT
+      set -euo pipefail
+      CID=$(curl -sk "https://$${CONTROLLER}/v2/api" \
+        -d "action=login&username=$${USERNAME}&password=$${PASSWORD}" \
+        | python3 -c "import sys,json; print(json.load(sys.stdin).get('CID',''))")
+      if [ -z "$${CID}" ]; then echo "ERROR: controller login failed" >&2; exit 1; fi
+      for feature in k8s k8s_dcf_policies dcf_multi_policies k8s_discovery log_enrichment; do
+        curl -sk "https://$${CONTROLLER}/v2/api" \
+          --data-urlencode "action=enable_controller_feature" \
+          --data-urlencode "CID=$${CID}" \
+          --data-urlencode "feature=$${feature}" > /dev/null &
+      done
+      wait
+      echo "All 5 DCF feature flags enabled"
+    EOT
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      CONTROLLER = var.controller_ip
+      USERNAME   = var.controller_username
+      PASSWORD   = var.controller_password
+    }
+  }
+
+  depends_on = [aviatrix_distributed_firewalling_config.enabled]
+}
+
+# SmartGroup: obot-mcp namespace (K8s label selector — does not resolve on EKS).
+# Retained for when the EKS enforcement gap is fixed upstream.
+resource "aviatrix_smart_group" "mcp_servers" {
+  name = "${local.name}-mcp-servers"
+  selector {
+    match_expressions {
+      type          = "k8s"
+      k8s_namespace = var.obot_mcp_namespace
+    }
+  }
+  depends_on = [time_sleep.cai_sync]
+}
+
+# SmartGroup: EKS VPC CIDR (source for infra permit rules)
+resource "aviatrix_smart_group" "eks_vpc" {
+  name = "${local.name}-eks-vpc"
+  selector {
+    match_expressions {
+      cidr = var.vpc_cidr
+    }
+  }
+  depends_on = [time_sleep.cai_sync]
+}
+
+# SmartGroup: obot-system pod /32 CIDRs (V1 CIDR workaround).
+# Empty match_expressions on first apply produces a valid SmartGroup that
+# matches nothing until re-applied with pod IPs after Obot is running.
+resource "aviatrix_smart_group" "obot_system_pods" {
+  name = "${local.name}-obot-system"
+  selector {
+    dynamic "match_expressions" {
+      for_each = var.obot_system_pod_cidrs
+      content {
+        cidr = match_expressions.value
+      }
+    }
+  }
+  depends_on = [time_sleep.cai_sync]
+}
+
+# SmartGroup: obot-mcp pod /32 CIDRs (V1 CIDR workaround for DENY enforcement).
+resource "aviatrix_smart_group" "mcp_pod_ips" {
+  count = length(var.obot_mcp_pod_cidrs) > 0 ? 1 : 0
+  name  = "${local.name}-obot-mcp-pod-ips"
+  selector {
+    dynamic "match_expressions" {
+      for_each = var.obot_mcp_pod_cidrs
+      content {
+        cidr = match_expressions.value
+      }
+    }
+  }
+  depends_on = [time_sleep.cai_sync]
+}
+
+# WebGroup: EKS infrastructure egress (ECR, S3, SSM, EC2, EKS endpoints)
+resource "aviatrix_web_group" "eks_infra_egress" {
+  name = "${local.name}-eks-infra"
+  selector {
+    match_expressions { snifilter = "*.eks.amazonaws.com" }
+    match_expressions { snifilter = "*.ecr.aws" }
+    match_expressions { snifilter = "*.dkr.ecr.*.amazonaws.com" }
+    match_expressions { snifilter = "*.s3.*.amazonaws.com" }
+    match_expressions { snifilter = "*.s3.amazonaws.com" }
+    match_expressions { snifilter = "ec2.*.amazonaws.com" }
+    match_expressions { snifilter = "ssm.*.amazonaws.com" }
+    match_expressions { snifilter = "sts.amazonaws.com" }
+    match_expressions { snifilter = "sts.*.amazonaws.com" }
+    match_expressions { snifilter = "ghcr.io" }
+    match_expressions { snifilter = "*.ghcr.io" }
+    match_expressions { snifilter = "pkg-containers.githubusercontent.com" }
+    match_expressions { snifilter = "charts.obot.ai" } # NPC chart pulled by Obot PostStart hook
+  }
+}
+
+# WebGroup: Obot application domains (scoped to obot-system pods only)
+resource "aviatrix_web_group" "obot_pod_egress" {
+  name = "${local.name}-obot-egress"
+  selector {
+    match_expressions { snifilter = "charts.obot.ai" }
+    match_expressions { snifilter = "api.anthropic.com" }
+    match_expressions { snifilter = "github.com" }
+    match_expressions { snifilter = "*.github.com" }
+    match_expressions { snifilter = "raw.githubusercontent.com" }
+    match_expressions { snifilter = "*.githubusercontent.com" }
+  }
+}
+
+# V1 policy list: EKS infra + obot-system permits evaluated before K8S block.
+resource "aviatrix_distributed_firewalling_policy_list" "infra" {
+  # P1: EKS infrastructure egress (ECR, S3, SSM, EC2, EKS endpoints)
+  policies {
+    name     = "eks-infra-egress"
+    action   = "PERMIT"
+    priority = 1
+    protocol = "TCP"
+    logging  = true
+    watch    = false
+    port_ranges { lo = 443 }
+    src_smart_groups = [aviatrix_smart_group.eks_vpc.uuid]
+    dst_smart_groups = ["def000ad-0000-0000-0000-000000000001"] # Aviatrix anywhere group (0.0.0.0/0)
+    web_groups       = [aviatrix_web_group.eks_infra_egress.uuid]
+  }
+
+  # P2: Obot pod egress — scoped to obot-system /32 CIDRs.
+  # When obot_system_pod_cidrs is empty (first apply), this rule has an
+  # empty-selector SmartGroup as source and will not match any traffic.
+  policies {
+    name     = "obot-pod-egress"
+    action   = "PERMIT"
+    priority = 2
+    protocol = "TCP"
+    logging  = true
+    watch    = false
+    port_ranges { lo = 443 }
+    src_smart_groups = [aviatrix_smart_group.obot_system_pods.uuid]
+    dst_smart_groups = ["def000ad-0000-0000-0000-000000000001"] # Aviatrix anywhere group (0.0.0.0/0)
+    web_groups       = [aviatrix_web_group.obot_pod_egress.uuid]
+  }
+
+  # P3: Deny all external egress for obot-mcp pods (when CIDRs provided).
+  dynamic "policies" {
+    for_each = length(var.obot_mcp_pod_cidrs) > 0 ? [1] : []
+    content {
+      name             = "eks-obot-mcp-deny-external"
+      action           = "DENY"
+      priority         = 3
+      protocol         = "TCP"
+      logging          = true
+      watch            = false
+      src_smart_groups = [aviatrix_smart_group.mcp_pod_ips[0].uuid]
+      dst_smart_groups = ["def000ad-0000-0000-0000-000000000001"] # Aviatrix anywhere group (0.0.0.0/0)
+    }
+  }
+
+  depends_on = [aviatrix_distributed_firewalling_config.enabled]
+}
+
+# Default deny-all at POST_RULES level.
+resource "aviatrix_distributed_firewalling_default_action_rule" "deny_all" {
+  action     = "DENY"
+  logging    = true
+  depends_on = [aviatrix_distributed_firewalling_policy_list.infra]
+}
+
+# CoPilot association via direct API call (provider resource lacks public_ip field).
+resource "null_resource" "copilot_association" {
+  triggers = {
+    private_ip = var.copilot_ip
+    public_ip  = var.copilot_public_ip
+  }
+
+  provisioner "local-exec" {
+    command     = <<-EOT
+      set -euo pipefail
+      CID=$(curl -sk "https://$${CONTROLLER}/v2/api" \
+        -d "action=login&username=$${USERNAME}&password=$${PASSWORD}" \
+        | python3 -c "import sys,json; print(json.load(sys.stdin).get('CID',''))")
+      if [ -z "$${CID}" ]; then echo "ERROR: controller login failed" >&2; exit 1; fi
+      curl -sk "https://$${CONTROLLER}/v2/api" \
+        -d "action=enable_copilot_association&CID=$${CID}&copilot_ip=$${PRIVATE_IP}&public_ip=$${PUBLIC_IP}"
+    EOT
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      CONTROLLER = var.controller_ip
+      USERNAME   = var.controller_username
+      PASSWORD   = var.controller_password
+      PRIVATE_IP = var.copilot_ip
+      PUBLIC_IP  = var.copilot_public_ip
+    }
+  }
+}
+
+# Index 9 must be free on the controller. Change if already in use.
+resource "aviatrix_remote_syslog" "copilot" {
+  index    = 9
+  name     = "${local.name}-copilot"
+  server   = var.copilot_ip
+  port     = 5000
+  protocol = "UDP"
+}

--- a/blueprints/obot-mcp-egress-aws/dcf.tf
+++ b/blueprints/obot-mcp-egress-aws/dcf.tf
@@ -215,7 +215,7 @@ resource "aviatrix_distributed_firewalling_default_action_rule" "deny_all" {
 # CoPilot association via direct API call (provider resource lacks public_ip field).
 resource "null_resource" "copilot_association" {
   triggers = {
-    private_ip = var.copilot_ip
+    private_ip = var.copilot_private_ip
     public_ip  = var.copilot_public_ip
   }
 
@@ -234,17 +234,16 @@ resource "null_resource" "copilot_association" {
       CONTROLLER = var.controller_ip
       USERNAME   = var.controller_username
       PASSWORD   = var.controller_password
-      PRIVATE_IP = var.copilot_ip
+      PRIVATE_IP = var.copilot_private_ip
       PUBLIC_IP  = var.copilot_public_ip
     }
   }
 }
 
-# Index 9 must be free on the controller. Change if already in use.
 resource "aviatrix_remote_syslog" "copilot" {
-  index    = 9
+  index    = var.copilot_syslog_index
   name     = "${local.name}-copilot"
-  server   = var.copilot_ip
+  server   = var.copilot_private_ip
   port     = 5000
   protocol = "UDP"
 }

--- a/blueprints/obot-mcp-egress-aws/eks.tf
+++ b/blueprints/obot-mcp-egress-aws/eks.tf
@@ -1,0 +1,63 @@
+# =============================================================================
+# EKS Cluster
+# =============================================================================
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.0"
+
+  cluster_name    = "${local.name}-cluster"
+  cluster_version = var.cluster_version
+
+  cluster_endpoint_public_access  = true
+  cluster_endpoint_private_access = true
+
+  enable_cluster_creator_admin_permissions = true
+
+  cluster_addons = {
+    coredns                = { most_recent = true }
+    kube-proxy             = { most_recent = true }
+    eks-pod-identity-agent = { most_recent = true }
+  }
+
+  vpc_id                   = module.vpc.vpc_id
+  subnet_ids               = module.vpc.private_subnets
+  control_plane_subnet_ids = module.vpc.private_subnets
+
+  eks_managed_node_groups = {
+    system = {
+      instance_types = [var.node_instance_type]
+      min_size       = 0
+      max_size       = var.node_max_size
+      # Start at 0; scale to desired after Aviatrix spoke GW programs routes.
+      # Nodes started before routes are in place may fail to reach ECR/S3 endpoints.
+      desired_size = var.node_desired_size
+      labels       = { role = "system" }
+    }
+  }
+
+  node_security_group_tags = {
+    "karpenter.sh/discovery" = "${local.name}-cluster"
+  }
+
+  tags = local.tags
+}
+
+# vpc-cni addon: EXTERNALSNAT preserves pod source IPs at the Aviatrix gateway.
+# Without this, vpc-cni SNATs pod IPs to node IPs before traffic reaches the
+# spoke gateway. SmartGroups resolve to pod IPs, so node IPs would never match
+# FirewallPolicy CRD rules.
+# AKS equivalent: ip-masq-agent nonMasqueradeCIDRs: 0.0.0.0/0
+resource "aws_eks_addon" "vpc_cni" {
+  cluster_name             = module.eks.cluster_name
+  addon_name               = "vpc-cni"
+  service_account_role_arn = aws_iam_role.vpc_cni_irsa.arn
+
+  configuration_values = jsonencode({
+    env = {
+      AWS_VPC_K8S_CNI_EXTERNALSNAT = "true"
+    }
+  })
+
+  depends_on = [module.eks]
+}

--- a/blueprints/obot-mcp-egress-aws/iam.tf
+++ b/blueprints/obot-mcp-egress-aws/iam.tf
@@ -1,0 +1,29 @@
+# =============================================================================
+# IAM
+# =============================================================================
+
+# IRSA for vpc-cni addon (manages ENIs for pod IPs)
+data "aws_iam_policy_document" "vpc_cni_assume" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [module.eks.oidc_provider_arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:kube-system:aws-node"]
+    }
+  }
+}
+
+resource "aws_iam_role" "vpc_cni_irsa" {
+  name               = "${local.name}-vpc-cni-irsa"
+  assume_role_policy = data.aws_iam_policy_document.vpc_cni_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "vpc_cni_irsa" {
+  role       = aws_iam_role.vpc_cni_irsa.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}

--- a/blueprints/obot-mcp-egress-aws/k8s-apps/example-mcpnetworkpolicy.yaml
+++ b/blueprints/obot-mcp-egress-aws/k8s-apps/example-mcpnetworkpolicy.yaml
@@ -1,0 +1,87 @@
+# Example: What Obot generates internally
+#
+# MCPNetworkPolicy is NOT a user-facing Kubernetes CRD.
+# Users configure egressDomains via the Obot API or UI.
+# Obot then creates MCPNetworkPolicy objects internally,
+# and the aviatrix-network-policy-controller reconciles
+# those into Aviatrix FirewallPolicy CRDs (networking.aviatrix.com/v1alpha1).
+#
+# DO NOT kubectl apply this file. There is no MCPNetworkPolicy CRD to target.
+#
+# EKS NOTE: FirewallPolicy CRDs are created by NPC, but K8s label SmartGroups
+# register as Partial on EKS (assetd watcher limitation). The CRD-based
+# per-pod enforcement is not fully applied at the spoke gateway on EKS.
+# The V1 CIDR /32 workaround (obot_mcp_pod_cidrs variable) provides deny-all
+# enforcement via the V1 policy list instead.
+#
+# To inspect the generated FirewallPolicies in your cluster:
+#   kubectl --kubeconfig ~/.kube/<cluster-name>.yaml get firewallpolicies -n obot-mcp
+#   kubectl --kubeconfig ~/.kube/<cluster-name>.yaml describe firewallpolicy <name> -n obot-mcp
+#
+# To configure egressDomains for an MCP server, use the Obot API:
+#
+#   # Create a server with specific egress domains:
+#   curl -X POST http://localhost:8080/api/mcp-servers \
+#     -H "Content-Type: application/json" \
+#     -d '{
+#       "manifest": {
+#         "name": "my-server",
+#         "runtime": "npx",
+#         "npxConfig": {
+#           "package": "@modelcontextprotocol/server-github",
+#           "egressDomains": ["api.github.com", "*.githubusercontent.com"]
+#         }
+#       }
+#     }'
+#
+# Domain rules:
+#   - Bare hostname or leading-wildcard only: "api.example.com" or "*.example.com"
+#   - No protocols, paths, ports, or IPs
+#   - "localhost" and "*.svc" are rejected
+#   - Bare "*" is rejected (not a valid wildcard)
+#   - Empty egressDomains with MCPDEFAULT_DENY_ALL_EGRESS=true = deny all
+#     (no permit rule is generated; server has zero outbound access)
+#
+# ---- Diagnostic reference: shape of a generated FirewallPolicy ----
+#
+# When a server is configured with egressDomains: ["api.openai.com"],
+# Obot generates a FirewallPolicy like this:
+#
+# apiVersion: networking.aviatrix.com/v1alpha1
+# kind: FirewallPolicy
+# metadata:
+#   name: obot-<mnp-id>-fw
+#   namespace: obot-mcp
+#   labels:
+#     obot.ai/mcp-server-name: <server-id>
+# spec:
+#   rules:
+#   - action: permit
+#     name: allow-approved-egress
+#     port: 443
+#     protocol: tcp
+#     selector:
+#       matchLabels:
+#         app: <server-id>
+#     webGroups:
+#     - name: obot-<server-id>-approved-domains
+#   - action: deny
+#     name: deny-all-external
+#     protocol: any
+#     selector:
+#       matchLabels:
+#         app: <server-id>
+#   smartGroups:
+#   - name: obot-<server-id>-pods
+#     selectors:
+#     - k8sNamespace: obot-mcp
+#       tags:
+#         app: <server-id>
+#       type: k8s
+#   - name: any-destination
+#     selectors:
+#     - cidr: 0.0.0.0/0
+#   webGroups:
+#   - domains:
+#     - api.openai.com
+#     name: obot-<server-id>-approved-domains

--- a/blueprints/obot-mcp-egress-aws/k8s.tf
+++ b/blueprints/obot-mcp-egress-aws/k8s.tf
@@ -1,0 +1,28 @@
+# =============================================================================
+# Kubernetes Namespaces
+# =============================================================================
+
+# obot-system: owns Obot pods and aviatrix-network-policy-controller
+resource "kubernetes_namespace_v1" "obot_system" {
+  metadata {
+    name   = var.obot_namespace
+    labels = { app = "obot", role = "platform" }
+  }
+  depends_on = [module.eks]
+}
+
+# obot-mcp: owns all Obot-managed MCP server pods.
+# Helm adoption labels set here before helm install to prevent namespace conflict.
+resource "kubernetes_namespace_v1" "obot_mcp" {
+  metadata {
+    name = var.obot_mcp_namespace
+    labels = {
+      "app.kubernetes.io/managed-by" = "Helm"
+    }
+    annotations = {
+      "meta.helm.sh/release-name"      = "obot"
+      "meta.helm.sh/release-namespace" = var.obot_namespace
+    }
+  }
+  depends_on = [module.eks]
+}

--- a/blueprints/obot-mcp-egress-aws/main.tf
+++ b/blueprints/obot-mcp-egress-aws/main.tf
@@ -1,0 +1,36 @@
+# =============================================================================
+# Providers
+# =============================================================================
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "aviatrix" {
+  controller_ip           = var.controller_ip
+  username                = var.controller_username
+  password                = var.controller_password
+  skip_version_validation = true
+}
+
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+  }
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+    exec = {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+    }
+  }
+}

--- a/blueprints/obot-mcp-egress-aws/obot.tf
+++ b/blueprints/obot-mcp-egress-aws/obot.tf
@@ -1,0 +1,72 @@
+# =============================================================================
+# Obot Platform Deployment
+# =============================================================================
+#
+# Obot uses embedded SQLite by default (dev.useEmbeddedDb: true).
+# For production, replace with an external PostgreSQL database by setting
+# OBOT_SERVER_DSN in the config block and setting dev.useEmbeddedDb: false.
+# =============================================================================
+
+resource "helm_release" "obot" {
+  name             = "obot"
+  repository       = "https://charts.obot.ai"
+  chart            = "obot"
+  version          = var.obot_version
+  namespace        = var.obot_namespace
+  create_namespace = false # created in k8s.tf
+
+  values = [
+    yamlencode({
+      image = {
+        repository = "ghcr.io/obot-platform/obot"
+        tag        = "v${var.obot_version}"
+        pullPolicy = "IfNotPresent"
+      }
+      # Embedded SQLite — suitable for evaluation and single-node deployments.
+      # Replace with external PostgreSQL for production (set OBOT_SERVER_DSN).
+      dev = {
+        useEmbeddedDb = true
+      }
+      updateStrategy = "Recreate"
+      service = {
+        type = "ClusterIP"
+        port = 80
+      }
+      ingress = {
+        enabled = false
+      }
+      mcpNamespace = {
+        name = var.obot_mcp_namespace
+        networkPolicy = {
+          enabled = false
+        }
+        podSecurity = {
+          enabled = false
+        }
+      }
+      config = {
+        OBOT_SERVER_ENABLE_AUTHENTICATION                    = false
+        OBOT_SERVER_ENABLE_REGISTRY_AUTH                     = false
+        OBOT_SERVER_MCPRUNTIME_BACKEND                       = "kubernetes"
+        OBOT_SERVER_MCPBASE_IMAGE                            = "ghcr.io/obot-platform/obot"
+        OBOT_SERVER_NANOBOT_INTEGRATION                      = true
+        OBOT_SERVER_DISABLE_LEGACY_CHAT                      = true
+        NAH_THREADINESS                                      = "10000"
+        OBOT_SERVER_ADMIN_PASSWORD                           = var.obot_admin_password
+        OBOT_SERVER_MCPNETWORK_POLICY_PROVIDER_CHART_REPO    = "https://charts.obot.ai"
+        OBOT_SERVER_MCPNETWORK_POLICY_PROVIDER_CHART_NAME    = "aviatrix-network-policy-controller"
+        OBOT_SERVER_MCPNETWORK_POLICY_PROVIDER_CHART_VERSION = var.npc_chart_version
+        OBOT_SERVER_MCPDEFAULT_DENY_ALL_EGRESS               = "true"
+      }
+    })
+  ]
+
+  depends_on = [
+    kubernetes_namespace_v1.obot_system,
+    kubernetes_namespace_v1.obot_mcp,
+    null_resource.k8s_dcf_features,
+    module.spoke,
+    aviatrix_distributed_firewalling_policy_list.infra,
+    aviatrix_distributed_firewalling_default_action_rule.deny_all,
+  ]
+}

--- a/blueprints/obot-mcp-egress-aws/outputs.tf
+++ b/blueprints/obot-mcp-egress-aws/outputs.tf
@@ -1,0 +1,43 @@
+# =============================================================================
+# Outputs
+# =============================================================================
+
+output "eks_cluster_name" {
+  description = "Name of the deployed EKS cluster"
+  value       = module.eks.cluster_name
+}
+
+output "spoke_gateway_name" {
+  description = "Name of the deployed Aviatrix spoke gateway"
+  value       = module.spoke.spoke_gateway.gw_name
+}
+
+output "spoke_gateway_public_ip" {
+  description = "Public IP of the Aviatrix spoke gateway. All MCP server pod egress SNATs to this IP."
+  value       = module.spoke.spoke_gateway.eip
+}
+
+output "next_steps" {
+  description = "Post-deployment actions"
+  value       = <<-EOT
+    Deployment complete. Next steps:
+
+    1. Scale EKS nodes to desired count (was 0 on first apply to wait for routes):
+       aws eks update-nodegroup-config --cluster-name ${module.eks.cluster_name} \
+         --nodegroup-name system --scaling-config minSize=1,maxSize=4,desiredSize=2
+
+    2. Access Obot UI:
+       kubectl port-forward -n ${var.obot_namespace} svc/obot-obot 8080:80
+
+    3. Enable DCF enforcement on Kubernetes (required once after deploy):
+       CoPilot -> DCF -> Settings -> Enforcement on Kubernetes -> Enable
+
+    4. Update obot-system pod CIDRs for scoped egress (re-apply required):
+       kubectl get pods -n ${var.obot_namespace} -o jsonpath='{range .items[*]}{.status.podIP}{"\n"}{end}'
+       # Add those IPs as /32 values to var.obot_system_pod_cidrs, then terraform apply
+
+    5. After deploying MCP servers, update obot-mcp pod CIDRs for DENY enforcement:
+       kubectl get pods -n ${var.obot_mcp_namespace} -o wide
+       # Add pod IPs as /32 values to var.obot_mcp_pod_cidrs, then terraform apply
+  EOT
+}

--- a/blueprints/obot-mcp-egress-aws/spoke.tf
+++ b/blueprints/obot-mcp-egress-aws/spoke.tf
@@ -1,0 +1,22 @@
+# =============================================================================
+# Aviatrix Spoke Gateway
+# =============================================================================
+
+module "spoke" {
+  source  = "terraform-aviatrix-modules/mc-spoke/aviatrix"
+  version = "~> 8.2.0"
+
+  cloud   = "AWS"
+  name    = "${local.name}-spoke"
+  region  = var.aws_region
+  account = var.aws_access_account
+
+  use_existing_vpc = true
+  vpc_id           = module.vpc.vpc_id
+  cidr             = var.vpc_cidr
+  gw_subnet        = module.vpc.public_subnets_cidr_blocks[0]
+
+  ha_gw          = false
+  single_ip_snat = true
+  attached       = false
+}

--- a/blueprints/obot-mcp-egress-aws/terraform.tfvars.example
+++ b/blueprints/obot-mcp-egress-aws/terraform.tfvars.example
@@ -21,7 +21,7 @@ controller_ip       = "20.1.2.3"      # REQUIRED
 controller_username = "admin"
 controller_password = "CHANGE_ME"     # REQUIRED; prefer TF_VAR_controller_password env var
 aws_access_account  = "aws-account"   # REQUIRED: Aviatrix access account name for AWS
-copilot_ip          = "10.200.0.5"    # REQUIRED
+copilot_private_ip  = "10.200.0.5"    # REQUIRED
 copilot_public_ip   = "20.1.2.4"      # REQUIRED
 
 # Obot

--- a/blueprints/obot-mcp-egress-aws/terraform.tfvars.example
+++ b/blueprints/obot-mcp-egress-aws/terraform.tfvars.example
@@ -1,0 +1,42 @@
+# =============================================================================
+# Example terraform.tfvars for blueprint: obot-mcp-egress-aws
+# Copy to terraform.tfvars and fill in your values.
+# =============================================================================
+
+# AWS
+aws_region = "us-east-1"
+vpc_cidr   = "10.10.0.0/16"
+
+# EKS
+cluster_version    = "1.32"
+node_instance_type = "m5.large"
+node_desired_size  = 0 # Start at 0; run outputs.next_steps step 1 after first apply to scale to 2
+node_max_size      = 4
+
+# Aviatrix Controller (pre-existing)
+# REQUIRED: controller_ip, controller_password, aws_access_account
+# Tip: set controller_password via env var to avoid storing on disk:
+#   export TF_VAR_controller_password="your-password"
+controller_ip       = "20.1.2.3"      # REQUIRED
+controller_username = "admin"
+controller_password = "CHANGE_ME"     # REQUIRED; prefer TF_VAR_controller_password env var
+aws_access_account  = "aws-account"   # REQUIRED: Aviatrix access account name for AWS
+copilot_ip          = "10.200.0.5"    # REQUIRED
+copilot_public_ip   = "20.1.2.4"      # REQUIRED
+
+# Obot
+obot_version        = "0.21.0"
+npc_chart_version   = "v0.0.1"
+obot_admin_password = "CHANGE_ME"     # REQUIRED; prefer TF_VAR_obot_admin_password env var
+
+# TWO-STEP: Leave empty on first apply. After Obot is running, populate with
+# pod IPs from: kubectl get pods -n obot-system -o jsonpath='{range .items[*]}{.status.podIP}{"\n"}{end}'
+obot_system_pod_cidrs = []
+
+# THREE-STEP: Leave empty until MCP servers are deployed. Populate after:
+#   kubectl get pods -n obot-mcp -o wide
+# Then re-apply. This activates the DCF DENY rule for MCP server pods.
+obot_mcp_pod_cidrs = []
+
+# Naming
+name_prefix = "obot-mcp"

--- a/blueprints/obot-mcp-egress-aws/variables.tf
+++ b/blueprints/obot-mcp-egress-aws/variables.tf
@@ -1,0 +1,174 @@
+# =============================================================================
+# Input Variables
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# AWS
+# -----------------------------------------------------------------------------
+
+variable "aws_region" {
+  description = "AWS region for all resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC. Private subnets are /24 slices; the public subnet (spoke gateway) is a /24 slice."
+  type        = string
+  default     = "10.10.0.0/16"
+
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr, 0))
+    error_message = "vpc_cidr must be a valid CIDR block."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# EKS
+# -----------------------------------------------------------------------------
+
+variable "cluster_version" {
+  description = "Kubernetes version for the EKS cluster"
+  type        = string
+  default     = "1.32"
+}
+
+variable "node_instance_type" {
+  description = "EC2 instance type for EKS managed node group"
+  type        = string
+  default     = "m5.large"
+}
+
+variable "node_desired_size" {
+  description = "Desired number of EKS nodes. Set to 0 initially; scale up after Aviatrix spoke gateway programs routes."
+  type        = number
+  default     = 0
+}
+
+variable "node_max_size" {
+  description = "Maximum number of EKS nodes"
+  type        = number
+  default     = 4
+}
+
+# -----------------------------------------------------------------------------
+# Aviatrix Controller (Bring Your Own — pre-existing)
+# -----------------------------------------------------------------------------
+
+variable "controller_ip" {
+  description = "IP address or hostname of the Aviatrix Controller"
+  type        = string
+}
+
+variable "controller_username" {
+  description = "Admin username for the Aviatrix Controller"
+  type        = string
+  default     = "admin"
+}
+
+variable "controller_password" {
+  description = "Admin password for the Aviatrix Controller"
+  type        = string
+  sensitive   = true
+}
+
+variable "aws_access_account" {
+  description = "Aviatrix access account name for AWS (onboarded in the Controller)"
+  type        = string
+}
+
+variable "copilot_ip" {
+  description = "CoPilot private IP — used for syslog stream configuration"
+  type        = string
+}
+
+variable "copilot_public_ip" {
+  description = "CoPilot public IP — required for spoke gateway OTEL exporters (TCP 31284) when the spoke VPC is not peered to the controlplane VNet. Without this, DCF Monitor logs stay empty even though FlowIQ works."
+  type        = string
+}
+
+# -----------------------------------------------------------------------------
+# Obot
+# -----------------------------------------------------------------------------
+
+variable "obot_version" {
+  description = "Obot Helm chart version to deploy. Must be >= 0.21.0 for MCPNetworkPolicy support."
+  type        = string
+  default     = "0.21.0"
+
+  validation {
+    condition     = can(regex("^[0-9]+\\.[0-9]+\\.[0-9]+", var.obot_version))
+    error_message = "obot_version must be a valid semver string (e.g. 0.21.0)."
+  }
+}
+
+variable "obot_admin_password" {
+  description = "Obot admin password"
+  type        = string
+  sensitive   = true
+}
+
+variable "npc_chart_version" {
+  description = "Version of the aviatrix-network-policy-controller Helm chart from charts.obot.ai. Update when Aviatrix releases a new NPC chart version."
+  type        = string
+  default     = "v0.0.1"
+}
+
+variable "obot_namespace" {
+  description = "Kubernetes namespace for Obot"
+  type        = string
+  default     = "obot-system"
+}
+
+variable "obot_mcp_namespace" {
+  description = "Kubernetes namespace where Obot deploys MCP server pods"
+  type        = string
+  default     = "obot-mcp"
+}
+
+# -----------------------------------------------------------------------------
+# DCF — EKS known limitation workaround
+# K8s label-based SmartGroups do not resolve on EKS (controller registers
+# EKS as Partial: assetd watcher subscriptions lost on restart). These CIDR
+# variables provide a V1 DENY workaround. Update after each pod restart using
+# the procedure in the README.
+# -----------------------------------------------------------------------------
+
+variable "obot_system_pod_cidrs" {
+  description = <<-EOT
+    List of /32 CIDRs for obot-system pods. Used to scope Obot egress permits
+    (Anthropic, GitHub, charts.obot.ai) to the orchestration layer only.
+    TWO-STEP DEPLOY: Leave empty ([]) on first apply. After Obot is running,
+    get pod IPs with:
+      kubectl get pods -n obot-system -o jsonpath='{range .items[*]}{.status.podIP}{"\n"}{end}'
+    Then re-apply with those IPs as /32 CIDRs.
+  EOT
+  type        = list(string)
+  default     = []
+}
+
+variable "obot_mcp_pod_cidrs" {
+  description = <<-EOT
+    List of /32 CIDRs for active obot-mcp pods that require DCF deny-all
+    enforcement. EKS-specific V1 CIDR workaround for K8s label SmartGroup
+    resolution failure (controller registers EKS as Partial).
+    Leave empty ([]) on first apply; populate after MCP servers are deployed.
+  EOT
+  type        = list(string)
+  default     = []
+}
+
+# -----------------------------------------------------------------------------
+# Naming
+# -----------------------------------------------------------------------------
+
+variable "name_prefix" {
+  description = "Prefix for all resource names created by this blueprint"
+  type        = string
+  default     = "obot-mcp"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*$", var.name_prefix))
+    error_message = "name_prefix must start with a letter and contain only lowercase letters, numbers, and hyphens."
+  }
+}

--- a/blueprints/obot-mcp-egress-aws/variables.tf
+++ b/blueprints/obot-mcp-egress-aws/variables.tf
@@ -77,7 +77,7 @@ variable "aws_access_account" {
   type        = string
 }
 
-variable "copilot_ip" {
+variable "copilot_private_ip" {
   description = "CoPilot private IP — used for syslog stream configuration"
   type        = string
 }
@@ -156,6 +156,16 @@ variable "obot_mcp_pod_cidrs" {
   EOT
   type        = list(string)
   default     = []
+}
+
+# -----------------------------------------------------------------------------
+# Observability
+# -----------------------------------------------------------------------------
+
+variable "copilot_syslog_index" {
+  description = "Remote syslog index slot on the Aviatrix Controller (0-9). Must be free; change if another blueprint or config already uses this slot."
+  type        = number
+  default     = 9
 }
 
 # -----------------------------------------------------------------------------

--- a/blueprints/obot-mcp-egress-aws/versions.tf
+++ b/blueprints/obot-mcp-egress-aws/versions.tf
@@ -1,0 +1,39 @@
+# =============================================================================
+# Blueprint: obot-mcp-egress-aws
+# Deploys an EKS cluster with Aviatrix spoke gateway and Obot, enforcing
+# zero-trust egress on all MCP server pods via DCF + MCPNetworkPolicy.
+# =============================================================================
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  # Blueprints use local state by design.
+  # Add your own backend block here for team/production use.
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 8.2"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.38"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.13"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+  }
+}

--- a/blueprints/obot-mcp-egress-aws/vpc.tf
+++ b/blueprints/obot-mcp-egress-aws/vpc.tf
@@ -1,0 +1,50 @@
+# =============================================================================
+# VPC
+# =============================================================================
+
+locals {
+  name = var.name_prefix
+  azs  = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  private_subnets = [
+    cidrsubnet(var.vpc_cidr, 8, 1),
+    cidrsubnet(var.vpc_cidr, 8, 2),
+    cidrsubnet(var.vpc_cidr, 8, 3),
+  ]
+  public_subnets = [
+    cidrsubnet(var.vpc_cidr, 8, 0), # Aviatrix spoke gateway
+  ]
+
+  tags = { project = local.name }
+}
+
+data "aws_availability_zones" "available" { state = "available" }
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = local.name
+  cidr = var.vpc_cidr
+  azs  = local.azs
+
+  private_subnets = local.private_subnets
+  public_subnets  = local.public_subnets
+
+  # NAT GW not needed — Aviatrix spoke GW handles SNAT for pod egress.
+  enable_nat_gateway = false
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  # EKS subnet discovery tags
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb"             = 1
+    "kubernetes.io/cluster/${local.name}-cluster" = "shared"
+  }
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = 1
+  }
+
+  tags = local.tags
+}

--- a/blueprints/obot-mcp-egress-azure/.gitignore
+++ b/blueprints/obot-mcp-egress-azure/.gitignore
@@ -1,0 +1,2 @@
+*.png
+*.drawio

--- a/blueprints/obot-mcp-egress-azure/CHANGELOG.md
+++ b/blueprints/obot-mcp-egress-azure/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 2026-05-01
+
+- Initial release
+- Tested with Controller 8.2.x, Aviatrix provider 8.2.0, Obot 0.21.0
+- Azure / AKS only (v1). AWS/GKE variants planned as separate blueprints.

--- a/blueprints/obot-mcp-egress-azure/README.md
+++ b/blueprints/obot-mcp-egress-azure/README.md
@@ -1,0 +1,296 @@
+# Zero-Trust MCP Egress: Obot on AKS with Aviatrix DCF
+
+Deploy [Obot](https://obot.ai) onto a new AKS cluster with network-layer zero-trust egress enforcement for all MCP server pods. An Aviatrix spoke gateway intercepts outbound traffic; MCPNetworkPolicy CRDs (reconciled by Obot's bundled aviatrix-network-policy-controller) translate per-server allowlists into live FirewallPolicy rules. No sidecars, no service mesh, no code changes required.
+
+## Architecture
+
+![Architecture Diagram](architecture.png)
+
+Traffic flow:
+
+1. Obot user creates an MCP server and configures its allowed egress domains via the Obot UI or API.
+2. Obot's bundled `aviatrix-network-policy-controller` reconciles the server's `MCPNetworkPolicy` into an Aviatrix `FirewallPolicy` CRD.
+3. The Aviatrix controller pushes the policy to the spoke gateway.
+4. The spoke gateway enforces FQDN-based egress: permitted domains pass, everything else is dropped and logged.
+
+Azure IP masquerade is disabled for all pod traffic so the spoke gateway sees original pod IPs. SmartGroups resolve pod identities via Kubernetes label selectors, enabling per-pod enforcement without sidecars.
+
+## Scope and Limitations
+
+- **Supported MCP runtimes:** `npx`, `uvx`, and containerized servers only. Stdio-mode servers are not covered.
+- **Protocol and port:** Enforcement applies to HTTPS egress on TCP 443 only. MCP servers requiring non-443 outbound connections are not protected by this feature.
+- **Remote MCP servers:** Out of scope. This feature applies only to Kubernetes-hosted MCP servers deployed by Obot. Remote (SSE/HTTP) MCP server connections are not subject to these policies.
+- **Domain format:** `egressDomains` entries must be bare hostnames. No protocols (`https://`), paths, ports, or IP addresses. `localhost` and `*.svc` cluster-local names are rejected by Obot at admission. Wildcard prefix notation is supported (e.g., `*.anthropic.com`).
+- **Obot-specific domains are scoped to obot-system pods via /32 CIDRs.** The blueprint uses `var.obot_system_pod_cidrs` (list of `/32` CIDRs for obot-system pods) as the source selector for a dedicated V1 permit rule covering `api.anthropic.com`, GitHub, and `charts.obot.ai`. MCP server pods in `obot-mcp` do not match this rule and cannot reach those domains unless declared in `egressDomains`. **Update `obot_system_pod_cidrs` when obot-system pods restart:** pod IPs change and the SmartGroup must be re-applied. Underlying limitation: Aviatrix V1 policy list only supports CIDR SmartGroups as source; k8s namespace SmartGroups are only valid in `K8S_POLICY_LIST`. Per-namespace scoping via `/32` CIDRs is the current workaround.
+- **`npx` runtime servers require `registry.npmjs.org` in `egressDomains`.** The npx shim downloads the package from npm at pod startup. This download is subject to the same FirewallPolicy enforcement as all other egress. A server deployed without `registry.npmjs.org` in its `egressDomains` will have its `mcp` container fail (package download blocked) while the `shim` container stays running. Add `registry.npmjs.org` to `egressDomains` for any npx-runtime server. This is intentional: zero-trust requires explicit declaration of every outbound dependency, including package registries.
+- **Azure node telemetry (`dc.services.visualstudio.com`) is intentionally blocked.** AKS nodes emit Application Insights telemetry to this endpoint. The default POST_RULES deny catches it because it is not in the infrastructure permit list; by design. AKS functions correctly without it. This is the correct zero-trust posture: every outbound flow that is not explicitly required and permitted is denied, including vendor telemetry. Adding it to the allowlist would undermine the enforcement boundary the blueprint is designed to demonstrate.
+
+## Prerequisites
+
+### Required Tools
+
+- [Aviatrix Control Plane](../../docs/prerequisites/aviatrix-controller.md) (v8.2+) with CoPilot; Controller and CoPilot public IPs required
+- [Terraform](../../docs/prerequisites/terraform.md) (v1.5+)
+- [Azure CLI](../../docs/prerequisites/azure-cli.md), authenticated (`az login`)
+- [kubectl](../../docs/prerequisites/kubectl.md), configured for your cluster
+
+### Required Access
+
+- Azure subscription with permissions to create resource groups, VNets, subnets, route tables, and AKS clusters
+- Aviatrix Controller with an Azure access account (`arm_account_name`) already onboarded
+- `Contributor` role on the target Azure subscription
+
+### Blueprint-Specific Requirements
+
+- Obot >= 0.21.0 (the MCPNetworkPolicy egress provider was introduced in this release)
+- `spoke_gateway_subnet_cidr` must not overlap `aks_subnet_cidr` or `vnet_address_space` sub-ranges used by other resources
+
+## Resources Created
+
+| Resource | Description | Quantity |
+|----------|-------------|----------|
+| Azure Resource Group | Contains all created resources | 1 |
+| Azure Virtual Network | VNet for AKS nodes and spoke gateway | 1 |
+| Azure Subnet | AKS node subnet (Azure CNI, pod IPs from VNet) | 1 |
+| Azure Subnet | Aviatrix spoke gateway subnet | 1 |
+| Azure Route Table | Public RT for spoke gateway subnet | 1 |
+| Azure Route Table | Private RT for AKS node subnet (routes pod egress via spoke) | 1 |
+| Azure Kubernetes Cluster | AKS cluster with Azure CNI | 1 |
+| Azure Role Assignment | Network Contributor for AKS identity on resource group | 1 |
+| Aviatrix Spoke Gateway | DCF-enforced egress gateway (no transit required) | 1 |
+| Aviatrix Kubernetes Cluster | AKS onboarding for pod identity resolution | 1 |
+| Aviatrix SmartGroup | MCP server pods (by namespace) | 1 |
+| Aviatrix SmartGroup | AKS node subnet CIDR | 1 |
+| Aviatrix SmartGroup | K8s API server public IP | 1 |
+| Aviatrix SmartGroup | obot-system pod /32 CIDRs | 1 |
+| Aviatrix WebGroup | AKS infrastructure egress domains | 1 |
+| Aviatrix WebGroup | Obot application domains (Anthropic, GitHub) | 1 |
+| Aviatrix DCF Policy List | V1 infrastructure permits | 1 |
+| Aviatrix DCF Default Action | Deny-all at POST_RULES level | 1 |
+| Kubernetes ConfigMap | Azure ip-masq-agent config (disables pod SNAT) | 1 |
+| Kubernetes Namespace | Obot system namespace | 1 |
+| Kubernetes Namespace | Obot MCP server namespace | 1 |
+| Helm Release | Obot platform (includes aviatrix-network-policy-controller) | 1 |
+
+**Estimated Cost**: ~$0.15–0.25/hour for the spoke gateway VM (Standard_B2ms) plus AKS node costs (~$0.10–0.20/hour for Standard_D4s_v3 at 2 nodes).
+
+## Deployment
+
+### Step 1: Clone and Navigate
+
+```bash
+git clone https://github.com/AviatrixSystems/aviatrix-blueprints.git
+cd aviatrix-blueprints/blueprints/obot-mcp-egress-azure
+```
+
+### Step 2: Configure Variables
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars`. All fields marked `REQUIRED` must be set.
+
+### Step 3: Deploy
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+Deployment takes approximately 15–20 minutes (spoke gateway provisioning is the longest step).
+
+### Step 4: Enable K8s Enforcement in CoPilot
+
+These two settings must be enabled manually after first deploy (controller UI only):
+
+1. **DCF Kubernetes Enforcement**: CoPilot → DCF → Settings → Enforcement on Kubernetes → Enable
+2. **Log Enrichment** (for pod-level FlowIQ identity): CoPilot → Feature Previews → Log Enrichment → Enable
+
+### Step 5: Verify Deployment
+
+```bash
+# Check Terraform outputs
+terraform output
+
+# Verify Obot is running
+kubectl get pods -n obot-system
+
+# Port-forward Obot UI (access at http://localhost:8080)
+kubectl port-forward -n obot-system svc/obot-obot 8080:80
+```
+
+## Variables
+
+| Variable | Description | Type | Default | Required |
+|----------|-------------|------|---------|----------|
+| `azure_subscription_id` | Azure subscription ID | `string` | n/a | yes |
+| `azure_location` | Azure region (e.g. `"UK South"`) | `string` | n/a | yes |
+| `controller_ip` | Aviatrix Controller IP or hostname | `string` | n/a | yes |
+| `controller_username` | Controller admin username | `string` | `"admin"` | no |
+| `controller_password` | Controller admin password | `string` | n/a | yes |
+| `arm_account_name` | Azure access account name onboarded in Controller | `string` | n/a | yes |
+| `copilot_private_ip` | CoPilot private IP (syslog) | `string` | n/a | yes |
+| `copilot_public_ip` | CoPilot public IP (OTEL/DCF Monitor) | `string` | n/a | yes |
+| `resource_group_name` | Name of Azure resource group to create | `string` | `"obot-mcp-rg"` | no |
+| `vnet_address_space` | VNet address space | `string` | `"10.1.0.0/16"` | no |
+| `aks_subnet_cidr` | CIDR for AKS node subnet | `string` | `"10.1.0.0/20"` | no |
+| `aks_vm_size` | Azure VM size for AKS nodes | `string` | `"Standard_D4s_v3"` | no |
+| `aks_node_count` | Number of AKS nodes | `number` | `2` | no |
+| `aks_service_cidr` | CIDR for K8s services (must not overlap VNet) | `string` | `"172.16.0.0/17"` | no |
+| `aks_dns_service_ip` | K8s DNS service IP (must be within `aks_service_cidr`) | `string` | `"172.16.0.10"` | no |
+| `spoke_gateway_subnet_cidr` | Subnet CIDR for Aviatrix spoke gateway | `string` | `"10.1.200.0/26"` | no |
+| `spoke_gateway_size` | Azure VM size for spoke gateway | `string` | `"Standard_B2ms"` | no |
+| `obot_version` | Obot Helm chart version (>= 0.21.0) | `string` | `"0.21.0"` | no |
+| `npc_chart_version` | aviatrix-network-policy-controller chart version | `string` | `"v0.0.1"` | no |
+| `obot_admin_password` | Obot admin password | `string` | n/a | yes |
+| `obot_namespace` | Kubernetes namespace for Obot | `string` | `"obot-system"` | no |
+| `obot_mcp_namespace` | Kubernetes namespace for MCP server pods | `string` | `"obot-mcp"` | no |
+| `obot_system_pod_cidrs` | /32 CIDRs for obot-system pods (two-step deploy) | `list(string)` | `[]` | no |
+| `name_prefix` | Prefix for all created resource names | `string` | `"obot-mcp"` | no |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `spoke_gateway_name` | Name of the deployed Aviatrix spoke gateway |
+| `spoke_gateway_public_ip` | Public IP of the spoke gateway (all pod egress SNATs to this) |
+| `obot_namespace` | Kubernetes namespace where Obot is deployed |
+| `obot_mcp_namespace` | Kubernetes namespace where Obot deploys MCP server pods |
+| `next_steps` | Post-deployment instructions |
+
+## Test Scenarios
+
+### Scenario 1: Verify Default Deny
+
+Confirm that a newly deployed MCP server with no `egressDomains` configured has no outbound access:
+
+```bash
+# Get the MCP server pod name (replace <server-name> as appropriate)
+kubectl get pods -n obot-mcp -l app=<server-name>
+
+# Attempt an outbound connection from inside the pod
+kubectl exec -n obot-mcp <pod-name> -- curl -s --max-time 5 https://api.openai.com
+
+# Expected result: connection times out (blocked by DCF default deny)
+```
+
+Check CoPilot → DCF → Monitor to see the denied flow logged.
+
+### Scenario 2: Configure egressDomains and Verify Allow
+
+`MCPNetworkPolicy` is an internal Obot concept; there is no user-facing Kubernetes CRD to apply.
+Configure `egressDomains` via the Obot API or UI. Obot creates the MCPNetworkPolicy internally;
+the `aviatrix-network-policy-controller` reconciles it into a `FirewallPolicy` CRD.
+
+```bash
+# Update the MCP server to allow specific egress domains (replace <server-id>)
+curl -X PUT http://localhost:8080/api/mcp-servers/<server-id> \
+  -H "Content-Type: application/json" \
+  -d '{
+    "manifest": {
+      "name": "my-server",
+      "runtime": "npx",
+      "npxConfig": {
+        "package": "@modelcontextprotocol/server-github",
+        "egressDomains": ["api.openai.com"]
+      }
+    }
+  }'
+
+# Verify the FirewallPolicy CRD was created or updated
+kubectl get firewallpolicies -n obot-mcp
+
+# Retry the outbound connection (no sleep needed; policy exists before pod starts)
+kubectl exec -n obot-mcp <pod-name> -- curl -s --max-time 10 https://api.openai.com
+
+# Expected result: connection succeeds
+```
+
+> **Note:** The `aviatrix-network-policy-controller` creates the FirewallPolicy at server-definition
+> time, not at launch time. By the time the pod starts, the policy is already enforced.
+> See `k8s/example-mcpnetworkpolicy.yaml` for the shape of the generated `FirewallPolicy`.
+
+### Scenario 3: Verify Unlisted Domain is Blocked
+
+```bash
+# This domain is not in the egressDomains allowlist
+kubectl exec -n obot-mcp <pod-name> -- curl -s --max-time 5 https://example.com
+
+# Expected result: connection times out (blocked by DCF, not in approved domains)
+```
+
+## Cleanup
+
+```bash
+terraform destroy
+```
+
+If destroy fails, manually delete the Azure Route Table associations before retrying:
+
+```bash
+az network vnet subnet update \
+  --name <aks-subnet-name> \
+  --vnet-name <vnet-name> \
+  --resource-group <vnet-rg> \
+  --remove routeTable
+```
+
+## Troubleshooting
+
+### Spoke gateway creation fails or times out
+
+Verify the gateway subnet is correctly classified as public:
+
+```bash
+az network route-table show \
+  --name <name_prefix>-rt-avx-gw \
+  --resource-group <vnet_resource_group> \
+  --query routes
+```
+
+The `default-Internet` route with `nextHopType: Internet` must be present.
+
+### DCF Monitor is empty but FlowIQ works
+
+The spoke gateway OTEL exporter is not reaching CoPilot. This happens when `copilot_public_ip` is wrong or missing. Verify:
+
+```bash
+terraform output spoke_gateway_public_ip
+# This IP must be permitted in the CoPilot NSG for TCP 31284 inbound.
+```
+
+### egressDomains configured but traffic still blocked
+
+1. Verify DCF Kubernetes Enforcement is enabled in CoPilot → DCF → Settings.
+2. Check the feature flags were applied: `terraform apply` re-runs the `k8s_dcf_features` provisioner on each apply.
+3. Verify Log Enrichment is enabled (required for SmartGroup pod-label matching).
+4. Confirm a `FirewallPolicy` exists for the server: `kubectl get firewallpolicies -n obot-mcp`
+5. Check pod labels match the FirewallPolicy selector: `kubectl get pod <pod-name> -n obot-mcp --show-labels`
+
+### SmartGroups show workload_type as VM instead of k8s
+
+Log Enrichment is not enabled. Enable it in CoPilot → Feature Previews → Log Enrichment.
+
+## Tested With
+
+| Component | Version |
+|-----------|---------|
+| Aviatrix Controller | 8.2.x |
+| Aviatrix Terraform Provider | 8.2.0 |
+| Terraform | 1.9.x |
+| AzureRM Provider | 3.116.x |
+| Obot | 0.21.0 |
+
+## Built With
+
+This blueprint was developed by [Nick Davitashvili](https://github.com/nickda) (Aviatrix) in collaboration with [Grant Linville](https://github.com/g-linville) (Obot AI), who built the MCPNetworkPolicy egress provider in Obot.
+
+## Contributing
+
+See the [Contributing Guide](../../CONTRIBUTING.md) for information on how to contribute to this blueprint.
+
+## License
+
+Apache 2.0. See [LICENSE](../../LICENSE)

--- a/blueprints/obot-mcp-egress-azure/README.md
+++ b/blueprints/obot-mcp-egress-azure/README.md
@@ -4,7 +4,7 @@ Deploy [Obot](https://obot.ai) onto a new AKS cluster with network-layer zero-tr
 
 ## Architecture
 
-![Architecture Diagram](architecture.png)
+![Architecture Diagram](architecture.svg)
 
 Traffic flow:
 
@@ -33,6 +33,7 @@ Azure IP masquerade is disabled for all pod traffic so the spoke gateway sees or
 - [Terraform](../../docs/prerequisites/terraform.md) (v1.5+)
 - [Azure CLI](../../docs/prerequisites/azure-cli.md), authenticated (`az login`)
 - [kubectl](../../docs/prerequisites/kubectl.md), configured for your cluster
+- **Python 3** — required by `local-exec` provisioners for JSON parsing (`curl | python3 -c`)
 
 ### Required Access
 
@@ -149,6 +150,7 @@ kubectl port-forward -n obot-system svc/obot-obot 8080:80
 | `obot_mcp_namespace` | Kubernetes namespace for MCP server pods | `string` | `"obot-mcp"` | no |
 | `obot_system_pod_cidrs` | /32 CIDRs for obot-system pods (two-step deploy) | `list(string)` | `[]` | no |
 | `name_prefix` | Prefix for all created resource names | `string` | `"obot-mcp"` | no |
+| `copilot_syslog_index` | Remote syslog index slot on the Controller (0-9); must be free | `number` | `9` | no |
 
 ## Outputs
 

--- a/blueprints/obot-mcp-egress-azure/architecture.svg
+++ b/blueprints/obot-mcp-egress-azure/architecture.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400">
+  <rect width="800" height="400" fill="#f8f9fa" rx="8"/>
+  <text x="400" y="180" font-family="sans-serif" font-size="24" fill="#6c757d" text-anchor="middle">Architecture diagram coming soon</text>
+  <text x="400" y="220" font-family="sans-serif" font-size="14" fill="#adb5bd" text-anchor="middle">obot-mcp-egress-azure</text>
+</svg>

--- a/blueprints/obot-mcp-egress-azure/cluster.tf
+++ b/blueprints/obot-mcp-egress-azure/cluster.tf
@@ -1,0 +1,69 @@
+# =============================================================================
+# Azure Resource Group, VNet, AKS Cluster
+# =============================================================================
+
+resource "azurerm_resource_group" "obot" {
+  name     = var.resource_group_name
+  location = var.azure_location
+}
+
+resource "azurerm_virtual_network" "obot" {
+  name                = "${var.name_prefix}-vnet"
+  location            = azurerm_resource_group.obot.location
+  resource_group_name = azurerm_resource_group.obot.name
+  address_space       = [var.vnet_address_space]
+}
+
+# AKS node subnet. Azure CNI required: pods get VNet IPs directly.
+# Without Azure CNI, SmartGroups cannot resolve pod IPs and
+# FirewallPolicy CRDs will never match traffic at the spoke gateway.
+resource "azurerm_subnet" "aks_nodes" {
+  name                 = "${var.name_prefix}-sn-aks"
+  address_prefixes     = [var.aks_subnet_cidr]
+  resource_group_name  = azurerm_resource_group.obot.name
+  virtual_network_name = azurerm_virtual_network.obot.name
+
+  private_endpoint_network_policies = "Disabled"
+}
+
+resource "azurerm_kubernetes_cluster" "obot" {
+  name                              = "${var.name_prefix}-aks"
+  location                          = azurerm_resource_group.obot.location
+  resource_group_name               = azurerm_resource_group.obot.name
+  node_resource_group               = "${var.name_prefix}-aksnode-rg"
+  dns_prefix                        = "${var.name_prefix}-aks"
+  local_account_disabled            = false
+  role_based_access_control_enabled = true
+  oidc_issuer_enabled               = true
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  default_node_pool {
+    name           = "agentpool"
+    vm_size        = var.aks_vm_size
+    node_count     = var.aks_node_count
+    vnet_subnet_id = azurerm_subnet.aks_nodes.id
+
+    upgrade_settings {
+      drain_timeout_in_minutes      = 0
+      max_surge                     = "10%"
+      node_soak_duration_in_minutes = 0
+    }
+  }
+
+  network_profile {
+    network_plugin    = "azure"
+    network_policy    = "azure"
+    load_balancer_sku = "standard"
+    service_cidr      = var.aks_service_cidr
+    dns_service_ip    = var.aks_dns_service_ip
+  }
+}
+
+resource "azurerm_role_assignment" "aks_network" {
+  scope                = azurerm_resource_group.obot.id
+  role_definition_name = "Network Contributor"
+  principal_id         = azurerm_kubernetes_cluster.obot.identity[0].principal_id
+}

--- a/blueprints/obot-mcp-egress-azure/dcf.tf
+++ b/blueprints/obot-mcp-egress-azure/dcf.tf
@@ -1,0 +1,288 @@
+# =============================================================================
+# Distributed Cloud Firewall (DCF) Configuration
+# =============================================================================
+
+# Onboard the AKS cluster into the Aviatrix controller.
+# This enables the controller to discover pod identities and resolve
+# Kubernetes workload labels inside SmartGroup selectors.
+resource "aviatrix_kubernetes_cluster" "aks" {
+  cluster_id          = lower(azurerm_kubernetes_cluster.obot.id)
+  use_csp_credentials = true
+}
+
+# Allow the controller's Cloud Asset Inventory (CAI) to sync Kubernetes
+# workload metadata before creating SmartGroups that use k8s selectors.
+resource "time_sleep" "cai_sync" {
+  create_duration = "30s"
+
+  depends_on = [
+    aviatrix_spoke_gateway.obot,
+    aviatrix_kubernetes_cluster.aks,
+  ]
+}
+
+# Enable Distributed Cloud Firewalling globally on the controller.
+resource "aviatrix_distributed_firewalling_config" "enabled" {
+  enable_distributed_firewalling = true
+}
+
+# Enable the five feature flags required for Kubernetes CRD enforcement.
+# These flags reset on controller reboot — the null_resource ensures they
+# are re-applied on every `terraform apply`. Without k8s_discovery and
+# log_enrichment, CoPilot cannot resolve pod IPs to Kubernetes workloads,
+# causing SmartGroup label-based matching to silently fail.
+resource "null_resource" "k8s_dcf_features" {
+  triggers = {
+    controller_ip = var.controller_ip
+  }
+
+  provisioner "local-exec" {
+    command     = <<-EOT
+      set -euo pipefail
+      CID=$(curl -sk "https://$${CONTROLLER}/v2/api" \
+        -d "action=login&username=$${USERNAME}&password=$${PASSWORD}" \
+        | python3 -c "import sys,json; print(json.load(sys.stdin).get('CID',''))")
+      if [ -z "$${CID}" ]; then echo "ERROR: controller login failed" >&2; exit 1; fi
+      for feature in k8s k8s_dcf_policies dcf_multi_policies k8s_discovery log_enrichment; do
+        curl -sk "https://$${CONTROLLER}/v2/api" \
+          --data-urlencode "action=enable_controller_feature" \
+          --data-urlencode "CID=$${CID}" \
+          --data-urlencode "feature=$${feature}" > /dev/null &
+      done
+      wait
+      echo "All 5 DCF feature flags enabled"
+    EOT
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      CONTROLLER = var.controller_ip
+      USERNAME   = var.controller_username
+      PASSWORD   = var.controller_password
+    }
+  }
+
+  depends_on = [aviatrix_distributed_firewalling_config.enabled]
+}
+
+# SmartGroup: all pods in the Obot MCP namespace.
+# This is the source selector for the default deny-all rule.
+# Obot deploys MCP server pods into var.obot_mcp_namespace.
+resource "aviatrix_smart_group" "mcp_servers" {
+  name = "${var.name_prefix}-mcp-servers"
+
+  selector {
+    match_expressions {
+      type          = "k8s"
+      k8s_namespace = var.obot_mcp_namespace
+    }
+  }
+
+  depends_on = [time_sleep.cai_sync]
+}
+
+# SmartGroup: all IPs in the AKS node subnet.
+# Used as the source for the V1 infrastructure permit rules.
+# Azure IP masquerade is disabled (see obot.tf) so pod IPs are preserved
+# all the way to the spoke gateway — but the AKS subnet CIDR is still
+# needed for the V1 block which evaluates before Kubernetes label matching.
+resource "aviatrix_smart_group" "aks_subnet" {
+  name = "${var.name_prefix}-aks-subnet"
+
+  selector {
+    match_expressions {
+      cidr = azurerm_subnet.aks_nodes.address_prefixes[0]
+    }
+  }
+
+  depends_on = [time_sleep.cai_sync]
+}
+
+# SmartGroup: K8s API server public IP (single /32).
+# Pods access the Kubernetes API via the ClusterIP (e.g. 172.16.0.1:443),
+# which kube-proxy DNATs to this public IP. TLS over an IP has no SNI field
+# in the ClientHello, so WebGroup-based matching cannot match this traffic.
+# A plain CIDR permit at priority 1 is required.
+resource "aviatrix_smart_group" "k8s_api_server" {
+  name = "${var.name_prefix}-k8s-api"
+
+  selector {
+    match_expressions {
+      cidr = "${data.dns_a_record_set.aks_api_server.addrs[0]}/32"
+    }
+  }
+
+  depends_on = [time_sleep.cai_sync]
+}
+
+# SmartGroup: obot-system pods via /32 CIDRs (workaround for V1 CIDR-only source).
+# Scopes Obot application domains (Anthropic, GitHub) to orchestration pods only.
+# On first apply, var.obot_system_pod_cidrs is empty — the SmartGroup is created
+# but matches nothing until re-applied with pod IPs after Obot is running.
+resource "aviatrix_smart_group" "obot_system_pods" {
+  name = "${var.name_prefix}-obot-system"
+
+  selector {
+    dynamic "match_expressions" {
+      for_each = var.obot_system_pod_cidrs
+      content {
+        cidr = match_expressions.value
+      }
+    }
+  }
+
+  depends_on = [time_sleep.cai_sync]
+}
+
+# WebGroup: AKS node + pod infrastructure domains (source = full AKS subnet CIDR).
+# Azure services and container registries required by all nodes and pods.
+resource "aviatrix_web_group" "aks_infra_egress" {
+  name = "${var.name_prefix}-aks-infra"
+
+  selector {
+    match_expressions { snifilter = "*.hcp.${local.azure_region_slug}.azmk8s.io" }
+    match_expressions { snifilter = "*.azurecr.io" }
+    match_expressions { snifilter = "*.blob.core.windows.net" }
+    match_expressions { snifilter = "*.servicebus.windows.net" }
+    match_expressions { snifilter = "mcr.microsoft.com" }
+    match_expressions { snifilter = "*.data.mcr.microsoft.com" }
+    match_expressions { snifilter = "management.azure.com" }
+    match_expressions { snifilter = "login.microsoftonline.com" }
+    match_expressions { snifilter = "packages.microsoft.com" }
+    match_expressions { snifilter = "acs-mirror.azureedge.net" }
+    match_expressions { snifilter = "ghcr.io" }
+    match_expressions { snifilter = "*.ghcr.io" }
+    match_expressions { snifilter = "pkg-containers.githubusercontent.com" }
+    match_expressions { snifilter = "charts.obot.ai" } # NPC chart pulled by Obot PostStart hook
+  }
+}
+
+# WebGroup: Obot application domains (source = obot-system pod /32 CIDRs only).
+resource "aviatrix_web_group" "obot_pod_egress" {
+  name = "${var.name_prefix}-obot-egress"
+
+  selector {
+    match_expressions { snifilter = "charts.obot.ai" }
+    match_expressions { snifilter = "api.anthropic.com" }
+    match_expressions { snifilter = "github.com" }
+    match_expressions { snifilter = "*.github.com" }
+    match_expressions { snifilter = "raw.githubusercontent.com" }
+    match_expressions { snifilter = "*.githubusercontent.com" }
+  }
+}
+
+# V1 policy list: infrastructure permits that must evaluate BEFORE the
+# Kubernetes CRD block (K8S_POLICY_LIST) and the default deny rule.
+#
+# Traffic evaluation order:
+#   V1 (this resource) -> K8S_POLICY_LIST (MCPNetworkPolicy CRDs) -> POST_RULES (deny-all)
+#
+# Do NOT place the deny-all in the V1 list — a V1 deny evaluates before the
+# K8S block and would block all MCPNetworkPolicy PERMIT rules.
+resource "aviatrix_distributed_firewalling_policy_list" "infra" {
+  # P1: K8s API server CIDR permit.
+  # Must be priority 1, evaluated before WebGroup rules. Pod→ClusterIP→kube-proxy
+  # DNAT→API server IP; no SNI in the ClientHello means WebGroup matching skips.
+  policies {
+    name     = "k8s-api-server-cidr"
+    action   = "PERMIT"
+    priority = 1
+    protocol = "TCP"
+    logging  = true
+    watch    = false
+    port_ranges {
+      lo = 443
+      hi = 443
+    }
+    src_smart_groups = [aviatrix_smart_group.aks_subnet.uuid]
+    dst_smart_groups = [aviatrix_smart_group.k8s_api_server.uuid]
+  }
+
+  # P2: AKS infrastructure domain egress (SNI-based WebGroup).
+  policies {
+    name     = "aks-infra-egress"
+    action   = "PERMIT"
+    priority = 2
+    protocol = "TCP"
+    logging  = true
+    watch    = false
+    port_ranges {
+      lo = 443
+      hi = 443
+    }
+    src_smart_groups = [aviatrix_smart_group.aks_subnet.uuid]
+    dst_smart_groups = ["def000ad-0000-0000-0000-000000000001"] # Aviatrix anywhere group (0.0.0.0/0)
+    web_groups       = [aviatrix_web_group.aks_infra_egress.uuid]
+  }
+
+  # P3: Obot pod egress — scoped to obot-system pod /32 CIDRs.
+  # Provides Anthropic/GitHub/charts.obot.ai access to the orchestration layer
+  # without leaking those permits to obot-mcp pods.
+  policies {
+    name     = "obot-pod-egress"
+    action   = "PERMIT"
+    priority = 3
+    protocol = "TCP"
+    logging  = true
+    watch    = false
+    port_ranges {
+      lo = 443
+      hi = 443
+    }
+    src_smart_groups = [aviatrix_smart_group.obot_system_pods.uuid]
+    dst_smart_groups = ["def000ad-0000-0000-0000-000000000001"]
+    web_groups       = [aviatrix_web_group.obot_pod_egress.uuid]
+  }
+
+  depends_on = [aviatrix_distributed_firewalling_config.enabled]
+}
+
+# Default deny-all at POST_RULES level.
+# Evaluates AFTER V1 and K8S_POLICY_LIST blocks. Any traffic not explicitly
+# permitted by a V1 rule or a MCPNetworkPolicy CRD is dropped and logged.
+resource "aviatrix_distributed_firewalling_default_action_rule" "deny_all" {
+  action  = "DENY"
+  logging = true
+
+  depends_on = [aviatrix_distributed_firewalling_policy_list.infra]
+}
+
+# CoPilot association via direct API call.
+# The aviatrix_copilot_association Terraform resource (provider v8.x) only
+# accepts a private IP. Without the public IP, spoke gateway OTEL exporters
+# (TCP 31284) silently fail when the spoke VNet is not peered to the
+# controlplane VNet: FlowIQ keeps working but DCF Monitor stays empty.
+resource "null_resource" "copilot_association" {
+  triggers = {
+    private_ip = var.copilot_private_ip
+    public_ip  = var.copilot_public_ip
+  }
+
+  provisioner "local-exec" {
+    command     = <<-EOT
+      set -euo pipefail
+      CID=$(curl -sk "https://$${CONTROLLER}/v2/api" \
+        -d "action=login&username=$${USERNAME}&password=$${PASSWORD}" \
+        | python3 -c "import sys,json; print(json.load(sys.stdin).get('CID',''))")
+      if [ -z "$${CID}" ]; then echo "ERROR: controller login failed" >&2; exit 1; fi
+      curl -sk "https://$${CONTROLLER}/v2/api" \
+        -d "action=enable_copilot_association&CID=$${CID}&copilot_ip=$${PRIVATE_IP}&public_ip=$${PUBLIC_IP}"
+    EOT
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      CONTROLLER = var.controller_ip
+      USERNAME   = var.controller_username
+      PASSWORD   = var.controller_password
+      PRIVATE_IP = var.copilot_private_ip
+      PUBLIC_IP  = var.copilot_public_ip
+    }
+  }
+}
+
+# Syslog stream to CoPilot (UDP 5000, index 9).
+# Index 9 must be free on the controller. Change if already in use.
+resource "aviatrix_remote_syslog" "copilot" {
+  index    = 9
+  name     = "${var.name_prefix}-copilot"
+  server   = var.copilot_private_ip
+  port     = 5000
+  protocol = "UDP"
+}

--- a/blueprints/obot-mcp-egress-azure/dcf.tf
+++ b/blueprints/obot-mcp-egress-azure/dcf.tf
@@ -277,10 +277,8 @@ resource "null_resource" "copilot_association" {
   }
 }
 
-# Syslog stream to CoPilot (UDP 5000, index 9).
-# Index 9 must be free on the controller. Change if already in use.
 resource "aviatrix_remote_syslog" "copilot" {
-  index    = 9
+  index    = var.copilot_syslog_index
   name     = "${var.name_prefix}-copilot"
   server   = var.copilot_private_ip
   port     = 5000

--- a/blueprints/obot-mcp-egress-azure/k8s-apps/example-mcpnetworkpolicy.yaml
+++ b/blueprints/obot-mcp-egress-azure/k8s-apps/example-mcpnetworkpolicy.yaml
@@ -1,0 +1,81 @@
+# Example: What Obot generates internally
+#
+# MCPNetworkPolicy is NOT a user-facing Kubernetes CRD.
+# Users configure egressDomains via the Obot API or UI.
+# Obot then creates MCPNetworkPolicy objects internally,
+# and the aviatrix-network-policy-controller reconciles
+# those into Aviatrix FirewallPolicy CRDs (networking.aviatrix.com/v1alpha1).
+#
+# DO NOT kubectl apply this file. There is no MCPNetworkPolicy CRD to target.
+#
+# To inspect the generated FirewallPolicies in your cluster:
+#   kubectl get firewallpolicies -n obot-mcp
+#   kubectl describe firewallpolicy <name> -n obot-mcp
+#
+# To configure egressDomains for an MCP server, use the Obot API:
+#
+#   # Create a server with specific egress domains:
+#   curl -X POST http://<obot-host>/api/mcp-servers \
+#     -H "Content-Type: application/json" \
+#     -d '{
+#       "manifest": {
+#         "name": "my-server",
+#         "runtime": "npx",
+#         "npxConfig": {
+#           "package": "@modelcontextprotocol/server-github",
+#           "egressDomains": ["api.github.com", "*.githubusercontent.com"]
+#         }
+#       }
+#     }'
+#
+# Domain rules:
+#   - Bare hostname or leading-wildcard only: "api.example.com" or "*.example.com"
+#   - No protocols, paths, ports, or IPs
+#   - "localhost" and "*.svc" are rejected
+#   - Bare "*" is rejected (not a valid wildcard)
+#   - Empty egressDomains with MCPDEFAULT_DENY_ALL_EGRESS=true = deny all
+#     (no permit rule is generated; server has zero outbound access)
+#
+# ---- Diagnostic reference: shape of a generated FirewallPolicy ----
+#
+# When a server is configured with egressDomains: ["api.openai.com"],
+# Obot generates a FirewallPolicy like this:
+#
+# apiVersion: networking.aviatrix.com/v1alpha1
+# kind: FirewallPolicy
+# metadata:
+#   name: obot-<mnp-id>-fw
+#   namespace: obot-mcp
+#   labels:
+#     obot.ai/mcp-server-name: <server-id>
+# spec:
+#   rules:
+#   - action: permit
+#     name: allow-approved-egress
+#     port: 443
+#     protocol: tcp
+#     selector:
+#       matchLabels:
+#         app: <server-id>
+#     webGroups:
+#     - name: obot-<server-id>-approved-domains
+#   - action: deny
+#     name: deny-all-external
+#     protocol: any
+#     selector:
+#       matchLabels:
+#         app: <server-id>
+#   smartGroups:
+#   - name: obot-<server-id>-pods
+#     selectors:
+#     - k8sNamespace: obot-mcp
+#       tags:
+#         app: <server-id>
+#       type: k8s
+#   - name: any-destination
+#     selectors:
+#     - cidr: 0.0.0.0/0
+#   webGroups:
+#   - domains:
+#     - api.openai.com
+#     name: obot-<server-id>-approved-domains

--- a/blueprints/obot-mcp-egress-azure/main.tf
+++ b/blueprints/obot-mcp-egress-azure/main.tf
@@ -1,0 +1,65 @@
+# =============================================================================
+# Blueprint: obot-mcp-egress-azure
+# Deploys an AKS cluster with Aviatrix spoke gateway and Obot, enforcing
+# zero-trust egress on all MCP server pods via DCF + MCPNetworkPolicy.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Providers
+# -----------------------------------------------------------------------------
+
+provider "azurerm" {
+  subscription_id = var.azure_subscription_id
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+provider "aviatrix" {
+  controller_ip           = var.controller_ip
+  username                = var.controller_username
+  password                = var.controller_password
+  skip_version_validation = true
+}
+
+provider "kubernetes" {
+  host                   = azurerm_kubernetes_cluster.obot.kube_config[0].host
+  username               = azurerm_kubernetes_cluster.obot.kube_config[0].username
+  password               = azurerm_kubernetes_cluster.obot.kube_config[0].password
+  client_certificate     = base64decode(azurerm_kubernetes_cluster.obot.kube_config[0].client_certificate)
+  client_key             = base64decode(azurerm_kubernetes_cluster.obot.kube_config[0].client_key)
+  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.obot.kube_config[0].cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = azurerm_kubernetes_cluster.obot.kube_config[0].host
+    username               = azurerm_kubernetes_cluster.obot.kube_config[0].username
+    password               = azurerm_kubernetes_cluster.obot.kube_config[0].password
+    client_certificate     = base64decode(azurerm_kubernetes_cluster.obot.kube_config[0].client_certificate)
+    client_key             = base64decode(azurerm_kubernetes_cluster.obot.kube_config[0].client_key)
+    cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.obot.kube_config[0].cluster_ca_certificate)
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Locals
+# -----------------------------------------------------------------------------
+
+locals {
+  # Azure region slug used in AKS API server domain (e.g. "UK South" -> "uksouth")
+  azure_region_slug = lower(replace(var.azure_location, " ", ""))
+}
+
+# -----------------------------------------------------------------------------
+# AKS API server IP (derived from cluster FQDN after creation)
+# Pods reach the K8s API via a ClusterIP that kube-proxy DNATs to this public
+# IP. TLS over a bare IP has no SNI field, so WebGroup matching cannot apply.
+# A CIDR-based permit at priority 1 (dcf.tf) is required.
+# -----------------------------------------------------------------------------
+
+data "dns_a_record_set" "aks_api_server" {
+  host = azurerm_kubernetes_cluster.obot.fqdn
+}

--- a/blueprints/obot-mcp-egress-azure/network.tf
+++ b/blueprints/obot-mcp-egress-azure/network.tf
@@ -1,0 +1,71 @@
+# =============================================================================
+# Network: Aviatrix spoke gateway subnet + route tables
+# =============================================================================
+
+# Dedicated subnet for the Aviatrix spoke gateway.
+# Must not overlap with var.aks_subnet_cidr.
+resource "azurerm_subnet" "avx_gateway" {
+  name                 = "${var.name_prefix}-sn-avx-gw"
+  address_prefixes     = [var.spoke_gateway_subnet_cidr]
+  resource_group_name  = azurerm_resource_group.obot.name
+  virtual_network_name = azurerm_virtual_network.obot.name
+}
+
+# Public route table for the gateway subnet.
+# next_hop_type = "Internet" classifies the subnet as public to Aviatrix,
+# required for the spoke gateway to acquire an EIP and handle local egress.
+resource "azurerm_route_table" "avx_gateway" {
+  name                = "${var.name_prefix}-rt-avx-gw"
+  location            = var.azure_location
+  resource_group_name = azurerm_resource_group.obot.name
+
+  route {
+    name           = "default-Internet"
+    address_prefix = "0.0.0.0/0"
+    next_hop_type  = "Internet"
+  }
+
+  lifecycle {
+    # Aviatrix injects additional routes during gateway provisioning.
+    ignore_changes = [route, tags]
+  }
+}
+
+resource "azurerm_subnet_route_table_association" "avx_gateway" {
+  subnet_id      = azurerm_subnet.avx_gateway.id
+  route_table_id = azurerm_route_table.avx_gateway.id
+}
+
+# Private route table for the AKS node subnet.
+# next_hop_type = "None" marks the subnet as private. Aviatrix replaces the
+# default route with its spoke gateway, so all pod egress flows through DCF.
+#
+# WARNING: Applying this association redirects all pod outbound traffic through
+# the Aviatrix spoke gateway. Verify the DCF infrastructure permits in dcf.tf
+# match your cluster's essential egress domains before applying to production.
+resource "azurerm_route_table" "aks" {
+  name                = "${var.name_prefix}-rt-aks"
+  location            = var.azure_location
+  resource_group_name = azurerm_resource_group.obot.name
+
+  route {
+    name           = "blackhole"
+    address_prefix = "0.0.0.0/0"
+    next_hop_type  = "None"
+  }
+
+  lifecycle {
+    # Aviatrix modifies routes during gateway provisioning.
+    ignore_changes = [route, tags]
+  }
+}
+
+# AKS nodes need outbound internet during bootstrap (package downloads).
+# Associate the blackhole RT only after AKS reports healthy to prevent
+# nodes being cut off before they finish bootstrapping.
+resource "azurerm_subnet_route_table_association" "aks" {
+  subnet_id      = azurerm_subnet.aks_nodes.id
+  route_table_id = azurerm_route_table.aks.id
+
+  depends_on = [azurerm_kubernetes_cluster.obot]
+}

--- a/blueprints/obot-mcp-egress-azure/obot.tf
+++ b/blueprints/obot-mcp-egress-azure/obot.tf
@@ -1,0 +1,100 @@
+# =============================================================================
+# Obot Platform Deployment
+# =============================================================================
+
+# Disable Azure IP masquerade for pod traffic.
+# Without this, Azure's ip-masq-agent rewrites pod source IPs to node IPs
+# before traffic reaches the spoke gateway. SmartGroups resolve to pod IPs,
+# so the gateway would see node IPs and FirewallPolicy rules would never match.
+# Setting nonMasqueradeCIDRs: 0.0.0.0/0 disables SNAT for all destinations,
+# preserving pod IPs end-to-end for Kubernetes label-based DCF enforcement.
+resource "kubernetes_config_map_v1" "ip_masq_config" {
+  metadata {
+    name      = "azure-ip-masq-agent-config"
+    namespace = "kube-system"
+    labels = {
+      component                         = "ip-masq-agent"
+      "kubernetes.io/cluster-service"   = "true"
+      "addonmanager.kubernetes.io/mode" = "EnsureExists"
+    }
+  }
+  data = {
+    "ip-masq-agent" = <<-EOT
+      nonMasqueradeCIDRs:
+        - "0.0.0.0/0"
+    EOT
+  }
+}
+
+# Obot platform namespace.
+resource "kubernetes_namespace_v1" "obot_system" {
+  metadata {
+    name = var.obot_namespace
+    labels = {
+      app  = "obot"
+      role = "platform"
+    }
+  }
+}
+
+# Obot MCP server namespace.
+# Obot deploys MCP server pods into this namespace.
+# The DCF SmartGroup (dcf.tf) and MCPNetworkPolicy CRDs target this namespace.
+resource "kubernetes_namespace_v1" "obot_mcp" {
+  metadata {
+    name = var.obot_mcp_namespace
+    labels = {
+      app  = "obot"
+      role = "mcp-servers"
+    }
+  }
+}
+
+# Obot Helm release.
+# Chart source: https://charts.obot.ai (published on each release)
+# Requires Obot with MCPNetworkPolicy (aviatrix egress provider) support.
+#
+# Key configuration:
+# - updateStrategy: Recreate — Obot uses a RWO PVC; RollingUpdate causes
+#   Multi-Attach errors if a new pod starts before the old one releases the volume.
+# - OBOT_SERVER_MCPNETWORK_POLICY_PROVIDER_*: tells Obot where to pull the
+#   aviatrix-network-policy-controller Helm chart (repo, name, version).
+# - OBOT_SERVER_MCPDEFAULT_DENY_ALL_EGRESS: enables deny-all default for new
+#   MCP servers. Servers with no MCPNetworkPolicy get zero outbound access.
+resource "helm_release" "obot" {
+  name             = "obot"
+  repository       = "https://charts.obot.ai"
+  chart            = "obot"
+  version          = var.obot_version
+  namespace        = var.obot_namespace
+  create_namespace = false
+
+  values = [
+    yamlencode({
+      updateStrategy = "Recreate"
+      dev = {
+        useEmbeddedDb = true
+      }
+      mcpNamespace = {
+        name = var.obot_mcp_namespace
+      }
+      config = {
+        OBOT_SERVER_MCPNETWORK_POLICY_PROVIDER_CHART_REPO    = "https://charts.obot.ai"
+        OBOT_SERVER_MCPNETWORK_POLICY_PROVIDER_CHART_NAME    = "aviatrix-network-policy-controller"
+        OBOT_SERVER_MCPNETWORK_POLICY_PROVIDER_CHART_VERSION = var.npc_chart_version
+        OBOT_SERVER_MCPDEFAULT_DENY_ALL_EGRESS               = "true"
+        OBOT_SERVER_ADMIN_PASSWORD                           = var.obot_admin_password
+      }
+    })
+  ]
+
+  depends_on = [
+    kubernetes_namespace_v1.obot_system,
+    kubernetes_namespace_v1.obot_mcp,
+    kubernetes_config_map_v1.ip_masq_config,
+    aviatrix_spoke_gateway.obot,
+    null_resource.k8s_dcf_features,
+    aviatrix_distributed_firewalling_policy_list.infra,
+    aviatrix_distributed_firewalling_default_action_rule.deny_all,
+  ]
+}

--- a/blueprints/obot-mcp-egress-azure/outputs.tf
+++ b/blueprints/obot-mcp-egress-azure/outputs.tf
@@ -1,0 +1,45 @@
+# =============================================================================
+# Outputs
+# =============================================================================
+
+output "spoke_gateway_name" {
+  description = "Name of the deployed Aviatrix spoke gateway"
+  value       = aviatrix_spoke_gateway.obot.gw_name
+}
+
+output "spoke_gateway_public_ip" {
+  description = "Public IP (EIP) of the Aviatrix spoke gateway. All MCP server pod egress SNATs to this IP."
+  value       = aviatrix_spoke_gateway.obot.eip
+}
+
+output "obot_namespace" {
+  description = "Kubernetes namespace where Obot is deployed"
+  value       = var.obot_namespace
+}
+
+output "obot_mcp_namespace" {
+  description = "Kubernetes namespace where Obot deploys MCP server pods"
+  value       = var.obot_mcp_namespace
+}
+
+output "next_steps" {
+  description = "Post-deployment actions"
+  value       = <<-EOT
+    Deployment complete. Next steps:
+
+    1. Access Obot UI:
+       kubectl port-forward -n ${var.obot_namespace} svc/obot-obot 8080:80
+
+    2. Enable DCF enforcement on Kubernetes (required once after deploy):
+       CoPilot -> DCF -> Settings -> Enforcement on Kubernetes -> Enable
+
+    3. Enable Log Enrichment for pod-level FlowIQ identity:
+       CoPilot -> Feature Previews -> Log Enrichment -> Enable
+
+    4. Apply an MCPNetworkPolicy to allow egress for an MCP server:
+       kubectl apply -f k8s/example-mcpnetworkpolicy.yaml
+
+    5. Verify enforcement in CoPilot:
+       CoPilot -> DCF -> Monitor -> filter by MCP server SmartGroup
+  EOT
+}

--- a/blueprints/obot-mcp-egress-azure/spoke.tf
+++ b/blueprints/obot-mcp-egress-azure/spoke.tf
@@ -1,0 +1,26 @@
+# =============================================================================
+# Aviatrix Spoke Gateway
+# =============================================================================
+
+# Spoke gateway deployed into the VNet's dedicated gateway subnet.
+# No transit attachment required: DCF enforces WebGroup egress rules
+# directly at the spoke via local egress (single_ip_snat = true).
+# single_ip_snat is required for FQDN-based DCF filtering: the gateway
+# must SNAT pod traffic to its own EIP so the firewall engine can match
+# outbound connections to the correct WebGroup entries.
+resource "aviatrix_spoke_gateway" "obot" {
+  cloud_type        = 8 # Azure
+  account_name      = var.arm_account_name
+  gw_name           = "${var.name_prefix}-spoke"
+  vpc_id            = "${azurerm_virtual_network.obot.name}:${azurerm_resource_group.obot.name}:${azurerm_virtual_network.obot.guid}"
+  vpc_reg           = var.azure_location
+  gw_size           = var.spoke_gateway_size
+  subnet            = var.spoke_gateway_subnet_cidr
+  single_ip_snat    = true
+  manage_ha_gateway = false
+
+  depends_on = [
+    azurerm_subnet_route_table_association.avx_gateway,
+    azurerm_subnet_route_table_association.aks,
+  ]
+}

--- a/blueprints/obot-mcp-egress-azure/terraform.tfvars.example
+++ b/blueprints/obot-mcp-egress-azure/terraform.tfvars.example
@@ -1,0 +1,42 @@
+# =============================================================================
+# Example terraform.tfvars for blueprint: obot-mcp-egress-azure
+# Copy to terraform.tfvars and fill in your values.
+# =============================================================================
+
+# Aviatrix Controller (pre-existing)
+# REQUIRED: controller_ip, controller_password, arm_account_name
+# Tip: set controller_password via env var to avoid storing on disk:
+#   export TF_VAR_controller_password="your-password"
+controller_ip       = "20.1.2.3"      # REQUIRED
+controller_username = "admin"
+controller_password = "CHANGE_ME"     # REQUIRED; prefer TF_VAR_controller_password env var
+arm_account_name    = "azure-account" # REQUIRED: Aviatrix access account name for Azure
+copilot_private_ip  = "10.200.0.5"    # REQUIRED
+copilot_public_ip   = "20.1.2.4"      # REQUIRED
+
+# Azure: REQUIRED: azure_subscription_id, azure_location
+azure_subscription_id = "00000000-0000-0000-0000-000000000000"  # REQUIRED
+azure_location        = "UK South"                               # REQUIRED
+resource_group_name   = "obot-mcp-rg"
+
+# VNet + AKS (created by this blueprint)
+vnet_address_space = "10.1.0.0/16"
+aks_subnet_cidr    = "10.1.0.0/20"
+aks_vm_size        = "Standard_D4s_v3"
+aks_node_count     = 2
+
+# Aviatrix spoke gateway
+spoke_gateway_subnet_cidr = "10.1.200.0/26"
+spoke_gateway_size        = "Standard_B2ms"
+
+# Obot
+obot_version        = "0.21.0"
+npc_chart_version   = "v0.0.1"
+obot_admin_password = "CHANGE_ME"     # REQUIRED; prefer TF_VAR_obot_admin_password env var
+
+# TWO-STEP: Leave empty on first apply. After Obot is running, populate with
+# pod IPs from: kubectl get pods -n obot-system -o jsonpath='{range .items[*]}{.status.podIP}{"\n"}{end}'
+obot_system_pod_cidrs = []
+
+# Naming
+name_prefix = "obot-mcp"

--- a/blueprints/obot-mcp-egress-azure/variables.tf
+++ b/blueprints/obot-mcp-egress-azure/variables.tf
@@ -1,0 +1,207 @@
+# =============================================================================
+# Input Variables
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Aviatrix Controller (Bring Your Own — pre-existing)
+# -----------------------------------------------------------------------------
+
+variable "controller_ip" {
+  description = "IP address or hostname of the Aviatrix Controller"
+  type        = string
+}
+
+variable "controller_username" {
+  description = "Admin username for the Aviatrix Controller"
+  type        = string
+  default     = "admin"
+}
+
+variable "controller_password" {
+  description = "Admin password for the Aviatrix Controller"
+  type        = string
+  sensitive   = true
+}
+
+variable "arm_account_name" {
+  description = "Aviatrix access account name for Azure (onboarded in the Controller)"
+  type        = string
+}
+
+variable "copilot_private_ip" {
+  description = "CoPilot private IP — used for syslog stream configuration"
+  type        = string
+}
+
+variable "copilot_public_ip" {
+  description = "CoPilot public IP — required for spoke gateway OTEL exporters (TCP 31284) when the spoke VNet is not peered to the controlplane VNet. Without this, DCF Monitor logs stay empty even though FlowIQ works."
+  type        = string
+}
+
+# -----------------------------------------------------------------------------
+# Azure Subscription + Location
+# -----------------------------------------------------------------------------
+
+variable "azure_subscription_id" {
+  description = "Azure subscription ID where resources will be created"
+  type        = string
+}
+
+variable "azure_location" {
+  description = "Azure region for all resources (e.g. 'UK South')"
+  type        = string
+}
+
+# -----------------------------------------------------------------------------
+# Resource Group + VNet (created by this blueprint)
+# -----------------------------------------------------------------------------
+
+variable "resource_group_name" {
+  description = "Name of the Azure resource group to create"
+  type        = string
+  default     = "obot-mcp-rg"
+}
+
+variable "vnet_address_space" {
+  description = "Address space for the VNet created by this blueprint"
+  type        = string
+  default     = "10.1.0.0/16"
+
+  validation {
+    condition     = can(cidrhost(var.vnet_address_space, 0))
+    error_message = "vnet_address_space must be a valid CIDR block."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# AKS Cluster (created by this blueprint)
+# -----------------------------------------------------------------------------
+
+variable "aks_subnet_cidr" {
+  description = "CIDR for the AKS node subnet. Must be within vnet_address_space and large enough for pod IPs with Azure CNI (each pod consumes one VNet IP). /20 = 4094 IPs."
+  type        = string
+  default     = "10.1.0.0/20"
+
+  validation {
+    condition     = can(cidrhost(var.aks_subnet_cidr, 0))
+    error_message = "aks_subnet_cidr must be a valid CIDR block."
+  }
+}
+
+variable "aks_vm_size" {
+  description = "Azure VM size for AKS nodes"
+  type        = string
+  default     = "Standard_D4s_v3"
+}
+
+variable "aks_node_count" {
+  description = "Number of AKS nodes"
+  type        = number
+  default     = 2
+}
+
+variable "aks_service_cidr" {
+  description = "CIDR for Kubernetes services. Must not overlap with vnet_address_space or aks_subnet_cidr."
+  type        = string
+  default     = "172.16.0.0/17"
+}
+
+variable "aks_dns_service_ip" {
+  description = "IP address for the Kubernetes DNS service. Must be within aks_service_cidr."
+  type        = string
+  default     = "172.16.0.10"
+}
+
+# -----------------------------------------------------------------------------
+# Spoke Gateway
+# -----------------------------------------------------------------------------
+
+variable "spoke_gateway_subnet_cidr" {
+  description = "CIDR for the Aviatrix spoke gateway subnet. Must be within vnet_address_space and must not overlap with aks_subnet_cidr. A /26 is sufficient."
+  type        = string
+  default     = "10.1.200.0/26"
+
+  validation {
+    condition     = can(cidrhost(var.spoke_gateway_subnet_cidr, 0))
+    error_message = "spoke_gateway_subnet_cidr must be a valid CIDR block."
+  }
+}
+
+variable "spoke_gateway_size" {
+  description = "Azure VM size for the Aviatrix spoke gateway"
+  type        = string
+  default     = "Standard_B2ms"
+}
+
+# -----------------------------------------------------------------------------
+# Obot
+# -----------------------------------------------------------------------------
+
+variable "obot_version" {
+  description = "Obot Helm chart version to deploy. Must be >= 0.21.0 for MCPNetworkPolicy support."
+  type        = string
+  default     = "0.21.0"
+
+  validation {
+    condition     = can(regex("^[0-9]+\\.[0-9]+\\.[0-9]+", var.obot_version))
+    error_message = "obot_version must be a valid semver string (e.g. 0.21.0)."
+  }
+}
+
+variable "obot_namespace" {
+  description = "Kubernetes namespace for Obot"
+  type        = string
+  default     = "obot-system"
+}
+
+variable "obot_mcp_namespace" {
+  description = "Kubernetes namespace where Obot deploys MCP server pods. DCF SmartGroup and FirewallPolicy CRDs target this namespace."
+  type        = string
+  default     = "obot-mcp"
+}
+
+variable "obot_admin_password" {
+  description = "Obot admin password"
+  type        = string
+  sensitive   = true
+}
+
+variable "obot_system_pod_cidrs" {
+  description = <<-EOT
+    List of /32 CIDRs for obot-system pods. Used to scope Obot-specific
+    egress permits (Anthropic, GitHub, charts.obot.ai) to the orchestration
+    layer only, preventing obot-mcp pods from inheriting them.
+
+    TWO-STEP DEPLOY: Leave empty ([]) on first apply. After Obot is running,
+    get pod IPs with:
+      kubectl get pods -n <obot_namespace> -o jsonpath='{range .items[*]}{.status.podIP}{"\n"}{end}'
+    Then re-apply with those IPs as /32 CIDRs.
+
+    Workaround for Aviatrix V1 policy list limitation: V1 does not support
+    k8s namespace SmartGroups as source — only CIDR SmartGroups are valid.
+    Update these values when obot-system pods restart.
+  EOT
+  type        = list(string)
+  default     = []
+}
+
+variable "npc_chart_version" {
+  description = "Version of the aviatrix-network-policy-controller Helm chart from charts.obot.ai. Update when Aviatrix releases a new NPC chart version."
+  type        = string
+  default     = "v0.0.1"
+}
+
+# -----------------------------------------------------------------------------
+# Naming
+# -----------------------------------------------------------------------------
+
+variable "name_prefix" {
+  description = "Prefix for all resource names created by this blueprint"
+  type        = string
+  default     = "obot-mcp"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*$", var.name_prefix))
+    error_message = "name_prefix must start with a letter and contain only lowercase letters, numbers, and hyphens."
+  }
+}

--- a/blueprints/obot-mcp-egress-azure/variables.tf
+++ b/blueprints/obot-mcp-egress-azure/variables.tf
@@ -192,6 +192,16 @@ variable "npc_chart_version" {
 }
 
 # -----------------------------------------------------------------------------
+# Observability
+# -----------------------------------------------------------------------------
+
+variable "copilot_syslog_index" {
+  description = "Remote syslog index slot on the Aviatrix Controller (0-9). Must be free; change if another blueprint or config already uses this slot."
+  type        = number
+  default     = 9
+}
+
+# -----------------------------------------------------------------------------
 # Naming
 # -----------------------------------------------------------------------------
 

--- a/blueprints/obot-mcp-egress-azure/versions.tf
+++ b/blueprints/obot-mcp-egress-azure/versions.tf
@@ -1,0 +1,45 @@
+# =============================================================================
+# Blueprint: obot-mcp-egress-azure
+# =============================================================================
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  # Blueprints use local state by design.
+  # Add your own backend block here for team/production use.
+
+  required_providers {
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 8.2"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.38"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.13"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+    dns = {
+      source  = "hashicorp/dns"
+      version = "~> 3.4"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds two new blueprints for securing MCP server egress in [Obot](https://obot.ai) deployments using the Aviatrix Distributed Cloud Firewall:

- **`obot-mcp-egress-aws`**: Obot on EKS with V1 DCF per-pod enforcement via CIDR SmartGroups
- **`obot-mcp-egress-azure`**: Obot on AKS with K8s label SmartGroup enforcement via the NPC

Both blueprints implement a three-step apply workflow to handle dynamic pod IPs, use Obot's bundled `aviatrix-network-policy-controller` to reconcile `MCPNetworkPolicy` CRDs into Aviatrix `FirewallPolicy` resources, and enforce a default deny-all at `POST_RULES` level with explicit permits for infrastructure and Obot orchestration traffic.

Key design decisions documented in both READMEs:

- No sidecars, no service mesh, no application code changes required
- `EXTERNALSNAT=true` (EKS) and `ip-masq-agent` (`0.0.0.0/0`) (AKS) preserve pod source IPs at the spoke gateway
- Three-step deploy sequence: infra first, then Obot pod CIDRs, then MCP pod CIDRs
- EKS-specific known limitation: K8s label SmartGroups register as Partial; workaround via `/32` CIDR SmartGroups documented inline

Architecture diagrams are placeholder SVGs pending final artwork.

## Test plan

- [ ] `terraform init` succeeds in both blueprint directories
- [ ] `terraform validate` passes for both blueprints
- [ ] `terraform plan` against a real Aviatrix controller produces expected resource graph
- [ ] Obot deploys, MCP servers can be created, egress enforcement confirmed via CoPilot DCF Monitor
- [ ] Default deny verified: MCP server with no `egressDomains` cannot reach external endpoints
- [ ] Allow verified: MCP server with `egressDomains` configured can reach listed domains only