### PR TITLE
agentcore-aws: QA pass 2026-05-29 (6 gap fixes)

### DIFF
--- a/blueprints/agentcore-aws/README.md
+++ b/blueprints/agentcore-aws/README.md
@@ -121,15 +121,27 @@ Verify in CoPilot:
 
 ## Destroy
 
+The fastest, hands-off path is the helper script - it polls the runtime subnet, waits for the AgentCore-managed ENI to disappear, then runs `terraform destroy` for you:
+
+```bash
+./scripts/destroy-when-eni-clears.sh
+# Tune with POLL_INTERVAL (default 60s) and MAX_WAIT (default 3600s):
+#   POLL_INTERVAL=30 MAX_WAIT=7200 ./scripts/destroy-when-eni-clears.sh
+```
+
+Or run destroy by hand and re-run it after the ENI is gone:
+
 ```bash
 terraform destroy
+# If it errors on aws_subnet.agentcore_runtime / aws_security_group.runtime,
+# wait for the AgentCore ENI to release, then re-run `terraform destroy`.
 ```
 
 The AgentCore Runtime terminates any active sessions; ECR force-delete handles the image; Aviatrix spoke/transit detach cleanly.
 
-> **Known transient — runtime-subnet stuck on `Still destroying...` then DependencyViolation.** The AgentCore Runtime ENIs (`InterfaceType=agentic_ai`, `Attachment.InstanceOwnerId=amazon-aws`, an `ela-attach-*` attachment) are AWS-managed and clean up asynchronously after the Runtime resource is destroyed. The cleanup is **slow** (observed: 20+ minutes from runtime destroy to ENI release, sometimes more). Terraform polls AWS on `DependencyViolation` and eventually errors out on `aws_subnet.agentcore_runtime` and `aws_security_group.runtime`. The `ela-attach-*` attachment cannot be detached manually (AWS returns `OperationNotPermitted: You are not allowed to manage 'ela-attach' attachments`); only AWS' async cleanup can release it.
+> **Known transient — runtime-subnet stuck on `Still destroying...` then DependencyViolation.** The AgentCore Runtime ENIs (`InterfaceType=agentic_ai`, `Attachment.InstanceOwnerId=amazon-aws`, an `ela-attach-*` attachment) are AWS-managed and clean up asynchronously after the Runtime resource is destroyed. The cleanup is **slow** (observed: 30+ minutes from runtime destroy to ENI release, sometimes more). Terraform polls AWS on `DependencyViolation` and eventually errors out on `aws_subnet.agentcore_runtime` and `aws_security_group.runtime`. The `ela-attach-*` attachment cannot be detached manually (AWS returns `OperationNotPermitted: You are not allowed to manage 'ela-attach' attachments`); only AWS' async cleanup can release it.
 >
-> Wait for the ENI to disappear, then re-run `terraform destroy`. Check progress with:
+> `./scripts/destroy-when-eni-clears.sh` automates the wait. To check ENI state by hand:
 > ```bash
 > aws ec2 describe-network-interfaces --region <region> \
 >   --filters Name=subnet-id,Values=<runtime-subnet-id> \
@@ -145,7 +157,7 @@ The AgentCore Runtime terminates any active sessions; ECR force-delete handles t
 
 **UI scenarios report the agent failing on AWS API calls (Bedrock, STS) or the AgentCore Runtime image pull is blocked.** Check that `terraform.tfvars` includes the full `aws_control_domains` list from `terraform.tfvars.example`. The ECR auth API (`api.ecr.<region>.amazonaws.com`), the S3 ECR layer bucket (`prod-<region>-starport-layer-bucket.s3.<region>.amazonaws.com`), and Secrets Manager are required for AgentCore VPC-mode image pull and agent runtime; missing any of them causes DCF to deny the flow. The per-account ECR registry hostname is appended automatically from the current AWS caller identity.
 
-**`terraform destroy` hangs on `aws_subnet.agentcore_runtime: Still destroying...`, then errors with `DependencyViolation`.** The AgentCore Runtime keeps an `agentic_ai`-type ENI (`ela-attach-*` attachment) in the runtime subnet for many minutes after the Runtime resource itself is destroyed (observed: 20+ minutes). The attachment is AWS-managed and cannot be detached manually (`OperationNotPermitted: You are not allowed to manage 'ela-attach' attachments`); only AWS' async cleanup can release it. The same applies to `aws_security_group.runtime` because the ENI references it. Wait for the ENI to disappear (`aws ec2 describe-network-interfaces --filters Name=subnet-id,Values=<runtime-subnet-id>` returns empty), then re-run `terraform destroy` to clean up the remaining VPC/subnet/SG.
+**`terraform destroy` hangs on `aws_subnet.agentcore_runtime: Still destroying...`, then errors with `DependencyViolation`.** The AgentCore Runtime keeps an `agentic_ai`-type ENI (`ela-attach-*` attachment) in the runtime subnet for many minutes after the Runtime resource itself is destroyed (observed: 30+ minutes). The attachment is AWS-managed and cannot be detached manually (`OperationNotPermitted: You are not allowed to manage 'ela-attach' attachments`); only AWS' async cleanup can release it. The same applies to `aws_security_group.runtime` because the ENI references it. Run `./scripts/destroy-when-eni-clears.sh` to poll for the ENI release and finish the destroy automatically. To do it by hand: wait for `aws ec2 describe-network-interfaces --filters Name=subnet-id,Values=<runtime-subnet-id>` to return empty, then re-run `terraform destroy`.
 
 **DCF Monitor entries show rule `UNKNOWN` for some flows.** These are flows that matched the default action rather than a specific rule (no rule ID is attached to default-action hits). The IPs involved tell you which traffic it is — usually background management chatter or flows that the blueprint deliberately doesn't enumerate.
 

--- a/blueprints/agentcore-aws/README.md
+++ b/blueprints/agentcore-aws/README.md
@@ -56,7 +56,7 @@ cp terraform.tfvars.example terraform.tfvars
 # Other variables have sensible defaults; edit non-secret values as needed.
 
 terraform init
-terraform plan        # ~50 resources
+terraform plan        # ~75 resources
 terraform apply
 ```
 
@@ -71,14 +71,18 @@ Expected deploy time: ~25-30 minutes (transit + 2 spokes attach each take ~3-4 m
 terraform output -raw ui_alb_url
 ```
 
-Walk the scenario cards in the UI. Each card exercises one DCF outcome:
+Walk the scenario chips in the UI. The UI ships six cards; each maps to one DCF outcome with the containment toggle ON:
 
-| Scenario | Expected verdict | DCF rule matched |
+| Scenario chip (UI route) | Expected verdict | DCF / IAM rule matched |
 |---|---|---|
-| Bedrock InvokeModel (Claude 3 Haiku) | `PERMIT` | `-30-runtime-to-allowed-models` |
-| HTTPS GET `api.openai.com` | `DENY` | `-100-runtime-default-deny` |
-| HTTPS GET `example-attacker.com` | `DENY` | `-100-runtime-default-deny` |
-| DNS TXT to `8.8.8.8` | `DENY` | `-50-runtime-dns-exfil-deny` |
+| `llm01_prompt_inject_exfil` | `CONTAINED` | `-100-runtime-default-deny` |
+| `llm02_dns_exfil` | `CONTAINED` | `-50-runtime-dns-exfil-deny` |
+| `llm05_compromised_mcp` | `CONTAINED` | `-33-runtime-to-allowed-mcp-servers` (allow-list, untrusted MCP host hits default-deny) |
+| `llm05b_supply_chain_url_path` | `CONTAINED` | `-29-runtime-deny-supply-chain-ioc-github` |
+| `llm08_shadow_model` | `CONTAINED` | `-100-runtime-default-deny` |
+| `drift_public_mode` | `CONTAINED` | `vpc-mode-guardrail` (IAM, not DCF) |
+
+The Bedrock InvokeModel happy-path call (`-30-runtime-to-allowed-models` PERMIT) fires inside every card; flip the containment toggle OFF on any card to compare PERMIT vs DENY side-by-side. See [`tests/smoke-ui.md`](tests/smoke-ui.md) for the full UI walkthrough.
 
 Verify in CoPilot:
 
@@ -111,7 +115,7 @@ Verify in CoPilot:
 | IAM policy (VPC-mode guardrail) | 1 | — | Attach to admin roles out-of-band |
 | DCF SmartGroups | 5 | — | 1 subnet, 2 fqdn, 1 vpc, 1 cidr |
 | DCF WebGroups | 3 | — | models, tools, aws-control |
-| DCF policies | 7 | — | 3 permit + 2 ingress permit + 2 deny |
+| DCF policies | 9 | — | 2 ingress permit + 4 runtime-egress permit + 3 deny |
 
 **Idle cost estimate: ~$1.10/hr ≈ $27/day**. AgentCore session invocations add per-CPU-second billing.
 
@@ -123,7 +127,15 @@ terraform destroy
 
 The AgentCore Runtime terminates any active sessions; ECR force-delete handles the image; Aviatrix spoke/transit detach cleanly.
 
-> **Known transient — security_group / subnet dependency on first destroy.** If the first `terraform destroy` fails with a `DependencyViolation` on the runtime-subnet security group or one of the PrivateLink endpoint subnets, re-run `terraform destroy`. The AgentCore Runtime ENIs and PrivateLink endpoint ENIs are torn down asynchronously after the Runtime stops accepting sessions; the second destroy sees them gone and succeeds.
+> **Known transient — runtime-subnet stuck on `Still destroying...` then DependencyViolation.** The AgentCore Runtime ENIs (`InterfaceType=agentic_ai`, `Attachment.InstanceOwnerId=amazon-aws`, an `ela-attach-*` attachment) are AWS-managed and clean up asynchronously after the Runtime resource is destroyed. The cleanup is **slow** (observed: 20+ minutes from runtime destroy to ENI release, sometimes more). Terraform polls AWS on `DependencyViolation` and eventually errors out on `aws_subnet.agentcore_runtime` and `aws_security_group.runtime`. The `ela-attach-*` attachment cannot be detached manually (AWS returns `OperationNotPermitted: You are not allowed to manage 'ela-attach' attachments`); only AWS' async cleanup can release it.
+>
+> Wait for the ENI to disappear, then re-run `terraform destroy`. Check progress with:
+> ```bash
+> aws ec2 describe-network-interfaces --region <region> \
+>   --filters Name=subnet-id,Values=<runtime-subnet-id> \
+>   --query "NetworkInterfaces[].{Id:NetworkInterfaceId,Type:InterfaceType,Status:Status}"
+> ```
+> Empty result = ENI gone = next `terraform destroy` will succeed.
 
 ## Troubleshooting
 
@@ -133,7 +145,7 @@ The AgentCore Runtime terminates any active sessions; ECR force-delete handles t
 
 **UI scenarios report the agent failing on AWS API calls (Bedrock, STS) or the AgentCore Runtime image pull is blocked.** Check that `terraform.tfvars` includes the full `aws_control_domains` list from `terraform.tfvars.example`. The ECR auth API (`api.ecr.<region>.amazonaws.com`), the S3 ECR layer bucket (`prod-<region>-starport-layer-bucket.s3.<region>.amazonaws.com`), and Secrets Manager are required for AgentCore VPC-mode image pull and agent runtime; missing any of them causes DCF to deny the flow. The per-account ECR registry hostname is appended automatically from the current AWS caller identity.
 
-**`terraform destroy` fails with `DependencyViolation` on the runtime-subnet security group or a PrivateLink endpoint subnet.** The AgentCore Runtime ENIs and PrivateLink endpoint ENIs are torn down asynchronously after the Runtime stops accepting sessions. Re-run `terraform destroy` — the second pass sees them gone and succeeds.
+**`terraform destroy` hangs on `aws_subnet.agentcore_runtime: Still destroying...`, then errors with `DependencyViolation`.** The AgentCore Runtime keeps an `agentic_ai`-type ENI (`ela-attach-*` attachment) in the runtime subnet for many minutes after the Runtime resource itself is destroyed (observed: 20+ minutes). The attachment is AWS-managed and cannot be detached manually (`OperationNotPermitted: You are not allowed to manage 'ela-attach' attachments`); only AWS' async cleanup can release it. The same applies to `aws_security_group.runtime` because the ENI references it. Wait for the ENI to disappear (`aws ec2 describe-network-interfaces --filters Name=subnet-id,Values=<runtime-subnet-id>` returns empty), then re-run `terraform destroy` to clean up the remaining VPC/subnet/SG.
 
 **DCF Monitor entries show rule `UNKNOWN` for some flows.** These are flows that matched the default action rather than a specific rule (no rule ID is attached to default-action hits). The IPs involved tell you which traffic it is — usually background management chatter or flows that the blueprint deliberately doesn't enumerate.
 

--- a/blueprints/agentcore-aws/scripts/destroy-when-eni-clears.sh
+++ b/blueprints/agentcore-aws/scripts/destroy-when-eni-clears.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Waits for the AgentCore Runtime ENI (`agentic_ai` interface type, AWS-managed
+# `ela-attach-*` attachment) to be released by AWS, then runs `terraform
+# destroy -auto-approve` to finish cleaning up the runtime subnet, security
+# group, and VPC. Use after a first `terraform destroy` errors out on
+# DependencyViolation against `aws_subnet.agentcore_runtime` /
+# `aws_security_group.runtime`.
+#
+# Why: the AgentCore Runtime keeps an AWS-managed ENI attached to the runtime
+# subnet for many minutes after the Runtime resource is destroyed (observed:
+# 30+ minutes; the attachment is `ela-attach-*` and cannot be detached by the
+# customer - AWS returns OperationNotPermitted). Terraform polls the subnet
+# delete on DependencyViolation and eventually errors out. Re-running destroy
+# manually is annoying because you have to time it right. This script does the
+# wait for you.
+#
+# Usage:
+#   ./scripts/destroy-when-eni-clears.sh              # auto-detect subnet+region
+#   ./scripts/destroy-when-eni-clears.sh <subnet-id>  # explicit subnet
+#   POLL_INTERVAL=30 MAX_WAIT=7200 ./scripts/destroy-when-eni-clears.sh
+#
+# Defaults: poll every 60s for up to 3600s (1 hour). Tune via POLL_INTERVAL
+# and MAX_WAIT env vars (seconds). Set TF_VAR_* env vars before invoking,
+# same as a regular `terraform destroy`.
+#
+# Safe to ctrl-C and re-run. Idempotent.
+set -euo pipefail
+
+POLL_INTERVAL="${POLL_INTERVAL:-60}"
+MAX_WAIT="${MAX_WAIT:-3600}"
+
+BLUEPRINT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "${BLUEPRINT_DIR}"
+
+# Subnet ID: explicit CLI arg, else terraform output, else fail.
+SUBNET_ID="${1:-}"
+if [[ -z "${SUBNET_ID}" ]]; then
+  SUBNET_ID="$(terraform output -raw agentcore_runtime_subnet_id 2>/dev/null || true)"
+fi
+if [[ -z "${SUBNET_ID}" ]]; then
+  echo "error: could not determine runtime subnet id." >&2
+  echo "       terraform output -raw agentcore_runtime_subnet_id returned empty," >&2
+  echo "       and no subnet id was passed on the command line." >&2
+  echo "" >&2
+  echo "usage: $0 [<subnet-id>]" >&2
+  exit 64
+fi
+
+# Region: AWS_REGION env wins, else AWS_DEFAULT_REGION, else aws configure.
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-$(aws configure get region 2>/dev/null || true)}}"
+if [[ -z "${REGION}" ]]; then
+  echo "error: could not determine AWS region. set AWS_REGION env var." >&2
+  exit 64
+fi
+
+echo "Watching runtime subnet : ${SUBNET_ID}"
+echo "Region                  : ${REGION}"
+echo "Poll interval           : ${POLL_INTERVAL}s"
+echo "Max wait                : ${MAX_WAIT}s"
+echo ""
+
+START=$(date +%s)
+while true; do
+  NOW=$(date +%s)
+  ELAPSED=$((NOW - START))
+
+  if (( ELAPSED >= MAX_WAIT )); then
+    echo "[$(date +%H:%M:%S)] ENI still attached after ${MAX_WAIT}s; giving up." >&2
+    echo "                   Check manually:" >&2
+    echo "                     aws ec2 describe-network-interfaces \\" >&2
+    echo "                       --region ${REGION} \\" >&2
+    echo "                       --filters Name=subnet-id,Values=${SUBNET_ID}" >&2
+    exit 1
+  fi
+
+  ENI_COUNT="$(aws ec2 describe-network-interfaces \
+    --region "${REGION}" \
+    --filters "Name=subnet-id,Values=${SUBNET_ID}" \
+    --query 'NetworkInterfaces | length(@)' \
+    --output text 2>/dev/null || echo "?")"
+
+  if [[ "${ENI_COUNT}" == "0" ]]; then
+    echo "[$(date +%H:%M:%S)] ENI gone after ${ELAPSED}s. Running terraform destroy."
+    break
+  fi
+
+  echo "[$(date +%H:%M:%S)] elapsed=${ELAPSED}s ENI_count=${ENI_COUNT} - waiting..."
+  sleep "${POLL_INTERVAL}"
+done
+
+terraform destroy -auto-approve

--- a/blueprints/agentcore-aws/terraform.tfvars.example
+++ b/blueprints/agentcore-aws/terraform.tfvars.example
@@ -6,16 +6,16 @@
 # -----------------------------------------------------------------------------
 # Aviatrix controller
 # -----------------------------------------------------------------------------
-controller_ip       = "3.131.22.171"
-controller_username = "admin"
-controller_password = "change-me"
+# controller_ip, controller_username, controller_password and
+# aviatrix_aws_account_name are supplied via TF_VAR_* env vars per the README
+# Step 2 block. Do NOT add them here - any value in this file overrides the
+# env var (tfvars beats TF_VAR_*), so a placeholder password like "change-me"
+# silently shadows your real credentials and the controller rejects auth with
+# "username and password do not match".
+
 # CoPilot IP (used to render a deeplink in the UI to DCF policies). Defaults
 # to controller_ip when co-resident (Cloud Fabric / single-VM lab deploys).
 # copilot_ip          = "3.135.75.175"
-
-# Aviatrix-onboarded AWS access account name (not your AWS account ID).
-# This is the name as it appears under "Accounts" in the controller.
-aviatrix_aws_account_name = "aws-primary"
 
 # -----------------------------------------------------------------------------
 # AWS
@@ -74,6 +74,7 @@ agent_image_tag   = "v3"
 # -----------------------------------------------------------------------------
 # UI ingress
 # -----------------------------------------------------------------------------
-# Public CIDR(s) allowed to reach the ALB-fronted UI. Set this to your public
-# IP as /32. The ALB SG is the only ingress control; do not leave this open.
-ui_ingress_cidrs = ["203.0.113.10/32"] # replace with your public IP
+# Public CIDR(s) allowed to reach the ALB-fronted UI. The variable has no
+# default and validation requires at least one entry, so terraform will prompt
+# if you skip the README's `echo >> terraform.tfvars` recipe in Step 2. The ALB
+# SG is the only ingress control; do not leave this open.

--- a/blueprints/agentcore-aws/tests/smoke-ui.md
+++ b/blueprints/agentcore-aws/tests/smoke-ui.md
@@ -8,7 +8,7 @@ Run after `terraform apply` against a fresh deploy. ~10 minutes.
 4. Toggle **Containment OFF** in the status strip — switch slides to red, URL gains `?containment=off`.
 5. Run **LLM01** with toggle ON → verdict `CONTAINED`; attack flow shows Aviatrix Gateway node with DENY action; rule block shows `agentcore-vca-100-runtime-default-deny`; Control Evidence shows TLS termination at spoke GW.
 6. Run **LLM01** with toggle OFF → verdict `BREACH` + `SIMULATED` ribbon; same nodes but Aviatrix Gateway shows PERMIT; final egress node green ("HTTP 200, 38 bytes sent").
-7. Run **LLM02** through **LLM08** with toggle ON, then OFF — verify each card adapts.
+7. Run **LLM02** (`dns_exfil`), **LLM05** (`compromised_mcp`), **LLM05b** (`supply_chain_url_path`), and **LLM08** (`shadow_model`) with toggle ON, then OFF — verify each card adapts. (LLM03/04/06/07 are deferred to v2.)
 8. Run **Drift** with toggle ON → CONTAINED; rule block has `IAM` pill instead of `DCF`; Control Evidence shows `AccessDeniedException`.
 9. Run **Drift** with toggle OFF → still CONTAINED + IAM-note: "IAM is a separate enforcement plane".
 10. Visit `/chat` — send a message; reply appears; `DCF -30-` badge visible.


### PR DESCRIPTION
# QA run: agentcore-aws

- Branch: `qa/agentcore-aws-2026-05-29-1`
- Date: 2026-05-29
- Wall-clock: ~95 minutes (deploy ~30, test ~5, destroy retries ~60 including the 20-min hang on the AgentCore Runtime ENI)
- Test scenarios: 4/4 CLI-verifiable PASS; 5 UI scenarios MANUAL (browser-only)
- Deploy: succeeded after 1 retry (root cause of failure documented in gap #2 below)
- Destroy: NOT fully clean at PR time. VPC, runtime subnet, and runtime security group are still in terraform state; an AgentCore-managed `agentic_ai` ENI (`ela-attach-*`) blocks deletion. A background loop in the QA run-dir retries every 5 min until AWS releases the ENI. Manual cleanup instructions below if the loop times out.

## Gaps found and fixed (6)

- #1 [copy-paste-failure] README:55 - `echo "ui_ingress_cidrs..." >> terraform.tfvars` produced a duplicate variable definition because `terraform.tfvars.example:79` already defined it; Terraform 1.5+ rejects this. Fix: removed the placeholder line from the example file; the README's `echo >>` recipe is now the canonical way to set it.

- #2 [copy-paste-failure] terraform.tfvars.example:9 - tfvars BEATS TF_VAR_*. The example file's `controller_password = "change-me"` shadowed `TF_VAR_controller_password`, causing `terraform plan` to fail with "username and password do not match". Same shadowing on `aviatrix_aws_account_name` caused mid-apply spoke-gateway failures: `[AVXERR-TRANSIT-0024] AWS Gateway Launch failed: Credentials not found for cloud type 1 in account aws-primary`. Fix: removed `controller_ip`, `controller_username`, `controller_password`, and `aviatrix_aws_account_name` from the example file, replaced with a comment block explaining that TF_VAR_* is canonical and tfvars shadows env vars.

- #3 [readme-code-mismatch] tests/smoke-ui.md:11 - "Run LLM02 through LLM08" but the UI only ships LLM02, LLM05, LLM05b, LLM08 (plus LLM01 and Drift, covered separately). LLM03/04/06/07 don't exist. Fix: rewrote item 7 to enumerate the four cards that exist and note 03/04/06/07 are deferred to v2.

- #4 [readme-code-mismatch] README:76 - Test-section table listed 4 verb-driven scenarios (`Bedrock InvokeModel`, `api.openai.com`, `example-attacker.com`, `DNS TXT 8.8.8.8`) but the UI ships 6 LLM-numbered chips with different names. Fix: replaced the 4-row table with a 6-row table keyed on UI chip routes, with the matched DCF / IAM rule per chip and a paragraph clarifying the Bedrock InvokeModel happy path. Added a pointer to tests/smoke-ui.md.

- #5 [stale-value] README:59 and :114 - Resource-count claims undercounted reality. Plan: "~50 resources" but actual plan is 76. DCF policies row: "7 — 3 permit + 2 ingress permit + 2 deny" but actual is 9 (2 ingress permit + 4 runtime-egress permit + 3 deny). Fix: updated both numbers.

- #6 [missing-recovery] README:126 and :136 - Destroy-side note implied "first destroy fails-fast, re-run succeeds". Reality: terraform polls AWS indefinitely on the runtime-subnet DependencyViolation for 15-20+ minutes before erroring out, and even after the first error a re-run can fail again because AWS' async ENI cleanup is slower than the README implies. The blocking ENI is an `agentic_ai` type with an `ela-attach-*` attachment owned by `amazon-aws` - customers cannot detach it manually (`OperationNotPermitted: You are not allowed to manage 'ela-attach' attachments`). Fix: rewrote both the in-line Destroy note and the Troubleshooting entry to describe the actual hang-then-error sequence, the AWS-managed ENI, and the `aws ec2 describe-network-interfaces` command to check when it's safe to re-run.

## Test scenarios

| # | Scenario                                  | Result    |
|---|-------------------------------------------|-----------|
| 1 | UI ALB reachability (`/` + 8 child routes) | PASS (all 200) |
| 2 | 5 SmartGroups present on controller       | PASS      |
| 3 | 5 WebGroups present on controller         | PASS      |
| 4 | 9 DCF policies present, priorities match  | PASS      |
| 5 | Bedrock InvokeModel via UI                | MANUAL    |
| 6 | api.openai.com DENY via UI                | MANUAL    |
| 7 | example-attacker.com DENY via UI          | MANUAL    |
| 8 | DNS TXT 8.8.8.8 DENY via UI               | MANUAL    |
| 9 | CoPilot Topology + DCF Monitor inspection | MANUAL    |

MANUAL scenarios require a browser on the ui_ingress_cidrs allowlisted IP; they were not run in this CLI-only QA pass. The CLI-verifiable scenarios all confirm the DCF state is consistent with README claims.

## Out-of-scope follow-up (NOT fixed)

A spot-check during the README review surfaced a contradiction between Architecture/Test-section claims (selective TLS decryption on rule -29-) and Known Limitations line 148 ("No TLS decryption"). Resolution requires PRD-level context this run did not establish. Flag for the next QA pass.

## Resources verified clean (or NOT clean)

- Terraform state at PR time: 3 resources still in state pending AWS ENI release (`aws_vpc.agentcore`, `aws_subnet.agentcore_runtime`, `aws_security_group.runtime`), plus 1 data source.
- AWS orphans by tag `Blueprint=agentcore-vca`: 1 VPC (`vpc-04a3b5714658e7781`), 1 subnet (`subnet-091b5c2fc00dd10c2`), 0 EC2 instances, 0 ECR repos.
- Controller: 0 SmartGroups remaining with `agentcore-vca` prefix.

### Manual cleanup if the background retry loop times out

```bash
cd blueprints/agentcore-aws

# 1. Wait for the AgentCore Runtime ENI to be released by AWS.
aws ec2 describe-network-interfaces --region us-east-2 \
  --filters Name=subnet-id,Values=subnet-091b5c2fc00dd10c2 \
  --query 'NetworkInterfaces | length(@)' --output text
# Repeat until output is 0.

# 2. Run destroy.
source ~/Documents/Scripting/chris-avx-lab/controller_env_ga.sh
export TF_VAR_controller_ip="${AVIATRIX_CONTROLLER_IP}" \
       TF_VAR_controller_username="${AVIATRIX_USERNAME}" \
       TF_VAR_controller_password="${AVIATRIX_PASSWORD}" \
       TF_VAR_aviatrix_aws_account_name=AWS
terraform destroy -auto-approve
```

