### PR TITLE
agentcore-aws: QA pass 2026-05-28 (11 SE-feedback fixes)

### DIFF
--- a/blueprints/agentcore-aws/README.md
+++ b/blueprints/agentcore-aws/README.md
@@ -22,12 +22,13 @@ No HA on transit or spokes in v1. `single_ip_snat = false` on spokes because dec
 |---|---|---|
 | Terraform | >= 1.5 | Deploy the blueprint |
 | AWS CLI | configured | ECR login, SSM, validation |
-| Podman (or Docker) | machine running | Build the ARM64 agent container image |
+| [AWS Session Manager Plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) | latest | Required by `probe_command` (SSM session into the client invoker) |
+| Podman | machine running | Build the ARM64 agent container image (the build path uses `podman` explicitly; Docker is not a drop-in) |
 | `jq` | any | Reads controller responses during validation |
 | Aviatrix Controller | 8.1+ (FQDN SmartGroups GA) | DCF + SmartGroup support |
-| AWS permissions | ECR, VPC, IAM, Route 53, EC2, SSM, `bedrock-agentcore-control:Create*` | Create all resources |
+| AWS permissions | ECR, VPC, IAM, Route 53, EC2, SSM, `secretsmanager:*`, `cloudformation:*`, `bedrock-agentcore-control:Create*`, `bedrock-agentcore:*` (data plane Create/Invoke) | Create all resources |
 
-Region must be one of the AgentCore-supported set; defaults to `us-east-2` which has full PrivateLink coverage (data plane, control plane, gateway).
+**Region:** `us-east-2` is recommended and is the only region this blueprint has been deployed end-to-end. The variable accepts the broader AgentCore-supported set, but individual AZs within those regions can be excluded for AgentCore data-plane PrivateLink — `us-east-1` in particular has hit AZ-level "not supported" failures mid-apply.
 
 ## Deploy
 
@@ -60,6 +61,8 @@ terraform apply
 
 Expected deploy time: ~25-30 minutes (transit + 2 spokes attach each take ~3-4 min; AgentCore Runtime create + container build+push ~4-5 min).
 
+> **Known transient — provider "inconsistent final plan" on `aviatrix_web_group.allowed_mcp_servers`.** The first apply occasionally fails with `was cty.StringVal("mcp.deepwiki.com"), but now cty.StringVal("<lambda-url>.on.aws")` because the controller resolves the SNI through CNAMEs at apply time. Re-run `terraform apply` — the next plan sees the resolved value and the resource creates cleanly. Reported upstream as a provider bug.
+
 ## Test
 
 ```bash
@@ -79,10 +82,17 @@ Expected probe results:
 Verify in CoPilot:
 
 1. **Topology** — transit + 2 spokes + DCF badge
-2. **Security → Distributed Cloud Firewall → SmartGroups** — `runtime-subnet`, `agentcore-data-host`, `agentcore-control-host`, `client-spoke`, `any`
-3. **Security → Distributed Cloud Firewall → WebGroups** — allowed-models, allowed-tools, aws-control-domains populated with their SNI filters
-4. **FlowIQ → filter by src SmartGroup = `agentcore-vca-runtime-subnet`** — allowed Bedrock flows and denied internet flows both visible with human-readable rule names
-5. **FlowIQ → filter action = denied** — entries for the three denied probes
+2. **Security → DCF → SmartGroups** — `runtime-subnet`, `agentcore-data-host`, `agentcore-control-host`, `client-spoke`, `any`
+3. **Security → DCF → Web Groups** — `allowed-models`, `allowed-tools`, `aws-control-domains`, `allowed-mcp-servers`, `supply-chain-ioc-github` populated with their SNI / URL filters
+4. **Security → DCF → Monitor → filter `src_smart_group = agentcore-vca-runtime-subnet`** — allowed Bedrock flows and denied internet flows both visible with human-readable rule names
+5. **Security → DCF → Monitor → filter `action = DENY`** — entries for the three denied probes
+
+> **Note:** Filtering by SmartGroup is supported by DCF Monitor, not FlowIQ. FlowIQ is the flow-visualization view and filters on source/destination IPs and gateways. If you see Monitor entries with rule `UNKNOWN`, those are usually flows that hit the default action (no rule ID attached) — visible by the IPs involved.
+
+### Next: tests/
+
+- [`tests/probe.sh`](tests/probe.sh) — the underlying probe script that `probe_command` invokes via SSM. Run it directly on the client-invoker EC2 if you want to script the four containment checks.
+- [`tests/smoke-ui.md`](tests/smoke-ui.md) — ~10-minute UI smoke checklist for the ALB-fronted scenario UI; run after every fresh deploy.
 
 ## Resources created
 
@@ -112,6 +122,8 @@ terraform destroy
 ```
 
 The AgentCore Runtime terminates any active sessions; ECR force-delete handles the image; Aviatrix spoke/transit detach cleanly.
+
+> **Known transient — security_group / subnet dependency on first destroy.** If the first `terraform destroy` fails with a `DependencyViolation` on the runtime-subnet security group or one of the PrivateLink endpoint subnets, re-run `terraform destroy`. The AgentCore Runtime ENIs and PrivateLink endpoint ENIs are torn down asynchronously after the Runtime stops accepting sessions; the second destroy sees them gone and succeeds.
 
 ## Known limitations (v1)
 

--- a/blueprints/agentcore-aws/README.md
+++ b/blueprints/agentcore-aws/README.md
@@ -125,6 +125,22 @@ The AgentCore Runtime terminates any active sessions; ECR force-delete handles t
 
 > **Known transient — security_group / subnet dependency on first destroy.** If the first `terraform destroy` fails with a `DependencyViolation` on the runtime-subnet security group or one of the PrivateLink endpoint subnets, re-run `terraform destroy`. The AgentCore Runtime ENIs and PrivateLink endpoint ENIs are torn down asynchronously after the Runtime stops accepting sessions; the second destroy sees them gone and succeeds.
 
+## Troubleshooting
+
+**Provider produced inconsistent final plan on `aviatrix_web_group.allowed_mcp_servers` during the first `terraform apply`.** The controller resolves the MCP host SNI through CNAMEs at apply time, so the planned value (`mcp.deepwiki.com`) and the realized value (a `*.lambda-url.<region>.on.aws` host) diverge. Re-run `terraform apply` — the next plan picks up the resolved value and the resource creates cleanly. Reported upstream as a provider bug.
+
+**`terraform apply` fails with AZ-level "not supported for AgentCore" partway through, in regions other than `us-east-2`.** AgentCore data-plane PrivateLink is not yet available in every AZ of every supported region. Destroy and redeploy in `us-east-2` (the variable's default and the only end-to-end-tested region for this blueprint).
+
+**`probe_command` fails with `SessionManagerPlugin is not found`.** The AWS CLI delegates SSM interactive sessions to a separate plugin. Install [`session-manager-plugin`](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) and re-run.
+
+**`probe_command` reports the agent failing on AWS API calls (Bedrock, STS) or the AgentCore Runtime image pull is blocked.** Check that `terraform.tfvars` includes the full `aws_control_domains` list from `terraform.tfvars.example`. The ECR auth API (`api.ecr.<region>.amazonaws.com`), the S3 ECR layer bucket (`prod-<region>-starport-layer-bucket.s3.<region>.amazonaws.com`), and Secrets Manager are required for AgentCore VPC-mode image pull and agent runtime; missing any of them causes DCF to deny the flow. The per-account ECR registry hostname is appended automatically from the current AWS caller identity.
+
+**`terraform destroy` fails with `DependencyViolation` on the runtime-subnet security group or a PrivateLink endpoint subnet.** The AgentCore Runtime ENIs and PrivateLink endpoint ENIs are torn down asynchronously after the Runtime stops accepting sessions. Re-run `terraform destroy` — the second pass sees them gone and succeeds.
+
+**DCF Monitor entries show rule `UNKNOWN` for some flows.** These are flows that matched the default action rather than a specific rule (no rule ID is attached to default-action hits). The IPs involved tell you which traffic it is — usually background management chatter or flows that the blueprint deliberately doesn't enumerate.
+
+**First `terraform apply` fails with IAM `AccessDenied` errors mentioning `secretsmanager`, `cloudformation`, or `bedrock-agentcore`.** The deploying principal needs those services in addition to the canonical ECR / VPC / IAM / Route 53 / EC2 / SSM set. See the AWS permissions row of the Prerequisites table for the full list.
+
 ## Known limitations (v1)
 
 - **No TLS decryption.** WebGroups match on SNI only. URL paths, methods, and bodies are invisible. This is a deliberate v1 choice (see PRD § TLS decryption feasibility).

--- a/blueprints/agentcore-aws/dcf.tf
+++ b/blueprints/agentcore-aws/dcf.tf
@@ -162,7 +162,7 @@ resource "aviatrix_web_group" "aws_control" {
     for_each = [1]
     content {
       dynamic "match_expressions" {
-        for_each = var.aws_control_domains
+        for_each = local.aws_control_domains
         content {
           snifilter = match_expressions.value
         }

--- a/blueprints/agentcore-aws/main.tf
+++ b/blueprints/agentcore-aws/main.tf
@@ -83,6 +83,12 @@ locals {
   copilot_host    = coalesce(var.copilot_ip, var.controller_ip)
   copilot_dcf_url = "https://${local.copilot_host}/security/distributed-cloud-firewall/policy"
 
+  # ECR registry hostname is account- and region-specific. Append it to the
+  # operator-supplied control-domain list so customers never have to hardcode
+  # their own account ID in the variable default.
+  ecr_registry_host   = "${local.account_id}.dkr.ecr.${var.aws_region}.amazonaws.com"
+  aws_control_domains = concat(var.aws_control_domains, [local.ecr_registry_host])
+
   common_tags = {
     Blueprint = var.name_prefix
   }

--- a/blueprints/agentcore-aws/terraform.tfvars.example
+++ b/blueprints/agentcore-aws/terraform.tfvars.example
@@ -47,12 +47,20 @@ allowed_mcp_server_domains = [
   "mcp.deepwiki.com",
 ]
 
+# NOTE: the per-account ECR registry hostname
+# (<your-account-id>.dkr.ecr.<region>.amazonaws.com) is appended automatically
+# by Terraform from the current AWS caller identity. Do not add it here.
 aws_control_domains = [
+  # Observability + identity
   "sts.us-east-2.amazonaws.com",
   "logs.us-east-2.amazonaws.com",
   "monitoring.us-east-2.amazonaws.com",
   "xray.us-east-2.amazonaws.com",
   "secretsmanager.us-east-2.amazonaws.com",
+  # ECR auth API (required for AgentCore VPC-mode image pull)
+  "api.ecr.us-east-2.amazonaws.com",
+  # S3 layer bucket backing ECR image layers in us-east-2
+  "prod-us-east-2-starport-layer-bucket.s3.us-east-2.amazonaws.com",
 ]
 
 # -----------------------------------------------------------------------------
@@ -62,3 +70,10 @@ aws_control_domains = [
 # out-of-band and just want Terraform to wire the runtime up.
 build_agent_image = true
 agent_image_tag   = "v3"
+
+# -----------------------------------------------------------------------------
+# UI ingress
+# -----------------------------------------------------------------------------
+# Public CIDR(s) allowed to reach the ALB-fronted UI. Set this to your public
+# IP as /32. The ALB SG is the only ingress control; do not leave this open.
+ui_ingress_cidrs = ["203.0.113.10/32"] # replace with your public IP

--- a/blueprints/agentcore-aws/variables.tf
+++ b/blueprints/agentcore-aws/variables.tf
@@ -133,7 +133,14 @@ variable "allowed_mcp_server_domains" {
 }
 
 variable "aws_control_domains" {
-  description = "AWS service control-plane FQDNs the agent runtime may call (STS, SSM, Secrets Manager, CloudWatch Logs, X-Ray) plus ECR hostnames required by AgentCore Runtime in VPC mode to pull the container image from the per-session microVM ENI."
+  description = <<-EOT
+    AWS service control-plane FQDNs the agent runtime may call (STS, SSM, Secrets Manager,
+    CloudWatch Logs, X-Ray) plus the ECR auth API and the S3 layer bucket required by
+    AgentCore Runtime in VPC mode to pull the container image from the per-session microVM
+    ENI. The per-account ECR registry hostname (`<account-id>.dkr.ecr.<region>.amazonaws.com`)
+    is appended automatically in `main.tf` from the current caller identity, so customers
+    do not need to encode their own account ID here.
+  EOT
   type        = list(string)
   default = [
     # Observability + identity
@@ -142,9 +149,8 @@ variable "aws_control_domains" {
     "monitoring.us-east-2.amazonaws.com",
     "xray.us-east-2.amazonaws.com",
     "secretsmanager.us-east-2.amazonaws.com",
-    # ECR (auth API + registry) - required for AgentCore VPC-mode image pull
+    # ECR auth API (registry hostname is appended dynamically; see main.tf locals)
     "api.ecr.us-east-2.amazonaws.com",
-    "538591868388.dkr.ecr.us-east-2.amazonaws.com",
     # S3 layer bucket backing ECR image layers in us-east-2
     "prod-us-east-2-starport-layer-bucket.s3.us-east-2.amazonaws.com",
   ]
@@ -171,9 +177,13 @@ variable "agent_image_tag" {
 # -----------------------------------------------------------------------------
 
 variable "ui_ingress_cidrs" {
-  description = "List of CIDR blocks allowed to reach the Streamlit UI via the ALB. Default is the operator who bootstrapped the lab. Keep this tight - the ALB publishes a public DNS name, and the SG rule is the only ingress control."
+  description = "List of CIDR blocks allowed to reach the Streamlit UI via the ALB. Required: set to your public IP as /32 (or a short list of operator CIDRs). Keep this tight - the ALB publishes a public DNS name, and the SG rule is the only ingress control."
   type        = list(string)
-  default     = ["45.26.1.144/32"]
+
+  validation {
+    condition     = length(var.ui_ingress_cidrs) > 0
+    error_message = "ui_ingress_cidrs must contain at least one CIDR (your public IP as /32). The ALB is internet-facing; an empty list would either fail SG creation or expose the UI to the world depending on subsequent edits."
+  }
 
   validation {
     condition = alltrue([


### PR DESCRIPTION
# agentcore-aws: QA pass 2026-05-28

Pass driven by SE feedback from the first independent customer-perspective run (deploy + probe + destroy). The skill's deploy/test/destroy phases were skipped because the SE supplied real failure observations; each item was validated against the current repo state (and against the live lab environment for the CoPilot claims) before being converted into a gap.

## Summary

11 gaps surfaced, all addressed in this PR. No code changes outside `blueprints/agentcore-aws/`.

| # | Category | Where | One-liner |
|---|---|---|---|
| 1 | unstated-prereq | README.md | IAM table missing `secretsmanager:*`, `cloudformation:*`, `bedrock-agentcore:*` (data plane) |
| 2 | ambiguous-wording | README.md | Prereqs said "Podman (or Docker)" — blueprint requires Podman only |
| 3 | missing-recovery | README.md | "Provider produced inconsistent final plan" on `aviatrix_web_group.allowed_mcp_servers` had no documented retry |
| 4 | unstated-prereq | README.md | `us-east-1` AZ-level support gaps not called out; `us-east-2` is the only end-to-end tested region |
| 5 | unstated-prereq | README.md | `probe_command` uses SSM but Session Manager Plugin wasn't listed |
| 6 | copy-paste-failure | tfvars.example | `aws_control_domains` exposed 5 of the 8 required entries; image pull failed silently |
| 7 | readme-code-mismatch | variables.tf / main.tf / dcf.tf | Default for `aws_control_domains` hardcoded a specific account ID — leak + wrong for other customers. Now derived dynamically from `aws_caller_identity` + region. |
| 8 | readme-code-mismatch | README.md | CoPilot verification used wrong nav paths; FlowIQ doesn't filter by SmartGroup (DCF Monitor does) |
| 9 | unstated-prereq | README.md | `tests/` was discoverable only by accident; now linked from the Test section |
| 10 | missing-recovery | README.md | Destroy SG/subnet `DependencyViolation` retry not documented |
| 11 | copy-paste-failure | tfvars.example / variables.tf | `ui_ingress_cidrs` was hidden in variables.tf with a hardcoded maintainer-IP default; now required, fails fast |

## Verification

- `terraform fmt -check` clean on the files this PR touches (a pre-existing fmt drift in `adversary.tf` is unrelated and left for a separate pass).
- `terraform init -backend=false && terraform validate` exits 0 against the modified blueprint.
- `terraform plan` against an existing deploy correctly fails fast on the now-required `ui_ingress_cidrs`, confirming the "fail loud" intent.

## What the SE will need to do on their next run

- Re-copy `terraform.tfvars.example` to `terraform.tfvars` and fill in `ui_ingress_cidrs` with their public IP. There is no maintainer-IP default anymore.
- They no longer need to hand-edit the ECR registry hostname — it is derived from the caller's AWS account ID + region.

## Out of scope (deliberately not in this PR)

- The `UNKNOWN` rule on some DCF Monitor entries appears to be product behavior when flows hit the default action (no rule ID attached). Surfaced in the new CoPilot Note but not fixed in code.
- The pre-existing fmt drift in `adversary.tf` (a heredoc-induced alignment shift) is unrelated to the SE feedback.

## Run artifacts

- gaps log: `/tmp/qa-blueprint-agentcore-aws-20260528-152548/gaps.md`
- this report: `/tmp/qa-blueprint-agentcore-aws-20260528-152548/report.md`
