### PR TITLE
agentcore-aws: fix client invoker egress + user_data heredoc

### DIFF
--- a/blueprints/agentcore-aws/aviatrix.tf
+++ b/blueprints/agentcore-aws/aviatrix.tf
@@ -63,12 +63,11 @@ module "spoke_client" {
 
   ha_gw         = false
   instance_size = var.gateway_size
-  # Decryption (9.0) and single_ip_snat are mutually-exclusive on the
-  # same spoke gateway today - the controller's enable_decryption flow
-  # disables SNAT to avoid conflicts with learned default routes. Keep
-  # this at false to match the controller's post-decryption-enable state.
-  # Internet egress continues to function via the transit's egress path.
-  single_ip_snat = false
+  # Client spoke does NOT do TLS decryption (decryption is only on the
+  # agentcore spoke for runtime egress URL filtering). SNAT here is safe
+  # and required so the client invoker EC2 can reach pypi/SSM/etc during
+  # cloud-init. Without it the workload subnet has no path to the internet.
+  single_ip_snat = true
 
   enable_vpc_dns_server = false
 

--- a/blueprints/agentcore-aws/client.tf
+++ b/blueprints/agentcore-aws/client.tf
@@ -40,35 +40,38 @@ resource "aws_instance" "client_invoker" {
     set -euo pipefail
     dnf -y install awscli python3-pip python3-devel jq gcc
     # ---- containment-probe CLI (SSM-invocable) ---------------------------------
-    cat > /usr/local/bin/probe-agentcore.sh <<'EOF'
-    #!/bin/bash
-    # Invoke the sample AgentCore runtime and pretty-print the probe results.
-    set -euo pipefail
-    RUNTIME_ARN="$${1:-$${AGENTCORE_RUNTIME_ARN:-}}"
-    REGION="$${AWS_REGION:-us-east-2}"
-    DATA_HOST="$${AGENTCORE_DATA_HOST:-bedrock-agentcore.$${REGION}.amazonaws.com}"
-    if [[ -z "$${RUNTIME_ARN}" ]]; then
-      echo "usage: probe-agentcore.sh <runtime-arn>" >&2
-      exit 1
-    fi
-    echo "[probe] resolving $${DATA_HOST}"
-    getent ahosts "$${DATA_HOST}" | head -1
-    OUT=$(mktemp)
-    PAYLOAD_B64=$(printf '%s' '{"task":"run-probes"}' | base64 -w0)
-    SESSION="probe-$$(date +%s)-$$RANDOM-$$(head /dev/urandom | tr -dc a-f0-9 | head -c 16)"
-    aws bedrock-agentcore invoke-agent-runtime \
-      --region "$${REGION}" \
-      --agent-runtime-arn "$${RUNTIME_ARN}" \
-      --runtime-session-id "$${SESSION}" \
-      --payload "$${PAYLOAD_B64}" \
-      "$${OUT}" >/dev/null
-    echo "[probe] runtime response:"
-    cat "$${OUT}" | jq .
-    EOF
+    # Inner heredoc terminators MUST be at column 0 (no leading whitespace).
+    # The outer <<-BASH strips leading TABS only; this file is space-indented,
+    # so <<'EOF' with an indented EOF would swallow the rest of user_data.
+    cat > /usr/local/bin/probe-agentcore.sh <<'PROBE_EOF'
+#!/bin/bash
+# Invoke the sample AgentCore runtime and pretty-print the probe results.
+set -euo pipefail
+RUNTIME_ARN="$${1:-$${AGENTCORE_RUNTIME_ARN:-}}"
+REGION="$${AWS_REGION:-us-east-2}"
+DATA_HOST="$${AGENTCORE_DATA_HOST:-bedrock-agentcore.$${REGION}.amazonaws.com}"
+if [[ -z "$${RUNTIME_ARN}" ]]; then
+  echo "usage: probe-agentcore.sh <runtime-arn>" >&2
+  exit 1
+fi
+echo "[probe] resolving $${DATA_HOST}"
+getent ahosts "$${DATA_HOST}" | head -1
+OUT=$(mktemp)
+PAYLOAD_B64=$(printf '%s' '{"task":"run-probes"}' | base64 -w0)
+SESSION="probe-$$(date +%s)-$$RANDOM-$$(head /dev/urandom | tr -dc a-f0-9 | head -c 16)"
+aws bedrock-agentcore invoke-agent-runtime \
+  --region "$${REGION}" \
+  --agent-runtime-arn "$${RUNTIME_ARN}" \
+  --runtime-session-id "$${SESSION}" \
+  --payload "$${PAYLOAD_B64}" \
+  "$${OUT}" >/dev/null
+echo "[probe] runtime response:"
+cat "$${OUT}" | jq .
+PROBE_EOF
     chmod +x /usr/local/bin/probe-agentcore.sh
-    cat > /etc/profile.d/agentcore.sh <<'ENV'
-    export AWS_REGION=${var.aws_region}
-    ENV
+    cat > /etc/profile.d/agentcore.sh <<'PROFILE_ENV'
+export AWS_REGION=${var.aws_region}
+PROFILE_ENV
 
     # ---- Streamlit scenario UI -------------------------------------------------
     # Fetch UI bundle from S3 (see ui.tf) so user_data stays under 16 KB.


### PR DESCRIPTION
## Summary

Two defects in the `agentcore-aws` blueprint blocked the demo Streamlit UI from ever coming up healthy on the ALB.

**Egress** — `aviatrix.tf`: client spoke had `single_ip_snat = false`. The old comment said decryption forced SNAT off, but decryption is only configured on the **agentcore** spoke (for runtime URL-path filtering rule 29). With no SNAT anywhere in the path and no NAT GW, the client workload subnet had no route to the internet. Cloud-init's first `dnf install` and the SSM agent registration both failed silently.

**User_data heredoc** — `client.tf`: the outer `user_data = <<-BASH` strips leading TABS only, but the file is space-indented. The inner `cat > /usr/local/bin/probe-agentcore.sh <<'EOF'` had its closing `EOF` indented 4 spaces. Bash never matched the terminator and consumed the rest of the script as heredoc body, so:
- `chmod +x probe-agentcore.sh` never ran
- The Streamlit S3 download + pip install + `systemctl enable agentcore-ui.service` block never ran

Renamed inner terminators to `PROBE_EOF` / `PROFILE_ENV` and moved them to column 0, matching the already-working `ENVEOF` block lower in the file.

## Test plan

- [x] `terraform fmt` / `terraform validate` clean
- [x] `terraform apply` on a fresh deploy with these fixes — ALB target flips `healthy` once Streamlit binds 8501 (~2 min)
- [x] SSM `describe-instance-information` shows the client invoker `Online` (proves egress works)
- [x] `bash -n` the rendered user_data shows no heredoc warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)