### PR TITLE
aws-eks-singlecluster: single-cluster EKS spoke-in-a-box + reusable modules

### DIFF
--- a/.github/scripts/validate-blueprint.sh
+++ b/.github/scripts/validate-blueprint.sh
@@ -68,6 +68,16 @@ else
 fi
 
 # --------------------------------------------------------------------
+# terraform validate triggers provider config validation, and the Aviatrix
+# provider declares controller_ip/username/password as required. validate never
+# connects to the controller, so dummy values satisfy the schema offline. Real
+# creds exported by the caller (e.g. a deploy job) take precedence.
+# --------------------------------------------------------------------
+export AVIATRIX_CONTROLLER_IP="${AVIATRIX_CONTROLLER_IP:-127.0.0.1}"
+export AVIATRIX_USERNAME="${AVIATRIX_USERNAME:-validate}"
+export AVIATRIX_PASSWORD="${AVIATRIX_PASSWORD:-validate-only}"
+
+# --------------------------------------------------------------------
 # Tier 1.1 / 1.2 — terraform init -backend=false + validate per leaf
 # --------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Blueprints are **complete, deployable lab environments** that demonstrate Aviatr
 | Blueprint | Description | Cloud(s) | Tier | Status |
 |-----------|-------------|----------|------|--------|
 | [aws-eks-multicluster](blueprints/aws-eks-multicluster/) | Multi-cluster EKS with Aviatrix transit and Distributed Cloud Firewall | AWS | Verified | ✅ Available |
+| [aws-eks-singlecluster](blueprints/aws-eks-singlecluster/) | Single-cluster EKS spoke-in-a-box with DCF egress filtering; attach to any transit | AWS | Verified | ✅ Available |
 | [azure-aks-multicluster](blueprints/azure-aks-multicluster/) | Multi-cluster AKS with Aviatrix transit and DCF (Cilium overlay, AppGW + NGINX two-tier ingress) | Azure | Verified | ✅ Available |
 | [prevent-lateral-movement-vm-tags](blueprints/prevent-lateral-movement-vm-tags/) | Zero Trust segmentation using DCF and VM tags to prevent lateral movement | AWS | Community | ✅ Available |
 | [zero-trust-segmentation](blueprints/zero-trust-segmentation/) | Zero Trust workload segmentation with DCF SmartGroups | AWS | Community | ✅ Available |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Blueprints are **complete, deployable lab environments** that demonstrate Aviatr
 | Blueprint | Description | Cloud(s) | Tier | Status |
 |-----------|-------------|----------|------|--------|
 | [aws-eks-multicluster](blueprints/aws-eks-multicluster/) | Multi-cluster EKS with Aviatrix transit and Distributed Cloud Firewall | AWS | Verified | ✅ Available |
-| [aws-eks-singlecluster](blueprints/aws-eks-singlecluster/) | Single-cluster EKS spoke-in-a-box with DCF egress filtering; attach to any transit | AWS | Verified | ✅ Available |
+| [aws-eks-singlecluster](blueprints/aws-eks-singlecluster/) | Single-cluster EKS spoke-in-a-box with DCF egress filtering; attach to any transit | AWS | — | 🚧 Work in progress |
 | [azure-aks-multicluster](blueprints/azure-aks-multicluster/) | Multi-cluster AKS with Aviatrix transit and DCF (Cilium overlay, AppGW + NGINX two-tier ingress) | Azure | Verified | ✅ Available |
 | [prevent-lateral-movement-vm-tags](blueprints/prevent-lateral-movement-vm-tags/) | Zero Trust segmentation using DCF and VM tags to prevent lateral movement | AWS | Community | ✅ Available |
 | [zero-trust-segmentation](blueprints/zero-trust-segmentation/) | Zero Trust workload segmentation with DCF SmartGroups | AWS | Community | ✅ Available |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Blueprints are **complete, deployable lab environments** that demonstrate Aviatr
 | Blueprint | Description | Cloud(s) | Tier | Status |
 |-----------|-------------|----------|------|--------|
 | [aws-eks-multicluster](blueprints/aws-eks-multicluster/) | Multi-cluster EKS with Aviatrix transit and Distributed Cloud Firewall | AWS | Verified | ✅ Available |
-| [aws-eks-singlecluster](blueprints/aws-eks-singlecluster/) | Single-cluster EKS spoke-in-a-box with DCF egress filtering; attach to any transit | AWS | — | 🚧 Work in progress |
+| [aws-eks-singlecluster](blueprints/aws-eks-singlecluster/) | Single-cluster EKS spoke-in-a-box with DCF egress filtering; attach to any transit | AWS | Community | ✅ Available |
 | [azure-aks-multicluster](blueprints/azure-aks-multicluster/) | Multi-cluster AKS with Aviatrix transit and DCF (Cilium overlay, AppGW + NGINX two-tier ingress) | Azure | Verified | ✅ Available |
 | [prevent-lateral-movement-vm-tags](blueprints/prevent-lateral-movement-vm-tags/) | Zero Trust segmentation using DCF and VM tags to prevent lateral movement | AWS | Community | ✅ Available |
 | [zero-trust-segmentation](blueprints/zero-trust-segmentation/) | Zero Trust workload segmentation with DCF SmartGroups | AWS | Community | ✅ Available |

--- a/blueprints/aws-eks-singlecluster/README.md
+++ b/blueprints/aws-eks-singlecluster/README.md
@@ -1,0 +1,390 @@
+# Single-Cluster EKS Spoke-in-a-Box Secured by the Aviatrix Cloud Native Security Fabric
+
+This blueprint deploys a **single EKS cluster** inside a self-contained "spoke-in-a-box" AWS VPC, fronted by an Aviatrix spoke gateway that performs **Distributed Cloud Firewall (DCF) egress filtering**. It demonstrates the Aviatrix Cloud Native Security Fabric (CNSF) for Kubernetes — threat prevention (GeoBlock + ThreatIntel), egress allow-listing with WebGroups (SNI/URL filtering), and Zero Trust enforcement — on a deliberately minimal footprint.
+
+The blueprint deploys **standalone by default** (no transit attachment). It is built on the reusable [`modules/aws-eks-spoke-vpc`](../../modules/aws-eks-spoke-vpc/README.md) module, so an operator can attach the spoke to any transit (Aviatrix, AWS Transit Gateway, or AWS Cloud WAN) post-deploy by setting one variable and re-applying. It is a single-cluster derivative of [`aws-eks-multicluster`](../aws-eks-multicluster/README.md).
+
+> [!TIP]
+> **🤖 Optimized for Claude Code** — Run `/deploy-blueprint aws-eks-singlecluster` for AI-guided deployment with prerequisite checks and automated orchestration, or `/analyze-blueprint aws-eks-singlecluster` for resource and cost details. [Get Claude Code](https://claude.ai/code)
+
+---
+
+## Architecture
+
+![Architecture Diagram](architecture.svg)
+
+A single spoke VPC (`10.30.0.0/23`) contains four subnet tiers across two AZs:
+
+- **`avx_public` (/28)** — Aviatrix spoke gateway. All cluster egress is SNAT'd here (`single_ip_snat`) and filtered by DCF.
+- **`lb_public` (/26)** — internet-facing ALB created by the AWS Load Balancer Controller for the Gatus Ingress.
+- **`infra_private` (/26)** — EKS managed node group (2× t3.large SPOT).
+- **`pod_private` (/17)** — pod ENIs from the secondary CIDR (`100.64.0.0/16`) via VPC CNI custom networking.
+
+Egress data flow: **Pod / Node → Aviatrix Spoke Gateway (DCF + SNAT) → IGW → Internet**. The DCF ruleset blocks GeoBlocked countries and threat-intel IPs first, then permits only EKS-required AWS services and an allow-list of domains (kubernetes.io, GitHub Aviatrix repos, npm).
+
+The spoke is **standalone by default** — there is no east-west connectivity until a transit target is supplied (see below). A dashed line in the diagram shows the optional post-deploy transit attachment.
+
+### Transit type × pod-CIDR mode matrix
+
+The underlying module is driven by `transit_type` and `pod_cidr_mode`. Their interaction determines SNAT shape and route-table behavior (full detail in the [module README](../../modules/aws-eks-spoke-vpc/README.md#transit-type-and-pod-cidr-mode-matrix)):
+
+| transit_type | pod_cidr_mode | SNAT | Route programming | Use-case |
+|---|---|---|---|---|
+| `aws_tgw` (default) | `non_routable` (default) | `single_ip_snat` | None (standalone); native routes when `aws_tgw_id` set | **Default standalone**; TGW attachment wired out-of-band |
+| `aws_tgw` | `routable` | `single_ip_snat` | Pod east-west via TGW when `aws_tgw_id` set | Unique pod CIDRs advertised into TGW |
+| `aws_cloudwan` | `non_routable` | `single_ip_snat` | None (standalone); native routes when ARN set | Cloud WAN attachment wired out-of-band |
+| `aws_cloudwan` | `routable` | `single_ip_snat` | Pod east-west via Cloud WAN when ARN set | Unique pod CIDRs advertised into Cloud WAN |
+| `aviatrix` | `non_routable` | Custom `aviatrix_gateway_snat` (3 policies) | Programmed by Aviatrix controller post-attach | Full Aviatrix fabric, overlapping pod CIDRs |
+| `aviatrix` | `routable` | Custom `aviatrix_gateway_snat` (2 policies) | Programmed by Aviatrix controller post-attach | Full Aviatrix fabric, unique pod CIDRs |
+
+**Standalone default explained:** with `transit_type = "aws_tgw"`, `pod_cidr_mode = "non_routable"`, and an **empty** `aws_tgw_id`, the spoke gateway is deployed with `single_ip_snat = true` and **no** route-table entries are programmed. The cluster has full filtered internet egress but no east-west reachability. To attach to a transit, set the relevant id/name for your `transit_type` and re-apply the `network` layer — the module then takes over route management.
+
+---
+
+## Prerequisites
+
+Before deploying, ensure the following are in place. See [docs/prerequisites/](../../docs/prerequisites/README.md) for detailed install guides.
+
+### Aviatrix Infrastructure
+
+| Component | Requirement | Notes |
+|-----------|-------------|-------|
+| **[Aviatrix Control Plane](../../docs/prerequisites/aviatrix-controller.md)** | Compatible with provider ~> 8.2 | Controller + CoPilot, or an Aviatrix Cloud Fabric subscription |
+| **AWS Account Onboarded** | Account registered in the Controller | Use the exact account name for `aviatrix_aws_account_name` |
+| **Controller IAM role for EKS** | `aviatrix-role-app` ARN | Passed as `aviatrix_controller_role_arn` to the cluster layer |
+
+### Local Tools
+
+| Tool | Version | Installation | Purpose |
+|------|---------|--------------|---------|
+| **Terraform** | >= 1.9 | [Guide](../../docs/prerequisites/terraform.md) | Infrastructure provisioning |
+| **AWS CLI** | v2 | [Guide](../../docs/prerequisites/aws-cli.md) | AWS auth + EKS `get-token` |
+| **kubectl** | Latest | [Guide](../../docs/prerequisites/kubectl.md) | Cluster interaction, applying k8s-apps |
+| **helm** | v3 | [Helm install](https://helm.sh/docs/intro/install/) | ALB Controller / k8s-firewall charts (installed via Terraform) |
+
+### Required Access
+
+- AWS credentials with permission to create VPC, EKS, EC2, IAM, ELB, and EKS add-on resources (`AdministratorAccess` is sufficient for demo).
+- Aviatrix Controller credentials exported as environment variables (see below).
+
+### Environment Variables
+
+The Aviatrix provider authenticates via environment variables — required for `plan` and `apply` on the `network` and `cluster` layers:
+
+```bash
+export AVIATRIX_CONTROLLER_IP="<controller-ip-or-hostname>"
+export AVIATRIX_USERNAME="<username>"
+export AVIATRIX_PASSWORD="<password>"
+export AWS_REGION="us-east-2"   # or use an AWS_PROFILE
+```
+
+---
+
+## Resources Created
+
+| Component | Resource | Qty | Size / Detail | Hourly | Monthly (~730h) |
+|-----------|----------|-----|---------------|--------|-----------------|
+| Aviatrix Spoke Gateway | EC2 | 1 | t3.medium, single_ip_snat, no HA | ~$0.04 | ~$30 |
+| EKS Control Plane | EKS | 1 | Kubernetes 1.34 (AWS-managed) | $0.10 | $73 |
+| EKS Node Group | EC2 | 2 (desired) | t3.large SPOT, min 1 / max 3 | ~$0.05 | ~$36 |
+| ALB (Gatus Ingress) | ELBv2 | 1 | internet-facing, IP target type | ~$0.025 + LCU | ~$20 |
+| VPC + subnets + IGW | Networking | 1 VPC | 4 subnet tiers × 2 AZs, no NAT GW | Free | $0 |
+| DCF SmartGroups / WebGroups / Ruleset | Aviatrix | — | Threat prevention + egress allow-list | — | — |
+| Pod / node EBS | gp3 | ~2 | ~20 GB each | — | ~$3 |
+
+**Estimated cost:** **~$0.22/hour (~$160/month)** in us-east-2 when running.
+
+> Excludes Aviatrix licensing (PAYG or BYOL), ALB LCU / data-processing charges, and internet egress data transfer. NAT Gateways are intentionally **not** deployed — Aviatrix SNAT replaces them.
+
+---
+
+## Deployment
+
+The blueprint is a **4-layer** deployment. Deploy in order: **network → cluster → nodes → k8s-apps**.
+
+```
+network/    Layer 1  Spoke VPC (module), Aviatrix spoke gateway, DCF SmartGroups/WebGroups/Ruleset
+cluster/    Layer 2  EKS control plane, OIDC/IRSA, VPC CNI addon, Controller onboarding
+nodes/      Layer 3  k8s-firewall Helm chart, ENIConfig, node group, CoreDNS, ALB Controller
+k8s-apps/   Layer 4  Gatus (kubectl apply); optional DCF CRD examples
+```
+
+Each layer reads the previous layer's outputs via `data "terraform_remote_state"` (local state only).
+
+> **Automated:** `/deploy-blueprint aws-eks-singlecluster` orchestrates all layers with prerequisite checks.
+
+### Step 0: Set environment variables
+
+```bash
+export AVIATRIX_CONTROLLER_IP="<controller-ip>"
+export AVIATRIX_USERNAME="<username>"
+export AVIATRIX_PASSWORD="<password>"
+aws sts get-caller-identity   # verify AWS access
+```
+
+### Step 1: Network layer (~5-8 min)
+
+```bash
+cd network/
+terraform init -upgrade
+cp ../terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars: aviatrix_aws_account_name (required), aws_region, name_prefix.
+# Leave transit_type/aws_tgw_id at defaults for a standalone spoke.
+terraform apply
+```
+
+Creates: spoke VPC (`10.30.0.0/23`) with the four subnet tiers, the Aviatrix spoke gateway, and the DCF ruleset (SmartGroups, WebGroups, threat-prevention + egress allow rules).
+
+### Step 2: Cluster layer (~10-15 min)
+
+```bash
+cd ../cluster/
+terraform init
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars: set aviatrix_controller_role_arn to your Controller's IAM role ARN
+#   (e.g., arn:aws:iam::123456789012:role/aviatrix-role-app)
+terraform apply
+```
+
+Creates: EKS control plane (K8s 1.34), OIDC provider, IRSA roles (ALB Controller, ExternalDNS), pod security group, and VPC CNI addon with custom networking. Onboards the cluster to the Aviatrix Controller.
+
+### Step 3: Nodes layer (~5-7 min)
+
+```bash
+cd ../nodes/
+terraform init
+terraform apply
+```
+
+Creates (in order): k8s-firewall Helm chart (FirewallPolicy + WebGroupPolicy CRDs) → ENIConfig (one per AZ) → managed node group (2× t3.large SPOT) → CoreDNS addon → AWS Load Balancer Controller (Helm).
+
+### Step 4: Configure kubectl + deploy k8s-apps (~1-2 min)
+
+```bash
+cd ../cluster/
+$(terraform output -raw configure_kubectl)
+kubectl get nodes   # should show 2 Ready nodes
+
+# Deploy Gatus (ClusterIP Service + ALB Ingress)
+kubectl create namespace gatus
+kubectl apply -f ../k8s-apps/gatus.yaml
+
+# Get the ALB hostname (provisioning takes 2-3 min)
+kubectl get ingress -n gatus
+```
+
+Open the ALB hostname in a browser to view the Gatus dashboard.
+
+**Total deployment time:** ~25-35 minutes.
+
+---
+
+## Variables
+
+### Network layer (`network/`) — also the top-level `terraform.tfvars.example`
+
+| Variable | Description | Type | Default | Required |
+|----------|-------------|------|---------|----------|
+| `name_prefix` | Prefix for all resource names | string | `"eks-singlecluster"` | no |
+| `aviatrix_aws_account_name` | AWS account name registered in the Controller | string | — | **yes** |
+| `aws_region` | AWS region | string | `"us-east-2"` | no |
+| `vpc_cidr` | Primary VPC CIDR (/23) | string | `"10.30.0.0/23"` | no |
+| `pod_cidr` | Secondary CIDR for pods | string | `"100.64.0.0/16"` | no |
+| `transit_type` | `aviatrix` \| `aws_tgw` \| `aws_cloudwan` | string | `"aws_tgw"` | no |
+| `pod_cidr_mode` | `routable` \| `non_routable` | string | `"non_routable"` | no |
+| `transit_gw_name` | Aviatrix transit gateway name (only when `transit_type = aviatrix`) | string | `""` | no |
+| `aws_tgw_id` | AWS TGW ID (only when `transit_type = aws_tgw`); empty = standalone | string | `""` | no |
+| `aws_cloudwan_core_network_arn` | Cloud WAN Core Network ARN (only when `transit_type = aws_cloudwan`); empty = standalone | string | `""` | no |
+
+### Cluster layer (`cluster/`)
+
+| Variable | Description | Type | Default | Required |
+|----------|-------------|------|---------|----------|
+| `aws_region` | AWS region | string | `"us-east-2"` | no |
+| `kubernetes_version` | EKS Kubernetes version | string | `"1.34"` | no |
+| `aviatrix_controller_role_arn` | IAM role ARN used by the Controller to access the cluster | string | — | **yes** |
+
+### Nodes layer (`nodes/`)
+
+| Variable | Description | Type | Default | Required |
+|----------|-------------|------|---------|----------|
+| `aws_region` | AWS region | string | `"us-east-2"` | no |
+| `alb_controller_chart_version` | AWS Load Balancer Controller Helm chart version | string | `"1.10.1"` | no |
+| `node_group_config` | Node group sizing/instance object (`min_size`, `max_size`, `desired_size`, `instance_types`, `capacity_type`) | object | `{1, 3, 2, ["t3.large"], "SPOT"}` | no |
+
+---
+
+## Outputs
+
+### Network layer
+
+| Output | Description |
+|--------|-------------|
+| `vpc_id` | Spoke VPC ID |
+| `vpc_cidr` / `secondary_cidr` | Primary VPC CIDR / pod CIDR |
+| `availability_zones` | AZs used by the spoke |
+| `cluster_name` | Derived EKS cluster name (`<name_prefix>-cluster`) |
+| `lb_public_subnet_ids` / `infra_private_subnet_ids` / `pod_private_subnet_ids` | Subnet IDs per tier |
+| `spoke_gateway_name` / `spoke_gateway_private_ip` | Aviatrix spoke gateway name and SNAT target IP |
+| `dcf_ruleset_uuid` | UUID of the DCF egress ruleset |
+| `smartgroup_cluster_vpc_uuid` | UUID of the cluster VPC SmartGroup |
+| `webgroup_github_aviatrix_uuid` | UUID of the GitHub Aviatrix WebGroup (for CRD reference) |
+
+### Cluster layer
+
+| Output | Description |
+|--------|-------------|
+| `cluster_name` / `cluster_version` / `cluster_endpoint` | EKS cluster identity |
+| `cluster_certificate_authority_data` | Base64 CA data (sensitive) |
+| `cluster_primary_security_group_id` / `node_security_group_id` / `pod_security_group_id` | Security group IDs |
+| `oidc_provider_arn` / `cluster_oidc_issuer_url` | OIDC / IRSA |
+| `alb_controller_role_arn` / `external_dns_role_arn` | IRSA role ARNs |
+| `configure_kubectl` | `aws eks update-kubeconfig` command |
+
+### Nodes layer
+
+| Output | Description |
+|--------|-------------|
+| `node_group_id` / `node_group_arn` / `node_group_status` | Node group identity and status |
+| `node_group_autoscaling_group_names` | ASG names backing the node group |
+| `iam_role_arn` | Node group IAM role ARN |
+
+---
+
+## Test Scenarios
+
+### Scenario 1: Egress allow-list (DCF permits)
+
+The Gatus dashboard's **Egress** group probes `kubernetes.io`, the Aviatrix GitHub repos, and `registry.npmjs.org` — all explicitly allow-listed via WebGroups in `network/dcf.tf`.
+
+```bash
+kubectl get ingress -n gatus   # open the ALB hostname in a browser
+```
+
+**Expected:** all Egress endpoints are **green** (HTTP 200).
+
+### Scenario 2: Threat prevention (DCF blocks)
+
+The **Threats** group probes a GeoBlocked destination (Iran) and a threat-intel IP, matched by the GeoBlock (IR/KP/RU) and ThreatIntel (major/critical) SmartGroups.
+
+**Expected:** Threat endpoints are **red / blocked**. (The threat-feed IP must be present in your current ThreatGuard feed — update it in `gatus.yaml` if your feed differs.)
+
+### Scenario 3: Verify in CoPilot
+
+1. **Security > Distributed Cloud Firewall** — confirm the `<name_prefix>-egress` ruleset and its rules.
+2. **FlowIQ** — generate traffic from Gatus and confirm permitted flows for allow-listed domains and dropped flows for the threat destinations.
+3. **Topology** — confirm the spoke gateway and VPC appear.
+
+### Scenario 4: East-west after attaching to a transit
+
+The spoke is standalone by default (no east-west). To validate east-west:
+
+```bash
+cd network/
+# In terraform.tfvars set aws_tgw_id (or transit_gw_name / aws_cloudwan_core_network_arn
+# to match transit_type), then:
+terraform apply
+```
+
+The module then programs east-west routes. Verify reachability to another spoke/VPC behind the same transit.
+
+---
+
+## CoPilot Verification
+
+| View | What to confirm |
+|------|-----------------|
+| **Topology** | Spoke gateway + VPC visible; transit edge appears once attached |
+| **FlowIQ** | Permitted egress to allow-listed domains; dropped flows to threat destinations |
+| **Security > DCF** | `<name_prefix>-egress` ruleset, SmartGroups (cluster VPC, GeoBlock, ThreatIntel), WebGroups |
+| **Security > Threat Prevention** | GeoBlock / ThreatIQ hits on the blocked probes |
+
+---
+
+## Troubleshooting
+
+### No east-west connectivity
+
+**Symptom:** pods/nodes can reach the internet but not other VPCs.
+
+**Cause:** this is expected — the spoke is **standalone** by default. Set `aws_tgw_id` (or `transit_gw_name` / `aws_cloudwan_core_network_arn` matching your `transit_type`) in `network/terraform.tfvars` and re-apply. The module then programs east-west routes.
+
+### Aviatrix-programmed routes disappear after apply
+
+**Cause:** route tables with inline routes drop controller-programmed entries on re-apply. The module already applies `lifecycle { ignore_changes = [route] }` to all route tables — do not remove it.
+
+### Aviatrix provider auth errors during plan/apply
+
+**Symptom:** the `network` or `cluster` layer fails authenticating to the Controller.
+
+**Solution:** export `AVIATRIX_CONTROLLER_IP`, `AVIATRIX_USERNAME`, and `AVIATRIX_PASSWORD` before running Terraform. The provider has no other auth source.
+
+### Pods can't reach EC2 metadata / ALB stuck pending
+
+**Cause:** pods use the non-routable secondary CIDR (`100.64.0.0/16`); pod traffic is SNAT'd to the spoke gateway via `single_ip_snat`. The ALB Controller Helm release sets `vpcId` and `region` explicitly to work around the metadata restriction. Verify the ALB Controller deployment is running:
+
+```bash
+kubectl get deployment -n kube-system aws-load-balancer-controller
+```
+
+### Threat probe shows green (not blocked)
+
+**Cause:** the threat-feed IP in `gatus.yaml` is not in your current ThreatGuard feed. Replace it with an IP present in your feed, or rely on the GeoBlock probe.
+
+### Terraform "chicken-and-egg" / count errors
+
+**Cause:** layers deployed out of order. Always deploy **network → cluster → nodes**, and confirm the prior layer's `terraform.tfstate` exists before the next.
+
+---
+
+## Cleanup
+
+Destroy in **reverse order**. Remove Kubernetes LoadBalancer/Ingress resources first so the ALB is deleted before its VPC/subnets.
+
+```bash
+# Step 1: remove k8s-apps (deletes the ALB)
+kubectl delete -f k8s-apps/gatus.yaml
+kubectl delete namespace gatus
+sleep 60   # wait for the ALB to be torn down
+
+# Step 2: nodes layer
+cd nodes/ && terraform destroy
+
+# Step 3: cluster layer
+cd ../cluster/ && terraform destroy
+
+# Step 4: network layer (spoke GW, VPC, DCF policies)
+cd ../network/ && terraform destroy
+```
+
+### Verify cleanup
+
+```bash
+aws ec2 describe-vpcs --filters "Name=tag:Blueprint,Values=aws-eks-singlecluster"
+# Expect: no VPCs returned
+```
+
+> If a destroy leaves stale DCF SmartGroups/WebGroups on the Controller, remove them from CoPilot **Security > DCF**.
+
+---
+
+## Tested With
+
+| Component | Version |
+|-----------|---------|
+| Terraform | 1.14 |
+| AWS Provider | ~> 6.0 |
+| Aviatrix Provider | 8.2.x |
+| `terraform-aws-modules/eks/aws` | ~> 21.x |
+| Kubernetes (EKS) | 1.34 |
+| Helm provider | ~> 2.x |
+
+> The blueprint may work with other versions; these are the versions used for validation.
+
+---
+
+## Related
+
+- [`modules/aws-eks-spoke-vpc`](../../modules/aws-eks-spoke-vpc/README.md) — the spoke-in-a-box VPC module (transit/pod-CIDR matrix, SNAT, route programming).
+- [`aws-eks-multicluster`](../aws-eks-multicluster/README.md) — the multi-cluster blueprint this is derived from.
+- `k8s-apps/dcf-crd/` — standalone FirewallPolicy / WebGroupPolicy CRD examples for in-cluster, namespace-level controls.

--- a/blueprints/aws-eks-singlecluster/architecture.svg
+++ b/blueprints/aws-eks-singlecluster/architecture.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 640" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#37474f"/>
+    </marker>
+    <marker id="arrowDash" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#90a4ae"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="960" height="640" fill="#fafafa"/>
+  <text x="480" y="32" text-anchor="middle" font-size="22" font-weight="bold" fill="#263238">aws-eks-singlecluster — EKS spoke-in-a-box with Aviatrix DCF egress filtering</text>
+
+  <!-- Internet -->
+  <ellipse cx="120" cy="90" rx="70" ry="28" fill="#eceff1" stroke="#607d8b" stroke-width="2"/>
+  <text x="120" y="96" text-anchor="middle" font-size="15" fill="#263238">Internet</text>
+
+  <!-- IGW -->
+  <rect x="60" y="160" width="120" height="44" rx="6" fill="#fff3e0" stroke="#fb8c00" stroke-width="2"/>
+  <text x="120" y="187" text-anchor="middle" font-size="14" fill="#263238">Internet Gateway</text>
+
+  <!-- Internet <-> IGW -->
+  <line x1="120" y1="118" x2="120" y2="160" stroke="#37474f" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="130" y1="160" x2="130" y2="118" stroke="#37474f" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- VPC box -->
+  <rect x="40" y="230" width="660" height="380" rx="10" fill="#e3f2fd" stroke="#1976d2" stroke-width="2"/>
+  <text x="60" y="256" font-size="16" font-weight="bold" fill="#0d47a1">Spoke VPC  10.30.0.0/23  (us-east-2, 2 AZs)</text>
+
+  <!-- avx_public subnet w/ spoke GW -->
+  <rect x="60" y="276" width="280" height="92" rx="6" fill="#fff" stroke="#1976d2" stroke-width="1.5"/>
+  <text x="72" y="296" font-size="12" fill="#1565c0">avx_public  /28</text>
+  <rect x="72" y="306" width="256" height="52" rx="5" fill="#e8f5e9" stroke="#2e7d32" stroke-width="2"/>
+  <text x="200" y="328" text-anchor="middle" font-size="13" font-weight="bold" fill="#1b5e20">Aviatrix Spoke Gateway</text>
+  <text x="200" y="346" text-anchor="middle" font-size="11" fill="#33691e">DCF egress filtering + single_ip_snat</text>
+
+  <!-- lb_public subnet w/ ALB -->
+  <rect x="360" y="276" width="320" height="92" rx="6" fill="#fff" stroke="#1976d2" stroke-width="1.5"/>
+  <text x="372" y="296" font-size="12" fill="#1565c0">lb_public  /26</text>
+  <rect x="372" y="306" width="296" height="52" rx="5" fill="#fff8e1" stroke="#f9a825" stroke-width="2"/>
+  <text x="520" y="328" text-anchor="middle" font-size="13" font-weight="bold" fill="#e65100">ALB (Gatus Ingress)</text>
+  <text x="520" y="346" text-anchor="middle" font-size="11" fill="#ef6c00">internet-facing, target-type: ip</text>
+
+  <!-- infra_private subnet w/ EKS nodes -->
+  <rect x="60" y="388" width="280" height="92" rx="6" fill="#fff" stroke="#1976d2" stroke-width="1.5"/>
+  <text x="72" y="408" font-size="12" fill="#1565c0">infra_private  /26</text>
+  <rect x="72" y="418" width="256" height="52" rx="5" fill="#ede7f6" stroke="#5e35b1" stroke-width="2"/>
+  <text x="200" y="440" text-anchor="middle" font-size="13" font-weight="bold" fill="#4527a0">EKS Nodes</text>
+  <text x="200" y="458" text-anchor="middle" font-size="11" fill="#512da8">2x t3.large SPOT (min 1 / max 3)</text>
+
+  <!-- pod_private subnet w/ pods -->
+  <rect x="360" y="388" width="320" height="92" rx="6" fill="#fff" stroke="#1976d2" stroke-width="1.5"/>
+  <text x="372" y="408" font-size="12" fill="#1565c0">pod_private  /17  (secondary CIDR)</text>
+  <rect x="372" y="418" width="296" height="52" rx="5" fill="#e1f5fe" stroke="#0288d1" stroke-width="2"/>
+  <text x="520" y="440" text-anchor="middle" font-size="13" font-weight="bold" fill="#01579b">Pods  100.64.0.0/16</text>
+  <text x="520" y="458" text-anchor="middle" font-size="11" fill="#0277bd">VPC CNI custom networking (ENIConfig)</text>
+
+  <!-- EKS control plane -->
+  <rect x="60" y="500" width="620" height="80" rx="6" fill="#fce4ec" stroke="#c2185b" stroke-width="2"/>
+  <text x="370" y="528" text-anchor="middle" font-size="14" font-weight="bold" fill="#880e4f">EKS Control Plane (AWS-managed, K8s 1.34)</text>
+  <text x="370" y="550" text-anchor="middle" font-size="11" fill="#ad1457">OIDC / IRSA, VPC CNI addon, CoreDNS, AWS Load Balancer Controller</text>
+  <text x="370" y="568" text-anchor="middle" font-size="11" fill="#ad1457">Onboarded to Aviatrix Controller via controller role ARN</text>
+
+  <!-- node-to-pod relation -->
+  <line x1="328" y1="444" x2="372" y2="444" stroke="#37474f" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- egress path: nodes/pods -> spoke GW -> IGW -->
+  <line x1="200" y1="418" x2="200" y2="358" stroke="#2e7d32" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="160" y1="306" x2="125" y2="204" stroke="#2e7d32" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="120" y="262" font-size="10" fill="#2e7d32" transform="rotate(-60 120 262)">filtered egress</text>
+
+  <!-- Transit (faded) -->
+  <rect x="760" y="330" width="160" height="120" rx="10" fill="#f5f5f5" stroke="#bdbdbd" stroke-width="2" stroke-dasharray="6 4"/>
+  <text x="840" y="372" text-anchor="middle" font-size="15" font-weight="bold" fill="#9e9e9e">Transit</text>
+  <text x="840" y="394" text-anchor="middle" font-size="10" fill="#9e9e9e">Aviatrix /</text>
+  <text x="840" y="408" text-anchor="middle" font-size="10" fill="#9e9e9e">AWS TGW /</text>
+  <text x="840" y="422" text-anchor="middle" font-size="10" fill="#9e9e9e">Cloud WAN</text>
+
+  <!-- dashed arrow spoke GW -> transit -->
+  <path d="M330 332 C 520 332, 600 390, 758 390" fill="none" stroke="#90a4ae" stroke-width="2.5" stroke-dasharray="8 5" marker-end="url(#arrowDash)"/>
+  <text x="560" y="318" text-anchor="middle" font-size="11" fill="#607d8b">attach to transit (post-deploy, set transit id/arn)</text>
+
+  <text x="480" y="624" text-anchor="middle" font-size="11" fill="#78909c">Default: standalone spoke (transit_type = aws_tgw, pod_cidr_mode = non_routable, empty aws_tgw_id). No east-west until a transit target is supplied.</text>
+</svg>

--- a/blueprints/aws-eks-singlecluster/cluster/data.tf
+++ b/blueprints/aws-eks-singlecluster/cluster/data.tf
@@ -1,0 +1,8 @@
+# Data source to read network outputs
+data "terraform_remote_state" "network" {
+  backend = "local"
+
+  config = {
+    path = "../network/terraform.tfstate"
+  }
+}

--- a/blueprints/aws-eks-singlecluster/cluster/main.tf
+++ b/blueprints/aws-eks-singlecluster/cluster/main.tf
@@ -1,0 +1,58 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+# Aviatrix provider - uses environment variables for authentication:
+# AVIATRIX_CONTROLLER_IP, AVIATRIX_USERNAME, AVIATRIX_PASSWORD
+provider "aviatrix" {
+  skip_version_validation = true
+}
+
+locals {
+  cluster_name = data.terraform_remote_state.network.outputs.cluster_name
+}
+
+# Kubernetes provider - connects to EKS cluster using AWS CLI exec auth
+# This allows Terraform to manage Kubernetes resources without requiring kubectl to be pre-configured
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args = [
+      "eks",
+      "get-token",
+      "--cluster-name",
+      local.cluster_name,
+      "--region",
+      var.aws_region
+    ]
+  }
+}
+
+#####################
+# EKS Cluster (Control Plane Only)
+#####################
+
+module "eks" {
+  source = "../../../modules/aws-eks-cluster"
+
+  cluster_name       = local.cluster_name
+  kubernetes_version = var.kubernetes_version
+  vpc_id             = data.terraform_remote_state.network.outputs.vpc_id
+  subnet_ids         = data.terraform_remote_state.network.outputs.infra_private_subnet_ids
+  pod_subnet_ids     = data.terraform_remote_state.network.outputs.pod_private_subnet_ids
+  availability_zones = data.terraform_remote_state.network.outputs.availability_zones
+  region             = var.aws_region
+
+  # Aviatrix Controller onboarding - role ARN for EKS access
+  aviatrix_controller_role_arn = var.aviatrix_controller_role_arn
+  enable_aviatrix_onboarding   = true
+
+  tags = {
+    Environment = "demo"
+    Terraform   = "true"
+  }
+}

--- a/blueprints/aws-eks-singlecluster/cluster/outputs.tf
+++ b/blueprints/aws-eks-singlecluster/cluster/outputs.tf
@@ -1,0 +1,93 @@
+# VPC output (needed for ALB Controller Helm install)
+output "vpc_id" {
+  description = "VPC ID where the cluster is deployed"
+  value       = module.eks.vpc_id
+}
+
+# Cluster identity outputs (used by node-group deployment)
+output "cluster_name" {
+  description = "EKS cluster name"
+  value       = module.eks.cluster_name
+}
+
+output "cluster_version" {
+  description = "Kubernetes version of the cluster"
+  value       = module.eks.cluster_version
+}
+
+output "cluster_service_cidr" {
+  description = "Kubernetes service CIDR"
+  value       = module.eks.cluster_service_cidr
+}
+
+output "cluster_endpoint" {
+  description = "EKS cluster endpoint"
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_certificate_authority_data" {
+  description = "Base64 encoded certificate data"
+  value       = module.eks.cluster_certificate_authority_data
+  sensitive   = true
+}
+
+# Security group outputs (used by node-group deployment)
+output "cluster_security_group_id" {
+  description = "Security group ID attached to the EKS cluster"
+  value       = module.eks.cluster_security_group_id
+}
+
+output "cluster_primary_security_group_id" {
+  description = "Primary security group ID of the cluster (for node groups)"
+  value       = module.eks.cluster_primary_security_group_id
+}
+
+output "node_security_group_id" {
+  description = "Security group ID for EKS nodes"
+  value       = module.eks.node_security_group_id
+}
+
+output "pod_security_group_id" {
+  description = "Security group ID for EKS pods"
+  value       = module.eks.pod_security_group_id
+}
+
+# OIDC outputs (for IRSA)
+output "cluster_oidc_issuer_url" {
+  description = "OIDC issuer URL"
+  value       = module.eks.cluster_oidc_issuer_url
+}
+
+output "oidc_provider_arn" {
+  description = "OIDC provider ARN"
+  value       = module.eks.oidc_provider_arn
+}
+
+# IAM role outputs
+output "alb_controller_role_arn" {
+  description = "IAM role ARN for AWS Load Balancer Controller"
+  value       = module.eks.alb_controller_role_arn
+}
+
+output "external_dns_role_arn" {
+  description = "IAM role ARN for ExternalDNS"
+  value       = module.eks.external_dns_role_arn
+}
+
+# Kubectl configuration
+output "configure_kubectl" {
+  description = "Command to configure kubectl"
+  value       = module.eks.configure_kubectl
+}
+
+# ENIConfig outputs
+output "eniconfig_manifests" {
+  description = "ENIConfig YAML manifests for custom networking"
+  value       = module.eks.eniconfig_manifests
+}
+
+# Helm values for ExternalDNS
+output "external_dns_helm_values" {
+  description = "Helm values for ExternalDNS deployment"
+  value       = module.eks.external_dns_helm_values
+}

--- a/blueprints/aws-eks-singlecluster/cluster/terraform.tfvars.example
+++ b/blueprints/aws-eks-singlecluster/cluster/terraform.tfvars.example
@@ -1,0 +1,3 @@
+aws_region                   = "us-east-2"
+kubernetes_version           = "1.34"
+aviatrix_controller_role_arn = "arn:aws:iam::ACCOUNT_ID:role/aviatrix-role-app"

--- a/blueprints/aws-eks-singlecluster/cluster/variables.tf
+++ b/blueprints/aws-eks-singlecluster/cluster/variables.tf
@@ -1,0 +1,16 @@
+variable "aws_region" {
+  description = "AWS region for all resources"
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version for EKS cluster"
+  type        = string
+  default     = "1.34"
+}
+
+variable "aviatrix_controller_role_arn" {
+  description = "IAM role ARN used by Aviatrix Controller to access EKS clusters (e.g., arn:aws:iam::ACCOUNT_ID:role/aviatrix-role-app)"
+  type        = string
+}

--- a/blueprints/aws-eks-singlecluster/cluster/versions.tf
+++ b/blueprints/aws-eks-singlecluster/cluster/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
+      version = "~> 2.30"
     }
   }
 }

--- a/blueprints/aws-eks-singlecluster/cluster/versions.tf
+++ b/blueprints/aws-eks-singlecluster/cluster/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 8.2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/blueprints/aws-eks-singlecluster/k8s-apps/dcf-crd/README.md
+++ b/blueprints/aws-eks-singlecluster/k8s-apps/dcf-crd/README.md
@@ -1,0 +1,142 @@
+# Aviatrix DCF Kubernetes CRD Policies
+
+This directory contains example Kubernetes CRD-based policies for Aviatrix Distributed Cloud Firewall (DCF).
+
+## Overview
+
+While base DCF policies are managed via Terraform (see `network-aviatrix/dcf.tf`), K8s CRD-based policies allow:
+
+- **Namespace-level control**: Apply policies scoped to specific namespaces
+- **Pod-label targeting**: Target pods by labels without needing Aviatrix-registered K8s clusters
+- **Self-service**: Allow dev teams to manage their own egress rules
+- **Temporary policies**: Quick changes without Terraform apply cycles
+
+## Prerequisites
+
+Install the Aviatrix K8s Firewall CRDs:
+
+```bash
+helm install --repo https://aviatrixsystems.github.io/k8s-firewall-charts k8s-firewall k8s-firewall
+```
+
+Verify CRD installation:
+
+```bash
+kubectl get crds | grep aviatrix
+```
+
+Expected output:
+```
+firewallpolicies.networking.aviatrix.com        2025-01-27T00:00:00Z
+webgrouppolicies.networking.aviatrix.com        2025-01-27T00:00:00Z
+```
+
+## Available CRDs
+
+### FirewallPolicy
+
+Full-featured firewall policy with SmartGroups and WebGroups defined inline.
+
+```yaml
+apiVersion: networking.aviatrix.com/v1alpha1
+kind: FirewallPolicy
+metadata:
+  name: my-policy
+  namespace: my-namespace
+spec:
+  rules:
+    - name: rule-name
+      selector:
+        matchLabels:
+          app: my-app
+      action: permit
+      protocol: tcp
+      ports:
+        - "443"
+      destinationSmartGroups:
+        - name: my-smartgroup
+      webGroups:
+        - name: my-webgroup
+
+  webGroups:
+    - name: my-webgroup
+      domains:
+        - "example.com"
+
+  smartGroups:
+    - name: my-smartgroup
+      selectors:
+        - cidr: 0.0.0.0/0
+```
+
+### WebGroupPolicy
+
+Simplified policy for web/HTTPS egress filtering.
+
+```yaml
+apiVersion: networking.aviatrix.com/v1alpha1
+kind: WebGroupPolicy
+metadata:
+  name: my-web-policy
+  namespace: my-namespace
+spec:
+  selector:
+    matchLabels:
+      app: my-app
+  action: permit
+  protocol: tcp
+  ports:
+    - "443"
+  domains:
+    - "api.example.com"
+```
+
+## Examples in This Directory
+
+| File | Purpose |
+|------|---------|
+| `firewallpolicy-infosec.yaml` | Allow infosec pods to access VirusTotal |
+| `webgrouppolicy-dev.yaml` | Allow dev namespace to access package registries |
+
+## Applying Policies
+
+```bash
+# Apply to frontend cluster
+kubectl config use-context frontend-cluster
+kubectl apply -f firewallpolicy-infosec.yaml
+
+# Apply to backend cluster
+kubectl config use-context backend-cluster
+kubectl apply -f webgrouppolicy-dev.yaml
+```
+
+## Verifying Policies
+
+```bash
+# Check policy status
+kubectl get firewallpolicies -A
+kubectl get webgrouppolicies -A
+
+# Check events for policy sync status
+kubectl get events -n <namespace> --field-selector reason=CreatePolicySuccess
+```
+
+## Policy Priority
+
+CRD-based policies are inserted at priority 50-99 in the DCF ruleset hierarchy:
+
+| Priority | Policy Type |
+|----------|-------------|
+| 0-9 | Threat Prevention (Terraform) |
+| 10-29 | Inter-VPC East-West (Terraform) |
+| 20-29 | EKS Required Services (Terraform) |
+| 30-49 | Explicit Egress Allow (Terraform) |
+| **50-99** | **K8s CRD Policies** |
+| 1000 | Default Deny (Terraform) |
+
+## Cleanup
+
+```bash
+kubectl delete -f firewallpolicy-infosec.yaml
+kubectl delete -f webgrouppolicy-dev.yaml
+```

--- a/blueprints/aws-eks-singlecluster/k8s-apps/dcf-crd/firewallpolicy-infosec.yaml
+++ b/blueprints/aws-eks-singlecluster/k8s-apps/dcf-crd/firewallpolicy-infosec.yaml
@@ -1,0 +1,49 @@
+#####################
+# FirewallPolicy CRD Example - InfoSec Namespace
+#
+# This policy demonstrates K8s-native DCF policy management.
+# Pods with label "app: infosec" can access security tools like VirusTotal.
+#
+# Prerequisites:
+#   helm install --repo https://aviatrixsystems.github.io/k8s-firewall-charts k8s-firewall k8s-firewall
+#
+# Apply:
+#   kubectl apply -f firewallpolicy-infosec.yaml
+#
+# Verify:
+#   kubectl get firewallpolicies -n gatus
+#   kubectl get events -n gatus
+#####################
+
+apiVersion: networking.aviatrix.com/v1alpha1
+kind: FirewallPolicy
+metadata:
+  name: infosec-egress
+  namespace: gatus
+spec:
+  rules:
+    - name: allow-virustotal
+      logging: true
+      selector:
+        matchLabels:
+          app: infosec
+      action: permit
+      protocol: tcp
+      ports:
+        - "443"
+      destinationSmartGroups:
+        - name: public-internet
+      webGroups:
+        - name: security-tools
+
+  webGroups:
+    - name: security-tools
+      domains:
+        - "www.virustotal.com"
+        - "virustotal.com"
+        - "*.virustotal.com"
+
+  smartGroups:
+    - name: public-internet
+      selectors:
+        - cidr: 0.0.0.0/0

--- a/blueprints/aws-eks-singlecluster/k8s-apps/dcf-crd/webgrouppolicy-dev.yaml
+++ b/blueprints/aws-eks-singlecluster/k8s-apps/dcf-crd/webgrouppolicy-dev.yaml
@@ -1,0 +1,50 @@
+#####################
+# WebGroupPolicy CRD Example - Dev Namespace
+#
+# This policy allows pods in the dev namespace to access
+# additional development resources not covered by the base Terraform policy.
+#
+# Use case: Developer needs to access a new API temporarily for testing.
+# Instead of modifying Terraform, apply a CRD-based policy.
+#
+# Prerequisites:
+#   helm install --repo https://aviatrixsystems.github.io/k8s-firewall-charts k8s-firewall k8s-firewall
+#
+# Apply:
+#   kubectl apply -f webgrouppolicy-dev.yaml
+#
+# Verify:
+#   kubectl get webgrouppolicies -n dev
+#   kubectl get events -n dev
+#####################
+
+apiVersion: networking.aviatrix.com/v1alpha1
+kind: WebGroupPolicy
+metadata:
+  name: dev-external-apis
+  namespace: dev
+spec:
+  selector:
+    matchLabels:
+      environment: development
+
+  action: permit
+  protocol: tcp
+  ports:
+    - "443"
+  logging: true
+
+  domains:
+    # Package registries
+    - "pypi.org"
+    - "*.pypi.org"
+    - "files.pythonhosted.org"
+    # Docker Hub
+    - "hub.docker.com"
+    - "registry-1.docker.io"
+    - "*.docker.io"
+    # GitHub (broader access for dev)
+    - "github.com"
+    - "*.github.com"
+    - "raw.githubusercontent.com"
+    - "api.github.com"

--- a/blueprints/aws-eks-singlecluster/k8s-apps/gatus.yaml
+++ b/blueprints/aws-eks-singlecluster/k8s-apps/gatus.yaml
@@ -1,0 +1,170 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend
+  namespace: gatus
+data:
+  config.yaml: |
+    storage:
+      type: memory
+    metrics: true
+    endpoints:
+      # Egress - Allowed Traffic
+      - name: "kubernetes.io"
+        group: "Egress"
+        url: "https://kubernetes.io"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      - name: "github.com/.../terraform-provider-aviatrix"
+        group: "Egress"
+        url: "https://github.com/AviatrixSystems/terraform-provider-aviatrix"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      - name: "github.com/.../avxlabs-docs"
+        group: "Egress"
+        url: "https://github.com/AviatrixSystems/avxlabs-docs"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      - name: "registry.npmjs.org"
+        group: "Egress"
+        url: "https://registry.npmjs.org"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      # Threats - Should be BLOCKED by DCF
+      - name: "GeoBlock - Iran"
+        group: "Threats"
+        url: "icmp://www.irna.ir"
+        interval: 60s
+        conditions: ["[CONNECTED] == true"]
+
+      # NOTE: This IP must appear in your Aviatrix ThreatGuard feed to be blocked.
+      # Verify against your current threat intelligence feed and replace if needed.
+      - name: "Threat Feed - Malicious IP"
+        group: "Threats"
+        url: "icmp://102.130.117.167"
+        interval: 60s
+        conditions: ["[CONNECTED] == true"]
+
+    ui:
+      logo: "https://aviatrix.com/wp-content/uploads/2019/10/cropped-Aviatrix-Logo@2x-1-32x32.png"
+      header: "EKS Single Cluster - ${HOSTNAME}"
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: frontend
+  namespace: gatus
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: gatus
+  labels:
+    app: frontend
+    cluster: frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      name: frontend
+      labels:
+        app: frontend
+        cluster: frontend
+    spec:
+      serviceAccountName: frontend
+      terminationGracePeriodSeconds: 5
+      containers:
+        - image: twinproduction/gatus:v5.14.0
+          imagePullPolicy: IfNotPresent
+          name: frontend
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 250m
+              memory: 100M
+            requests:
+              cpu: 50m
+              memory: 30M
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 5
+          volumeMounts:
+            - mountPath: /config
+              name: frontend-config
+      volumes:
+        - configMap:
+            name: frontend
+          name: frontend-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: gatus
+  labels:
+    app: frontend
+    service: frontend
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: frontend
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend-ingress
+  namespace: gatus
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/healthcheck-path: /health
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 8080

--- a/blueprints/aws-eks-singlecluster/network/dcf.tf
+++ b/blueprints/aws-eks-singlecluster/network/dcf.tf
@@ -1,0 +1,419 @@
+#####################
+# Distributed Cloud Firewall (DCF) Policies
+#
+# This file defines SmartGroups, WebGroups, and DCF Rulesets for the single-cluster EKS blueprint.
+#
+# Architecture:
+#   - Cluster VPC - single EKS cluster spoke VPC (named after var.name_prefix)
+#   - Pod CIDR (100.64.0.0/16) - SNAT'd to spoke gateway IP
+#
+# Policy Structure:
+#   1. Threat Prevention (GeoBlock, ThreatIQ) - Priority 0-9
+#   2. Egress with WebGroups (DPI) - Priority 20-49
+#
+# IMPORTANT LESSONS LEARNED:
+#   - DCF sees POST-SNAT traffic (spoke gateway IPs), not pod IPs
+#   - Use VPC type SmartGroups for source matching (match by VPC name)
+#   - Default deny with dst=0.0.0.0/0 blocks all traffic - DO NOT USE
+#
+# NOTE: K8s CRD-based policies (FirewallPolicy, WebGroupPolicy) can be applied
+# directly in-cluster for namespace-level controls. See k8s-apps/dcf-crd/ for examples.
+#####################
+
+#####################
+# SmartGroups - VPC Based (Infrastructure)
+# Match by VPC name for source traffic identification
+#####################
+
+resource "aviatrix_smart_group" "cluster_vpc" {
+  name = "sg-${var.name_prefix}-vpc"
+  selector {
+    match_expressions {
+      type = "vpc"
+      name = var.name_prefix
+    }
+  }
+}
+
+#####################
+# SmartGroups - External Feeds (Threats)
+#####################
+
+resource "aviatrix_smart_group" "geo_blocked" {
+  name = "sg-geo-blocked"
+  selector {
+    match_expressions {
+      external = "geo"
+      ext_args = {
+        country_iso_code = "IR"
+      }
+    }
+    match_expressions {
+      external = "geo"
+      ext_args = {
+        country_iso_code = "KP"
+      }
+    }
+    match_expressions {
+      external = "geo"
+      ext_args = {
+        country_iso_code = "RU"
+      }
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "threat_intel" {
+  name = "sg-threat-intel"
+  selector {
+    match_expressions {
+      external = "threatiq"
+      ext_args = {
+        severity = "major"
+      }
+    }
+    match_expressions {
+      external = "threatiq"
+      ext_args = {
+        severity = "critical"
+      }
+    }
+  }
+}
+
+#####################
+# Built-in SmartGroups
+# These are system-defined SmartGroups provided by Aviatrix
+#####################
+
+locals {
+  # Built-in "Public Internet" SmartGroup UUID
+  # This is a system-defined SmartGroup that matches all public (non-RFC1918) IPs
+  public_internet_uuid = "def000ad-0000-0000-0000-000000000001"
+}
+
+#####################
+# WebGroups - Allowed Egress (SNI Filter)
+#####################
+
+resource "aviatrix_web_group" "kubernetes_io" {
+  name = "wg-kubernetes-io"
+  selector {
+    match_expressions {
+      snifilter = "kubernetes.io"
+    }
+  }
+}
+
+resource "aviatrix_web_group" "npm_registry" {
+  name = "wg-npm-registry"
+  selector {
+    match_expressions {
+      snifilter = "registry.npmjs.org"
+    }
+    match_expressions {
+      snifilter = "npmjs.org"
+    }
+    match_expressions {
+      snifilter = "www.npmjs.com"
+    }
+  }
+}
+
+#####################
+# WebGroups - Allowed Egress (URL Path Filter)
+# Demonstrates granular URL-based filtering within allowed domain
+#####################
+
+resource "aviatrix_web_group" "github_aviatrix" {
+  name = "wg-github-aviatrix"
+  selector {
+    match_expressions {
+      urlfilter = "github.com/AviatrixSystems/terraform-provider-aviatrix"
+    }
+    match_expressions {
+      urlfilter = "github.com/AviatrixSystems/avxlabs-docs"
+    }
+  }
+}
+
+#####################
+# WebGroups - EKS Required Services (Catch-all)
+# These are required for EKS cluster operation
+#####################
+
+resource "aviatrix_web_group" "eks_required" {
+  name = "wg-eks-required"
+  selector {
+    ###################################
+    # ECR - AWS EKS Managed Account Only
+    # 602401143452 is AWS's EKS container account
+    ###################################
+    match_expressions {
+      snifilter = "602401143452.dkr.ecr.*.amazonaws.com"
+    }
+    match_expressions {
+      snifilter = "api.ecr.*.amazonaws.com"
+    }
+
+    ###################################
+    # ECR - Public Registry (read-only)
+    ###################################
+    match_expressions {
+      snifilter = "public.ecr.aws"
+    }
+    match_expressions {
+      snifilter = "api.ecr-public.*.amazonaws.com"
+    }
+
+    ###################################
+    # S3 - AWS-Owned EKS/SSM Buckets Only
+    # Locked to specific AWS bucket naming patterns
+    ###################################
+    # AL2023 package repositories
+    match_expressions {
+      snifilter = "al2023-repos-*.s3.dualstack.*.amazonaws.com"
+    }
+    # SSM agent/documents
+    match_expressions {
+      snifilter = "amazon-ssm-*.s3.*.amazonaws.com"
+    }
+    # SSM patch baselines
+    match_expressions {
+      snifilter = "patch-baseline-snapshot-*.s3.*.amazonaws.com"
+    }
+    # Kubernetes registry S3 storage layer
+    match_expressions {
+      snifilter = "prod-registry-k8s-io-*.s3.dualstack.*.amazonaws.com"
+    }
+    # EKS container layer storage
+    match_expressions {
+      snifilter = "prod-*-starport-layer-bucket.s3.*.amazonaws.com"
+    }
+
+    ###################################
+    # EC2 & Instance Services (APIs only)
+    ###################################
+    match_expressions {
+      snifilter = "ec2.*.amazonaws.com"
+    }
+    match_expressions {
+      snifilter = "ec2messages.*.amazonaws.com"
+    }
+
+    ###################################
+    # Systems Manager (SSM) APIs
+    ###################################
+    match_expressions {
+      snifilter = "ssm.*.amazonaws.com"
+    }
+    match_expressions {
+      snifilter = "ssmmessages.*.amazonaws.com"
+    }
+
+    ###################################
+    # Identity & Auth APIs
+    ###################################
+    match_expressions {
+      snifilter = "sts.*.amazonaws.com"
+    }
+    match_expressions {
+      snifilter = "cognito-identity.*.amazonaws.com"
+    }
+
+    ###################################
+    # DNS (global service)
+    ###################################
+    match_expressions {
+      snifilter = "route53.amazonaws.com"
+    }
+
+    ###################################
+    # Telemetry (EKS node telemetry)
+    ###################################
+    match_expressions {
+      snifilter = "pinpoint.*.amazonaws.com"
+    }
+
+    ###################################
+    # EKS API (control plane)
+    ###################################
+    match_expressions {
+      snifilter = "*.eks.amazonaws.com"
+    }
+
+    ###################################
+    # CloudFront - ECR/EKS CDN only
+    # TODO: Lock to specific distribution IDs if known
+    ###################################
+    match_expressions {
+      snifilter = "*.cloudfront.net"
+    }
+
+    ###################################
+    # Kubernetes Registry
+    ###################################
+    match_expressions {
+      snifilter = "registry.k8s.io"
+    }
+    match_expressions {
+      snifilter = "*.pkg.dev"
+    }
+  }
+}
+
+#####################
+# DCF Ruleset
+#####################
+
+data "aviatrix_dcf_attachment_point" "tf_before_ui" {
+  name = "TERRAFORM_BEFORE_UI_MANAGED"
+}
+
+resource "aviatrix_dcf_ruleset" "k8s_demo" {
+  name = "${var.name_prefix}-egress"
+  # TODO: revert to data source once Controller returns correct ID
+  # attach_to = data.aviatrix_dcf_attachment_point.tf_before_ui.id
+  attach_to = "defa11a1-3000-4001-0000-000000000000"
+
+  #############################
+  # THREAT PREVENTION (Priority 0-9)
+  # Block malicious traffic before any permit rules
+  #############################
+
+  rules {
+    name             = "Block GeoBlocked Countries"
+    action           = "DENY"
+    priority         = 0
+    protocol         = "ANY"
+    logging          = true
+    src_smart_groups = [aviatrix_smart_group.cluster_vpc.uuid]
+    dst_smart_groups = [aviatrix_smart_group.geo_blocked.uuid]
+  }
+
+  rules {
+    name             = "Block Threat Intel IPs"
+    action           = "DENY"
+    priority         = 1
+    protocol         = "ANY"
+    logging          = true
+    src_smart_groups = [aviatrix_smart_group.cluster_vpc.uuid]
+    dst_smart_groups = [aviatrix_smart_group.threat_intel.uuid]
+  }
+
+  #############################
+  # EGRESS - EKS Required (Priority 20)
+  # Allow EKS cluster operational traffic
+  #############################
+
+  rules {
+    name                 = "EKS Required AWS Services"
+    action               = "PERMIT"
+    priority             = 20
+    protocol             = "TCP"
+    logging              = true
+    src_smart_groups     = [aviatrix_smart_group.cluster_vpc.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.eks_required.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  #############################
+  # EGRESS - Allowed Destinations (Priority 30-49)
+  # Explicit allow for specific external services
+  #############################
+
+  rules {
+    name                 = "Allow kubernetes-io"
+    action               = "PERMIT"
+    priority             = 30
+    protocol             = "TCP"
+    logging              = true
+    src_smart_groups     = [aviatrix_smart_group.cluster_vpc.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.kubernetes_io.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  rules {
+    name                 = "Allow GitHub Aviatrix Repos"
+    action               = "PERMIT"
+    priority             = 31
+    protocol             = "TCP"
+    logging              = true
+    watch                = true
+    src_smart_groups     = [aviatrix_smart_group.cluster_vpc.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.github_aviatrix.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  rules {
+    name                 = "Allow npm Registry"
+    action               = "PERMIT"
+    priority             = 32
+    protocol             = "TCP"
+    logging              = true
+    src_smart_groups     = [aviatrix_smart_group.cluster_vpc.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.npm_registry.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  #############################
+  # PLACEHOLDER FOR K8S CRD POLICIES (Priority 50-99)
+  #
+  # K8s CRD-based policies (FirewallPolicy, WebGroupPolicy) are applied
+  # directly in the cluster and will be inserted at these priority levels.
+  # See k8s-apps/dcf-crd/ for CRD examples.
+  #
+  # Example CRD use cases:
+  #   - Namespace-specific egress rules (e.g., allow dev namespace to access test APIs)
+  #   - Pod-label based policies (e.g., allow app=infosec pods to access virustotal.com)
+  #   - Temporary rules for debugging/testing
+  #############################
+
+  #############################
+  # DEFAULT DENY - INTENTIONALLY OMITTED
+  #
+  # DO NOT add a default deny rule with dst_smart_groups = public_internet (0.0.0.0/0)
+  # because 0.0.0.0/0 matches ALL traffic including private RFC1918 addresses.
+  # This would block inter-VPC traffic even with explicit permit rules above.
+  #
+  # If you need default deny for internet egress:
+  #   1. Create a SmartGroup that excludes RFC1918 ranges
+  #   2. Or use WebGroups with explicit deny for specific domains
+  #   3. Or rely on AWS Security Groups / NACLs for internet egress control
+  #############################
+}
+
+#####################
+# Outputs
+#####################
+
+output "dcf_ruleset_uuid" {
+  description = "UUID of the DCF ruleset"
+  value       = aviatrix_dcf_ruleset.k8s_demo.id
+}
+
+output "smartgroup_cluster_vpc_uuid" {
+  description = "UUID of cluster VPC SmartGroup"
+  value       = aviatrix_smart_group.cluster_vpc.uuid
+}
+
+output "webgroup_github_aviatrix_uuid" {
+  description = "UUID of GitHub Aviatrix WebGroup (for CRD reference)"
+  value       = aviatrix_web_group.github_aviatrix.uuid
+}

--- a/blueprints/aws-eks-singlecluster/network/main.tf
+++ b/blueprints/aws-eks-singlecluster/network/main.tf
@@ -7,7 +7,12 @@ provider "aws" {
 }
 
 locals {
-  cluster_name = "${var.name_prefix}-cluster"
+  # The cluster is named after name_prefix directly (no "-cluster" suffix): the
+  # eks-cluster module derives IRSA role name_prefixes as
+  # "${cluster_name}-alb-controller-role-" (21 chars of suffix), and AWS caps an
+  # IAM role name_prefix at 38 chars. Keeping cluster_name == name_prefix (<= 17,
+  # enforced in variables.tf) keeps the longest IRSA prefix at <= 38.
+  cluster_name = var.name_prefix
 }
 
 module "spoke_vpc" {

--- a/blueprints/aws-eks-singlecluster/network/main.tf
+++ b/blueprints/aws-eks-singlecluster/network/main.tf
@@ -1,0 +1,35 @@
+provider "aviatrix" {
+  skip_version_validation = true
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+locals {
+  cluster_name = "${var.name_prefix}-cluster"
+}
+
+module "spoke_vpc" {
+  source = "../../../modules/aws-eks-spoke-vpc"
+
+  name         = var.name_prefix
+  cluster_name = local.cluster_name
+  primary_cidr = var.vpc_cidr
+  pod_cidr     = var.pod_cidr
+  region       = var.aws_region
+
+  aviatrix_aws_account_name = var.aviatrix_aws_account_name
+
+  transit_type                  = var.transit_type
+  pod_cidr_mode                 = var.pod_cidr_mode
+  transit_gw_name               = var.transit_gw_name
+  aws_tgw_id                    = var.aws_tgw_id
+  aws_cloudwan_core_network_arn = var.aws_cloudwan_core_network_arn
+
+  tags = {
+    Environment = "demo"
+    Blueprint   = "aws-eks-singlecluster"
+    Terraform   = "true"
+  }
+}

--- a/blueprints/aws-eks-singlecluster/network/outputs.tf
+++ b/blueprints/aws-eks-singlecluster/network/outputs.tf
@@ -1,13 +1,56 @@
-output "vpc_id" { value = module.spoke_vpc.vpc_id }
-output "vpc_cidr" { value = module.spoke_vpc.vpc_cidr }
-output "secondary_cidr" { value = module.spoke_vpc.secondary_cidr }
-output "availability_zones" { value = module.spoke_vpc.availability_zones }
-output "cluster_name" { value = local.cluster_name }
+output "vpc_id" {
+  description = "Spoke VPC ID. Consumed by the cluster and nodes layers."
+  value       = module.spoke_vpc.vpc_id
+}
 
-output "lb_public_subnet_ids" { value = module.spoke_vpc.lb_public_subnet_ids }
-output "infra_private_subnet_ids" { value = module.spoke_vpc.infra_private_subnet_ids }
-output "infra_private_subnet_cidrs" { value = module.spoke_vpc.infra_private_subnet_cidrs }
-output "pod_private_subnet_ids" { value = module.spoke_vpc.pod_private_subnet_ids }
+output "vpc_cidr" {
+  description = "Primary VPC CIDR."
+  value       = module.spoke_vpc.vpc_cidr
+}
 
-output "spoke_gateway_name" { value = module.spoke_vpc.spoke_gateway_name }
-output "spoke_gateway_private_ip" { value = module.spoke_vpc.spoke_gateway_private_ip }
+output "secondary_cidr" {
+  description = "Secondary VPC CIDR used for pod networking (VPC CNI custom networking)."
+  value       = module.spoke_vpc.secondary_cidr
+}
+
+output "availability_zones" {
+  description = "Availability zones the spoke VPC subnets are placed in."
+  value       = module.spoke_vpc.availability_zones
+}
+
+output "cluster_name" {
+  description = "EKS cluster name derived from name_prefix; consumed by the cluster and nodes layers."
+  value       = local.cluster_name
+}
+
+output "lb_public_subnet_ids" {
+  description = "Public load-balancer subnet IDs (for the AWS Load Balancer Controller / ALB)."
+  value       = module.spoke_vpc.lb_public_subnet_ids
+}
+
+output "infra_private_subnet_ids" {
+  description = "Infrastructure private subnet IDs where EKS nodes and the control-plane ENIs live."
+  value       = module.spoke_vpc.infra_private_subnet_ids
+}
+
+output "infra_private_subnet_cidrs" {
+  description = "Infrastructure private subnet CIDR blocks."
+  value       = module.spoke_vpc.infra_private_subnet_cidrs
+}
+
+output "pod_private_subnet_ids" {
+  description = "Pod private subnet IDs (from the secondary CIDR); consumed by the nodes layer ENIConfig."
+  value       = module.spoke_vpc.pod_private_subnet_ids
+}
+
+output "spoke_gateway_name" {
+  description = "Aviatrix spoke gateway name (used for DCF SmartGroup references and post-attach automation)."
+  value       = module.spoke_vpc.spoke_gateway_name
+  sensitive   = true
+}
+
+output "spoke_gateway_private_ip" {
+  description = "Aviatrix spoke gateway private IP (the SNAT target for pod and node egress)."
+  value       = module.spoke_vpc.spoke_gateway_private_ip
+  sensitive   = true
+}

--- a/blueprints/aws-eks-singlecluster/network/outputs.tf
+++ b/blueprints/aws-eks-singlecluster/network/outputs.tf
@@ -1,0 +1,13 @@
+output "vpc_id" { value = module.spoke_vpc.vpc_id }
+output "vpc_cidr" { value = module.spoke_vpc.vpc_cidr }
+output "secondary_cidr" { value = module.spoke_vpc.secondary_cidr }
+output "availability_zones" { value = module.spoke_vpc.availability_zones }
+output "cluster_name" { value = local.cluster_name }
+
+output "lb_public_subnet_ids" { value = module.spoke_vpc.lb_public_subnet_ids }
+output "infra_private_subnet_ids" { value = module.spoke_vpc.infra_private_subnet_ids }
+output "infra_private_subnet_cidrs" { value = module.spoke_vpc.infra_private_subnet_cidrs }
+output "pod_private_subnet_ids" { value = module.spoke_vpc.pod_private_subnet_ids }
+
+output "spoke_gateway_name" { value = module.spoke_vpc.spoke_gateway_name }
+output "spoke_gateway_private_ip" { value = module.spoke_vpc.spoke_gateway_private_ip }

--- a/blueprints/aws-eks-singlecluster/network/variables.tf
+++ b/blueprints/aws-eks-singlecluster/network/variables.tf
@@ -1,7 +1,12 @@
 variable "name_prefix" {
-  description = "Prefix for all resource names."
+  description = "Prefix for all resource names. Also used verbatim as the EKS cluster name. Capped at 17 chars because the eks-cluster module derives IRSA IAM role name_prefixes as \"<name_prefix>-alb-controller-role-\" and AWS caps an IAM role name_prefix at 38 chars."
   type        = string
   default     = "eks-singlecluster"
+
+  validation {
+    condition     = length(var.name_prefix) >= 1 && length(var.name_prefix) <= 17
+    error_message = "name_prefix must be 1-17 characters (it becomes the cluster name, and the eks-cluster module's IRSA role name_prefixes must stay within AWS's 38-char limit)."
+  }
 }
 
 variable "aviatrix_aws_account_name" {

--- a/blueprints/aws-eks-singlecluster/network/variables.tf
+++ b/blueprints/aws-eks-singlecluster/network/variables.tf
@@ -1,0 +1,58 @@
+variable "name_prefix" {
+  description = "Prefix for all resource names."
+  type        = string
+  default     = "eks-singlecluster"
+}
+
+variable "aviatrix_aws_account_name" {
+  description = "AWS account name as registered in the Aviatrix Controller."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region."
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "vpc_cidr" {
+  description = "Primary VPC CIDR (chosen to avoid multicluster's 10.10/10.20/10.5 defaults)."
+  type        = string
+  default     = "10.30.0.0/23"
+}
+
+variable "pod_cidr" {
+  description = "Secondary CIDR for pod networking."
+  type        = string
+  default     = "100.64.0.0/16"
+}
+
+variable "transit_type" {
+  description = "Spoke transit mode: aviatrix | aws_tgw | aws_cloudwan."
+  type        = string
+  default     = "aws_tgw"
+}
+
+variable "pod_cidr_mode" {
+  description = "routable | non_routable."
+  type        = string
+  default     = "non_routable"
+}
+
+variable "transit_gw_name" {
+  description = "Aviatrix transit gateway name (only when transit_type = aviatrix)."
+  type        = string
+  default     = ""
+}
+
+variable "aws_tgw_id" {
+  description = "AWS TGW ID to attach E-W routes to (only when transit_type = aws_tgw). Empty = standalone."
+  type        = string
+  default     = ""
+}
+
+variable "aws_cloudwan_core_network_arn" {
+  description = "AWS Cloud WAN Core Network ARN (only when transit_type = aws_cloudwan). Empty = standalone."
+  type        = string
+  default     = ""
+}

--- a/blueprints/aws-eks-singlecluster/network/versions.tf
+++ b/blueprints/aws-eks-singlecluster/network/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 8.2.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/blueprints/aws-eks-singlecluster/nodes/data.tf
+++ b/blueprints/aws-eks-singlecluster/nodes/data.tf
@@ -1,0 +1,18 @@
+# Data source to read network outputs
+data "terraform_remote_state" "network" {
+  backend = "local"
+
+  config = {
+    path = "../network/terraform.tfstate"
+  }
+}
+
+# Data source to read cluster outputs
+# By Layer 3, the cluster state exists and all values are known at plan time
+data "terraform_remote_state" "cluster" {
+  backend = "local"
+
+  config = {
+    path = "../cluster/terraform.tfstate"
+  }
+}

--- a/blueprints/aws-eks-singlecluster/nodes/helm.tf
+++ b/blueprints/aws-eks-singlecluster/nodes/helm.tf
@@ -1,0 +1,53 @@
+#####################
+# Kubernetes Add-ons (Helm Charts)
+#####################
+# These add-ons are automatically installed after the cluster and nodes are ready
+# Deployed in Layer 3 to ensure cluster and nodes exist before installation
+
+# AWS Load Balancer Controller
+# Manages ALB/NLB for Kubernetes Service and Ingress resources
+resource "helm_release" "aws_load_balancer_controller" {
+  name       = "aws-load-balancer-controller"
+  repository = "https://aws.github.io/eks-charts"
+  chart      = "aws-load-balancer-controller"
+  namespace  = "kube-system"
+  version    = var.alb_controller_chart_version
+
+  set {
+    name  = "clusterName"
+    value = data.terraform_remote_state.cluster.outputs.cluster_name
+  }
+
+  set {
+    name  = "serviceAccount.create"
+    value = "true"
+  }
+
+  set {
+    name  = "serviceAccount.name"
+    value = "aws-load-balancer-controller"
+  }
+
+  set {
+    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+    value = data.terraform_remote_state.cluster.outputs.alb_controller_role_arn
+  }
+
+  # IMPORTANT: vpcId and region are required when using VPC CNI custom networking
+  # Pods can't access EC2 metadata due to secondary CIDR, so these must be explicit
+  set {
+    name  = "vpcId"
+    value = data.terraform_remote_state.network.outputs.vpc_id
+  }
+
+  set {
+    name  = "region"
+    value = var.aws_region
+  }
+
+  # Wait for nodes to be ready before installing
+  depends_on = [
+    module.default_node_group,
+    aws_eks_addon.coredns
+  ]
+}

--- a/blueprints/aws-eks-singlecluster/nodes/main.tf
+++ b/blueprints/aws-eks-singlecluster/nodes/main.tf
@@ -1,0 +1,141 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+# Kubernetes provider for ENIConfig resources
+# By Layer 3, the cluster exists and can authenticate
+provider "kubernetes" {
+  host                   = data.terraform_remote_state.cluster.outputs.cluster_endpoint
+  cluster_ca_certificate = base64decode(data.terraform_remote_state.cluster.outputs.cluster_certificate_authority_data)
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", data.terraform_remote_state.cluster.outputs.cluster_name, "--region", var.aws_region]
+  }
+}
+
+# Helm provider for Kubernetes add-ons
+# Uses the same authentication as the Kubernetes provider
+provider "helm" {
+  kubernetes {
+    host                   = data.terraform_remote_state.cluster.outputs.cluster_endpoint
+    cluster_ca_certificate = base64decode(data.terraform_remote_state.cluster.outputs.cluster_certificate_authority_data)
+
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", data.terraform_remote_state.cluster.outputs.cluster_name, "--region", var.aws_region]
+    }
+  }
+}
+
+#####################
+# Aviatrix Distributed Cloud Firewall (DCF) for Kubernetes
+#####################
+
+# Install the k8s-firewall Helm chart which provides CRDs for:
+# - firewallpolicies.networking.aviatrix.com
+# - webgrouppolicies.networking.aviatrix.com
+# These enable Kubernetes-native firewall policy management via Aviatrix DCF
+resource "helm_release" "k8s_firewall" {
+  name       = "k8s-firewall"
+  repository = "https://aviatrixsystems.github.io/k8s-firewall-charts"
+  chart      = "k8s-firewall"
+  namespace  = "default"
+
+  # Skip waiting for resources - CRDs don't have traditional ready status
+  wait = false
+
+  # Recreate pods on upgrade to pick up new CRD versions
+  recreate_pods = false
+}
+
+#####################
+# ENIConfig for VPC CNI Custom Networking
+#####################
+
+# ENIConfig resources tell the VPC CNI which subnet and security group to use for pod ENIs
+# Deployed in Layer 3 (after cluster exists) to avoid Kubernetes provider auth issues
+resource "kubernetes_manifest" "eniconfig" {
+  for_each = { for idx, az in data.terraform_remote_state.network.outputs.availability_zones : az => data.terraform_remote_state.network.outputs.pod_private_subnet_ids[idx] }
+
+  manifest = {
+    apiVersion = "crd.k8s.amazonaws.com/v1alpha1"
+    kind       = "ENIConfig"
+    metadata = {
+      name = each.key
+    }
+    spec = {
+      subnet         = each.value
+      securityGroups = [data.terraform_remote_state.cluster.outputs.pod_security_group_id]
+    }
+  }
+}
+
+#####################
+# EKS Node Group
+#####################
+
+# This deployment runs AFTER cluster exists
+# All values from the cluster state are known at plan time
+
+module "default_node_group" {
+  source = "../../../modules/aws-eks-node-group"
+
+  # Cluster identity - from cluster state (exists at plan time)
+  cluster_name    = data.terraform_remote_state.cluster.outputs.cluster_name
+  cluster_version = data.terraform_remote_state.cluster.outputs.cluster_version
+
+  # Network - from network state (exists at plan time)
+  subnet_ids = data.terraform_remote_state.network.outputs.infra_private_subnet_ids
+
+  # Security - from cluster state (exists at plan time)
+  cluster_primary_security_group_id = data.terraform_remote_state.cluster.outputs.cluster_primary_security_group_id
+
+  # Cluster service CIDR - read from cluster state
+  cluster_service_cidr = data.terraform_remote_state.cluster.outputs.cluster_service_cidr
+
+  # Scaling configuration - from variables (known at plan time)
+  node_group_name = "default"
+  min_size        = var.node_group_config.min_size
+  max_size        = var.node_group_config.max_size
+  desired_size    = var.node_group_config.desired_size
+
+  # Instance configuration - from variables (known at plan time)
+  instance_types = var.node_group_config.instance_types
+  capacity_type  = var.node_group_config.capacity_type
+
+  tags = {
+    Environment = "demo"
+    Terraform   = "true"
+  }
+
+  # Ensure ENIConfig is created before nodes so pods get correct networking
+  depends_on = [kubernetes_manifest.eniconfig]
+}
+
+#####################
+# CoreDNS Addon
+#####################
+
+# Deploy CoreDNS in Layer 3 after nodes exist
+# This ensures CoreDNS pods can be scheduled immediately
+resource "aws_eks_addon" "coredns" {
+  cluster_name = data.terraform_remote_state.cluster.outputs.cluster_name
+  addon_name   = "coredns"
+
+  # Omit addon_version to use latest compatible version
+  resolve_conflicts_on_create = "NONE"
+  resolve_conflicts_on_update = "OVERWRITE"
+
+  preserve = true
+
+  tags = {
+    Environment = "demo"
+    Terraform   = "true"
+  }
+
+  # Ensure nodes are created before CoreDNS is deployed
+  depends_on = [module.default_node_group]
+}

--- a/blueprints/aws-eks-singlecluster/nodes/outputs.tf
+++ b/blueprints/aws-eks-singlecluster/nodes/outputs.tf
@@ -1,0 +1,24 @@
+output "node_group_id" {
+  description = "EKS node group ID"
+  value       = module.default_node_group.node_group_id
+}
+
+output "node_group_arn" {
+  description = "EKS node group ARN"
+  value       = module.default_node_group.node_group_arn
+}
+
+output "node_group_status" {
+  description = "Status of the EKS node group"
+  value       = module.default_node_group.node_group_status
+}
+
+output "node_group_autoscaling_group_names" {
+  description = "List of the autoscaling group names"
+  value       = module.default_node_group.node_group_autoscaling_group_names
+}
+
+output "iam_role_arn" {
+  description = "IAM role ARN for the node group"
+  value       = module.default_node_group.iam_role_arn
+}

--- a/blueprints/aws-eks-singlecluster/nodes/variables.tf
+++ b/blueprints/aws-eks-singlecluster/nodes/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_region" {
+  description = "AWS region for all resources"
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "alb_controller_chart_version" {
+  description = "Helm chart version for AWS Load Balancer Controller"
+  type        = string
+  default     = "1.10.1"
+}
+
+variable "node_group_config" {
+  description = "Configuration for EKS managed node groups"
+  type = object({
+    min_size       = number
+    max_size       = number
+    desired_size   = number
+    instance_types = list(string)
+    capacity_type  = string
+  })
+  default = {
+    min_size       = 1
+    max_size       = 3
+    desired_size   = 2
+    instance_types = ["t3.large"]
+    capacity_type  = "SPOT"
+  }
+}

--- a/blueprints/aws-eks-singlecluster/nodes/versions.tf
+++ b/blueprints/aws-eks-singlecluster/nodes/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.30"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.16"
+    }
+  }
+}

--- a/blueprints/aws-eks-singlecluster/terraform.tfvars.example
+++ b/blueprints/aws-eks-singlecluster/terraform.tfvars.example
@@ -1,0 +1,16 @@
+name_prefix               = "eks-singlecluster"
+aviatrix_aws_account_name = "your-aws-account-name"
+aws_region                = "us-east-2"
+
+# Module mode — defaults to standalone AWS TGW spoke, non-routable pods.
+# transit_type  = "aws_tgw"        # aviatrix | aws_tgw | aws_cloudwan
+# pod_cidr_mode = "non_routable"   # routable | non_routable
+
+# Attach to existing transit by setting ONE of these and re-applying:
+# transit_gw_name               = "my-aviatrix-transit"            # transit_type = aviatrix
+# aws_tgw_id                    = "tgw-0abc123..."                 # transit_type = aws_tgw
+# aws_cloudwan_core_network_arn = "arn:aws:networkmanager::..."    # transit_type = aws_cloudwan
+
+# CIDRs (chosen to not collide with multicluster's 10.10/10.20/10.5 defaults)
+# vpc_cidr = "10.30.0.0/23"
+# pod_cidr = "100.64.0.0/16"

--- a/modules/aws-eks-cluster/README.md
+++ b/modules/aws-eks-cluster/README.md
@@ -1,0 +1,110 @@
+> ⚠️ **DUPLICATED MODULE — time-boxed.** An identical copy lives at
+> `blueprints/aws-eks-multicluster/modules/eks-cluster/`. Until the multicluster
+> blueprint is retargeted to consume this repo-root module (separate follow-up
+> branch), **any change here must be made in both copies.** See
+> `docs/superpowers/specs/2026-06-04-aws-eks-singlecluster-design.md`.
+
+# EKS Cluster Module
+
+This module deploys an EKS cluster configured for CNI custom networking with Aviatrix integration.
+
+## Features
+
+- **Configurable cluster name** - No hardcoded names
+- **CNI Custom Networking** - Pods get IPs from secondary CIDR subnets
+- **ENIConfig Resources** - Automatically created via Kubernetes provider
+- **External SNAT Disabled** - Allows Aviatrix to perform SNAT
+- **IRSA Roles** - Pre-configured for AWS Load Balancer Controller and ExternalDNS
+- **Security Groups** - Separate SGs for nodes and pods
+- **SPOT Instances** - Cost-optimized with configurable capacity type
+
+## CNI Configuration
+
+The module automatically configures VPC CNI with:
+
+```yaml
+AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG: "true"
+ENI_CONFIG_LABEL_DEF: "topology.kubernetes.io/zone"
+AWS_VPC_K8S_CNI_EXTERNALSNAT: "true"  # Critical for Aviatrix
+```
+
+## Usage
+
+```hcl
+module "frontend_eks" {
+  source = "../shared-modules/eks-cluster"
+
+  cluster_name       = "frontend-cluster"
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.infra_private_subnet_ids  # For nodes
+  pod_subnet_ids     = module.vpc.pod_private_subnet_ids    # For pods
+  availability_zones = ["us-east-2a", "us-east-2b"]
+  region             = "us-east-2"
+
+  node_group_config = {
+    min_size       = 1
+    max_size       = 3
+    desired_size   = 2
+    instance_types = ["t3.large"]
+    capacity_type  = "SPOT"
+  }
+
+  tags = {
+    Environment = "demo"
+    Cluster     = "frontend"
+  }
+}
+```
+
+## Post-Deployment
+
+After cluster creation, configure kubectl:
+
+```bash
+aws eks update-kubeconfig --region us-east-2 --name frontend-cluster
+```
+
+Verify CNI configuration:
+
+```bash
+kubectl get eniconfigs
+kubectl describe daemonset -n kube-system aws-node
+```
+
+## Integration with Aviatrix
+
+This cluster is designed to work with Aviatrix spoke gateway SNAT:
+
+1. **Pods get IPs from secondary CIDR** (100.64.0.0/16)
+2. **CNI external SNAT is disabled** (`AWS_VPC_K8S_CNI_EXTERNALSNAT=true`)
+3. **Aviatrix spoke gateway performs SNAT** to translate pod IPs to routable IPs
+
+Traffic flow:
+```
+Pod (100.64.x.x) → Aviatrix Spoke GW → SNAT to 10.x.x.x → Transit GW
+```
+
+## IAM Roles
+
+The module creates IRSA roles for:
+
+1. **AWS Load Balancer Controller** - For ALB/NLB provisioning
+2. **ExternalDNS** - For Route53 DNS management
+
+Use these role ARNs when deploying the controllers:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-load-balancer-controller
+  namespace: kube-system
+  annotations:
+    eks.amazonaws.com/role-arn: <alb_controller_role_arn>
+```
+
+## Security Groups
+
+- **Cluster Additional SG**: Allows monitoring traffic (ports 8080-8081)
+- **Node SG**: Managed by EKS module
+- **Pod SG**: Used in ENIConfig, allows traffic from nodes and other pods

--- a/modules/aws-eks-cluster/README.md
+++ b/modules/aws-eks-cluster/README.md
@@ -1,7 +1,10 @@
-> ⚠️ **DUPLICATED MODULE — time-boxed.** An identical copy lives at
-> `blueprints/aws-eks-multicluster/modules/eks-cluster/`. Until the multicluster
-> blueprint is retargeted to consume this repo-root module (separate follow-up
-> branch), **any change here must be made in both copies.** See
+> ⚠️ **DUPLICATED MODULE — time-boxed.** A functionally equivalent copy lives at
+> `blueprints/aws-eks-multicluster/modules/eks-cluster/`. This copy's `versions.tf`
+> was corrected to declare the `kubernetes` provider the module actually requires
+> (for the Aviatrix-onboarding `kubernetes_cluster_role`/`_role_binding` RBAC); it
+> was missing from the source's provider block. Until the multicluster blueprint is
+> retargeted to consume this repo-root module (separate follow-up branch), **any
+> change here must be made in both copies.** See
 > `docs/superpowers/specs/2026-06-04-aws-eks-singlecluster-design.md`.
 
 # EKS Cluster Module
@@ -32,7 +35,7 @@ AWS_VPC_K8S_CNI_EXTERNALSNAT: "true"  # Critical for Aviatrix
 
 ```hcl
 module "frontend_eks" {
-  source = "../shared-modules/eks-cluster"
+  source = "../../../modules/aws-eks-cluster"
 
   cluster_name       = "frontend-cluster"
   vpc_id             = module.vpc.vpc_id

--- a/modules/aws-eks-cluster/main.tf
+++ b/modules/aws-eks-cluster/main.tf
@@ -1,0 +1,296 @@
+# IAM role for reader access (example)
+resource "aws_iam_role" "reader_role" {
+  name = "${var.cluster_name}-reader-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  tags = var.tags
+}
+
+# IAM role for service accounts - ALB Controller
+module "iam_irsa_alb_controller" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.2"
+
+  name                                   = "${var.cluster_name}-alb-controller-role"
+  attach_load_balancer_controller_policy = true
+  attach_vpc_cni_policy                  = true
+  vpc_cni_enable_ipv4                    = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:aws-load-balancer-controller"]
+    }
+  }
+
+  tags = var.tags
+}
+
+# IAM role for ExternalDNS
+module "external_dns_irsa_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.2"
+
+  name                       = "${var.cluster_name}-external-dns"
+  attach_external_dns_policy = true
+
+  # Restrict to specific hosted zone if provided, otherwise allow all
+  external_dns_hosted_zone_arns = var.route53_zone_id != "" ? [
+    "arn:aws:route53:::hostedzone/${var.route53_zone_id}"
+  ] : ["arn:aws:route53:::hostedzone/*"]
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:external-dns"]
+    }
+  }
+
+  tags = var.tags
+}
+
+# Security group for cluster-level traffic (e.g., monitoring)
+resource "aws_security_group" "cluster_additional" {
+  name        = "${var.cluster_name}-cluster-additional-sg"
+  description = "Additional security group for ${var.cluster_name} cluster"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "Allow monitoring traffic"
+    from_port   = 8080
+    to_port     = 8081
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.cluster_name}-cluster-additional-sg"
+  })
+}
+
+# Security group for pods (used by ENIConfig)
+resource "aws_security_group" "pod" {
+  name        = "${var.cluster_name}-pod-sg"
+  description = "Security group for ${var.cluster_name} pods"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.cluster_name}-pod-sg"
+  })
+}
+
+# Allow nodes to communicate with pods
+resource "aws_vpc_security_group_ingress_rule" "pod_from_nodes" {
+  security_group_id = aws_security_group.pod.id
+  description       = "Allow all traffic from node security group"
+
+  referenced_security_group_id = module.eks.node_security_group_id
+  ip_protocol                  = "-1"
+}
+
+# Allow pods to communicate with each other
+resource "aws_vpc_security_group_ingress_rule" "pod_from_pods" {
+  security_group_id = aws_security_group.pod.id
+  description       = "Allow all traffic from other pods"
+
+  referenced_security_group_id = aws_security_group.pod.id
+  ip_protocol                  = "-1"
+}
+
+# Allow pods to communicate with the cluster control plane (for API server access)
+resource "aws_vpc_security_group_ingress_rule" "cluster_from_pods" {
+  security_group_id = module.eks.cluster_primary_security_group_id
+  description       = "Allow pods to reach EKS control plane"
+
+  referenced_security_group_id = aws_security_group.pod.id
+  ip_protocol                  = "-1"
+}
+
+# Allow EKS control plane to reach pod webhooks (e.g., AWS LB Controller, cert-manager)
+resource "aws_vpc_security_group_ingress_rule" "pods_from_cluster" {
+  security_group_id = aws_security_group.pod.id
+  description       = "Allow EKS control plane to reach pod webhooks"
+
+  referenced_security_group_id = module.eks.cluster_primary_security_group_id
+  from_port                    = 9443
+  to_port                      = 9443
+  ip_protocol                  = "tcp"
+}
+
+# EKS Cluster
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 21.9"
+
+  name               = var.cluster_name
+  kubernetes_version = var.kubernetes_version
+
+  endpoint_public_access = true
+
+  # Cluster addons
+  # NOTE: CoreDNS is deployed in Layer 3 (node-group) to avoid waiting for nodes during cluster deployment
+  addons = {
+    kube-proxy = {
+      most_recent = true
+    }
+    vpc-cni = {
+      most_recent = true
+      configuration_values = jsonencode({
+        env = {
+          # Enable custom networking - pods use secondary CIDR (100.64.x.x) via ENIConfig
+          AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG = "true"
+          # Match ENIConfig resources by node's AZ label
+          ENI_CONFIG_LABEL_DEF = "topology.kubernetes.io/zone"
+          # CRITICAL: Disable CNI SNAT so Aviatrix can handle it
+          AWS_VPC_K8S_CNI_EXTERNALSNAT = "true"
+        }
+      })
+    }
+  }
+
+  vpc_id                        = var.vpc_id
+  subnet_ids                    = var.subnet_ids
+  control_plane_subnet_ids      = var.subnet_ids
+  additional_security_group_ids = [aws_security_group.cluster_additional.id]
+
+  # Node groups are managed separately in eks-node-group module
+  # This solves the chicken-and-egg problem where node group count/for_each
+  # depends on cluster outputs that don't exist during initial plan
+  eks_managed_node_groups = {}
+
+  # Cluster access entry - enable cluster creator as admin
+  enable_cluster_creator_admin_permissions = true
+
+  # Additional access entries
+  access_entries = {
+    reader = {
+      kubernetes_groups = []
+      principal_arn     = aws_iam_role.reader_role.arn
+
+      policy_associations = {
+        view = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+  }
+
+  tags = var.tags
+}
+
+
+#####################
+# Aviatrix Controller Onboarding
+#####################
+# Register the EKS cluster with Aviatrix Controller for Smart Groups
+# This allows the controller to build workload-based security policies
+
+resource "aviatrix_kubernetes_cluster" "this" {
+  count = var.enable_aviatrix_onboarding ? 1 : 0
+
+  cluster_id          = module.eks.cluster_arn
+  use_csp_credentials = true
+
+  depends_on = [module.eks]
+}
+
+# EKS access entry for Aviatrix Controller IAM role
+# This allows the Aviatrix Controller to authenticate to the EKS cluster
+resource "aws_eks_access_entry" "aviatrix_controller" {
+  count = var.enable_aviatrix_onboarding && var.aviatrix_controller_role_arn != "" ? 1 : 0
+
+  cluster_name      = module.eks.cluster_name
+  principal_arn     = var.aviatrix_controller_role_arn
+  kubernetes_groups = ["view-nodes"]
+  type              = "STANDARD"
+
+  depends_on = [module.eks]
+}
+
+# Associate AmazonEKSViewPolicy with Aviatrix Controller access entry
+# This provides read access to most Kubernetes resources
+resource "aws_eks_access_policy_association" "aviatrix_controller" {
+  count = var.enable_aviatrix_onboarding && var.aviatrix_controller_role_arn != "" ? 1 : 0
+
+  cluster_name  = module.eks.cluster_name
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
+  principal_arn = var.aviatrix_controller_role_arn
+
+  access_scope {
+    type = "cluster"
+  }
+
+  depends_on = [aws_eks_access_entry.aviatrix_controller]
+}
+
+# ClusterRole for viewing nodes (required by Aviatrix for Smart Groups)
+# AmazonEKSViewPolicy doesn't include nodes, so we need this additional role
+resource "kubernetes_cluster_role" "view_nodes" {
+  count = var.enable_aviatrix_onboarding && var.aviatrix_controller_role_arn != "" ? 1 : 0
+
+  metadata {
+    name = "view-nodes"
+  }
+
+  rule {
+    verbs      = ["get", "list", "watch"]
+    api_groups = [""]
+    resources  = ["nodes"]
+  }
+
+  depends_on = [module.eks]
+}
+
+# ClusterRoleBinding to grant view-nodes group the view-nodes ClusterRole
+resource "kubernetes_cluster_role_binding" "view_nodes" {
+  count = var.enable_aviatrix_onboarding && var.aviatrix_controller_role_arn != "" ? 1 : 0
+
+  metadata {
+    name = "view-nodes"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.view_nodes[0].metadata[0].name
+  }
+
+  subject {
+    kind      = "Group"
+    name      = "view-nodes"
+    api_group = "rbac.authorization.k8s.io"
+  }
+
+  depends_on = [kubernetes_cluster_role.view_nodes]
+}

--- a/modules/aws-eks-cluster/outputs.tf
+++ b/modules/aws-eks-cluster/outputs.tf
@@ -1,0 +1,136 @@
+output "vpc_id" {
+  description = "VPC ID where the EKS cluster is deployed"
+  value       = var.vpc_id
+}
+
+output "cluster_id" {
+  description = "EKS cluster ID"
+  value       = module.eks.cluster_id
+}
+
+output "cluster_name" {
+  description = "EKS cluster name"
+  value       = module.eks.cluster_name
+}
+
+output "cluster_version" {
+  description = "Kubernetes version of the EKS cluster"
+  value       = module.eks.cluster_version
+}
+
+output "cluster_service_cidr" {
+  description = "Kubernetes service CIDR"
+  value       = try(module.eks.cluster.kubernetes_network_config[0].service_ipv4_cidr, "172.20.0.0/16")
+}
+
+output "cluster_endpoint" {
+  description = "Endpoint for EKS control plane"
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_security_group_id" {
+  description = "Security group ID attached to the EKS cluster"
+  value       = module.eks.cluster_security_group_id
+}
+
+output "cluster_primary_security_group_id" {
+  description = "Primary security group ID of the EKS cluster (for node groups)"
+  value       = module.eks.cluster_primary_security_group_id
+}
+
+output "cluster_certificate_authority_data" {
+  description = "Base64 encoded certificate data required to communicate with the cluster"
+  value       = module.eks.cluster_certificate_authority_data
+  sensitive   = true
+}
+
+output "cluster_oidc_issuer_url" {
+  description = "The URL on the EKS cluster OIDC Issuer"
+  value       = module.eks.cluster_oidc_issuer_url
+}
+
+output "oidc_provider_arn" {
+  description = "ARN of the OIDC Provider for EKS"
+  value       = module.eks.oidc_provider_arn
+}
+
+output "node_security_group_id" {
+  description = "Security group ID attached to the EKS nodes"
+  value       = module.eks.node_security_group_id
+}
+
+output "pod_security_group_id" {
+  description = "Security group ID for EKS pods"
+  value       = aws_security_group.pod.id
+}
+
+output "alb_controller_role_arn" {
+  description = "IAM role ARN for AWS Load Balancer Controller"
+  value       = module.iam_irsa_alb_controller.arn
+}
+
+output "external_dns_role_arn" {
+  description = "IAM role ARN for ExternalDNS"
+  value       = module.external_dns_irsa_role.arn
+}
+
+output "configure_kubectl" {
+  description = "Command to configure kubectl"
+  value       = "aws eks update-kubeconfig --region ${var.region} --name ${var.cluster_name}"
+}
+
+output "route53_zone_id" {
+  description = "Route53 zone ID (if configured)"
+  value       = var.route53_zone_id
+}
+
+output "route53_zone_name" {
+  description = "Route53 zone name (if configured)"
+  value       = var.route53_zone_name
+}
+
+output "external_dns_helm_values" {
+  description = "Helm values for ExternalDNS deployment"
+  value = var.route53_zone_id != "" ? {
+    serviceAccount = {
+      create = true
+      annotations = {
+        "eks.amazonaws.com/role-arn" = module.external_dns_irsa_role.arn
+      }
+      name = "external-dns"
+    }
+    provider      = "aws"
+    sources       = ["service", "ingress"]
+    domainFilters = [var.route53_zone_name]
+    policy        = "sync"
+    txtOwnerId    = var.cluster_name
+    extraArgs = [
+      "--aws-zone-type=private",
+      "--aws-prefer-cname"
+    ]
+  } : null
+}
+
+output "eniconfig_manifests" {
+  description = "ENIConfig YAML manifests to apply via kubectl"
+  value = join("\n---\n", [
+    for az, config in { for idx, az in var.availability_zones : az => {
+      subnet_id = var.pod_subnet_ids[idx]
+      az        = az
+    } } : <<-EOT
+    apiVersion: crd.k8s.amazonaws.com/v1alpha1
+    kind: ENIConfig
+    metadata:
+      name: ${config.az}
+    spec:
+      subnet: ${config.subnet_id}
+      securityGroups:
+        - ${aws_security_group.pod.id}
+    EOT
+  ])
+}
+
+output "eniconfig_apply_command" {
+  description = "Command to apply ENIConfig resources"
+  value       = "terraform output -raw ${var.cluster_name}_eniconfig_manifests | kubectl apply -f -"
+}

--- a/modules/aws-eks-cluster/variables.tf
+++ b/modules/aws-eks-cluster/variables.tf
@@ -1,0 +1,69 @@
+variable "cluster_name" {
+  description = "Name of the EKS cluster"
+  type        = string
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version for the EKS cluster"
+  type        = string
+  default     = "1.34"
+}
+
+variable "vpc_id" {
+  description = "VPC ID where EKS cluster will be deployed"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs for EKS control plane ENIs and node groups (infrastructure subnets)"
+  type        = list(string)
+}
+
+variable "pod_subnet_ids" {
+  description = "Subnet IDs for EKS pods (from secondary CIDR, used in ENIConfig)"
+  type        = list(string)
+}
+
+variable "availability_zones" {
+  description = "Availability zones corresponding to pod_subnet_ids (e.g., ['us-east-2a', 'us-east-2b'])"
+  type        = list(string)
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-2"
+}
+
+# Node group configuration has been moved to the eks-node-group module
+# This module now only creates the EKS control plane
+
+variable "tags" {
+  description = "Additional tags for all resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "route53_zone_id" {
+  description = "Route53 private hosted zone ID for ExternalDNS"
+  type        = string
+  default     = ""
+}
+
+variable "route53_zone_name" {
+  description = "Route53 private hosted zone name for ExternalDNS"
+  type        = string
+  default     = ""
+}
+
+variable "enable_aviatrix_onboarding" {
+  description = "Enable registration of the EKS cluster with Aviatrix Controller for Smart Groups"
+  type        = bool
+  default     = true
+}
+
+variable "aviatrix_controller_role_arn" {
+  description = "IAM role ARN used by Aviatrix Controller to access EKS clusters (e.g., arn:aws:iam::ACCOUNT:role/aviatrix-role-app)"
+  type        = string
+  default     = ""
+}

--- a/modules/aws-eks-cluster/versions.tf
+++ b/modules/aws-eks-cluster/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 8.2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/modules/aws-eks-node-group/README.md
+++ b/modules/aws-eks-node-group/README.md
@@ -1,0 +1,77 @@
+> ⚠️ **DUPLICATED MODULE — time-boxed.** A functionally equivalent copy lives at
+> `blueprints/aws-eks-multicluster/modules/eks-node-group/`. This copy's provider
+> requirements were moved into a dedicated `versions.tf`. Until the multicluster
+> blueprint is retargeted to consume this repo-root module (separate follow-up
+> branch), **any change here must be made in both copies.** See
+> `docs/superpowers/specs/2026-06-04-aws-eks-singlecluster-design.md`.
+
+# EKS Node Group Module
+
+This module creates EKS managed node groups **separately** from the EKS cluster.
+
+## Why Separate?
+
+This solves the "chicken-and-egg" problem in Terraform where:
+- Node group `count`/`for_each` depends on cluster outputs
+- Cluster outputs don't exist during initial `terraform plan`
+- Terraform fails with: `The "count" value depends on resource attributes that cannot be determined until apply`
+
+By deploying node groups in a separate Terraform state **after** the cluster exists, all required values are known at plan time.
+
+## Usage
+
+```hcl
+module "node_group" {
+  source = "../../../modules/aws-eks-node-group"
+
+  cluster_name       = data.terraform_remote_state.cluster.outputs.cluster_name
+  kubernetes_version = data.terraform_remote_state.cluster.outputs.cluster_version
+
+  # From network state (static)
+  subnet_ids = data.terraform_remote_state.network.outputs.frontend_infra_private_subnet_ids
+
+  # From cluster state (exists at plan time)
+  cluster_primary_security_group_id = data.terraform_remote_state.cluster.outputs.cluster_primary_security_group_id
+
+  # Scaling
+  min_size     = 1
+  max_size     = 5
+  desired_size = 2
+
+  # Instance config
+  instance_types = ["t3.large", "t3.xlarge"]
+  capacity_type  = "SPOT"
+
+  tags = {
+    Environment = "demo"
+  }
+}
+```
+
+## Deployment Order
+
+1. Deploy `network/` - Creates VPCs and subnets
+2. Deploy `eks/frontend-cluster/` - Creates EKS control plane (no nodes)
+3. Deploy `eks/frontend-nodes/` - Creates node groups (this module)
+
+## Inputs
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| cluster_name | EKS cluster name | string | required |
+| kubernetes_version | K8s version | string | required |
+| subnet_ids | Subnet IDs for nodes | list(string) | required |
+| cluster_primary_security_group_id | Cluster SG ID | string | required |
+| min_size | Min nodes | number | 1 |
+| max_size | Max nodes | number | 3 |
+| desired_size | Desired nodes | number | 2 |
+| instance_types | Instance types | list(string) | ["t3.large"] |
+| capacity_type | ON_DEMAND or SPOT | string | "SPOT" |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| node_group_id | Node group ID |
+| node_group_arn | Node group ARN |
+| iam_role_arn | Node IAM role ARN |

--- a/modules/aws-eks-node-group/main.tf
+++ b/modules/aws-eks-node-group/main.tf
@@ -1,0 +1,49 @@
+# Query the EKS cluster to get its current version
+data "aws_eks_cluster" "this" {
+  name = var.cluster_name
+}
+
+# EKS Managed Node Group
+# This module is deployed AFTER the cluster exists, solving the chicken-and-egg problem
+module "node_group" {
+  source  = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
+  version = "~> 21.9"
+
+  name               = "${var.cluster_name}-${var.node_group_name}"
+  cluster_name       = var.cluster_name
+  kubernetes_version = var.cluster_version
+
+  # Cluster service CIDR - required for user data
+  cluster_service_cidr = var.cluster_service_cidr
+
+  # Subnet IDs - these come from network state (static at plan time)
+  subnet_ids = var.subnet_ids
+
+  # Scaling configuration
+  min_size     = var.min_size
+  max_size     = var.max_size
+  desired_size = var.desired_size
+
+  # Instance configuration
+  instance_types = var.instance_types
+  capacity_type  = var.capacity_type
+  ami_type       = var.ami_type
+
+  # Security - these values come from cluster state (which exists at plan time)
+  cluster_primary_security_group_id = var.cluster_primary_security_group_id
+
+  # IAM - let the module create the role
+  create_iam_role = true
+  iam_role_name   = "${var.cluster_name}-${var.node_group_name}-role"
+  iam_role_additional_policies = {
+    AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  }
+
+  # Labels and taints
+  labels = var.labels
+  taints = {} # Taints disabled - use var.taints if needed (must be map format)
+
+  tags = merge(var.tags, {
+    Name = "${var.cluster_name}-${var.node_group_name}"
+  })
+}

--- a/modules/aws-eks-node-group/outputs.tf
+++ b/modules/aws-eks-node-group/outputs.tf
@@ -1,0 +1,29 @@
+output "node_group_id" {
+  description = "EKS node group ID"
+  value       = module.node_group.node_group_id
+}
+
+output "node_group_arn" {
+  description = "EKS node group ARN"
+  value       = module.node_group.node_group_arn
+}
+
+output "node_group_status" {
+  description = "Status of the EKS node group"
+  value       = module.node_group.node_group_status
+}
+
+output "node_group_autoscaling_group_names" {
+  description = "List of the autoscaling group names"
+  value       = module.node_group.node_group_autoscaling_group_names
+}
+
+output "iam_role_arn" {
+  description = "IAM role ARN for the node group"
+  value       = module.node_group.iam_role_arn
+}
+
+output "iam_role_name" {
+  description = "IAM role name for the node group"
+  value       = module.node_group.iam_role_name
+}

--- a/modules/aws-eks-node-group/variables.tf
+++ b/modules/aws-eks-node-group/variables.tf
@@ -1,0 +1,89 @@
+variable "cluster_name" {
+  description = "Name of the EKS cluster to attach node group to"
+  type        = string
+}
+
+variable "cluster_version" {
+  description = "Kubernetes version of the cluster (for AMI selection)"
+  type        = string
+}
+
+variable "node_group_name" {
+  description = "Name suffix for the node group"
+  type        = string
+  default     = "default"
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs where nodes will be launched"
+  type        = list(string)
+}
+
+variable "cluster_primary_security_group_id" {
+  description = "EKS cluster primary security group ID (from cluster outputs)"
+  type        = string
+}
+
+variable "cluster_service_cidr" {
+  description = "Kubernetes service CIDR for the cluster"
+  type        = string
+  default     = ""
+}
+
+variable "min_size" {
+  description = "Minimum number of nodes"
+  type        = number
+  default     = 1
+}
+
+variable "max_size" {
+  description = "Maximum number of nodes"
+  type        = number
+  default     = 3
+}
+
+variable "desired_size" {
+  description = "Desired number of nodes"
+  type        = number
+  default     = 2
+}
+
+variable "instance_types" {
+  description = "List of instance types for the node group"
+  type        = list(string)
+  default     = ["t3.large"]
+}
+
+variable "capacity_type" {
+  description = "Capacity type: ON_DEMAND or SPOT"
+  type        = string
+  default     = "SPOT"
+}
+
+variable "ami_type" {
+  description = "AMI type for nodes (AL2_x86_64, AL2023_x86_64_STANDARD, etc.)"
+  type        = string
+  default     = "AL2023_x86_64_STANDARD"
+}
+
+variable "labels" {
+  description = "Kubernetes labels to apply to nodes"
+  type        = map(string)
+  default     = {}
+}
+
+variable "taints" {
+  description = "Kubernetes taints to apply to nodes"
+  type = list(object({
+    key    = string
+    value  = string
+    effect = string
+  }))
+  default = []
+}
+
+variable "tags" {
+  description = "Additional tags for all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws-eks-node-group/versions.tf
+++ b/modules/aws-eks-node-group/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/modules/aws-eks-spoke-vpc/README.md
+++ b/modules/aws-eks-spoke-vpc/README.md
@@ -1,0 +1,207 @@
+# aws-eks-spoke-vpc
+
+Terraform module that provisions a "spoke-in-a-box" AWS VPC shaped for EKS workloads and wired with an Aviatrix spoke gateway.
+
+## What this module creates
+
+The module builds every layer needed between raw AWS account credentials and a running Aviatrix spoke:
+
+- **VPC** with a primary CIDR and a secondary CIDR for pod networking (VPC CNI custom networking).
+- **Four subnet tiers** per availability zone (two AZs, hardcoded):
+  - `avx_public` /28 — Aviatrix gateway subnets.
+  - `lb_public` /26 — Public load-balancer subnets, tagged `kubernetes.io/role/elb=1`.
+  - `infra_private` /26 — EKS node subnets, tagged `kubernetes.io/role/internal-elb=1`.
+  - `pod_private` /17 — Pod subnets from the secondary CIDR, consumed by ENIConfig in the nodes layer.
+- **Route tables** for each tier (avx_public, lb_public, infra_private, pod_private), all with `lifecycle { ignore_changes = [route] }` so Aviatrix controller-programmed RFC1918 routes survive re-apply.
+- **Internet gateway** attached to the public route tables.
+- **Aviatrix spoke gateway** (via the `terraform-aviatrix-modules/mc-spoke/aviatrix` module), optionally attached to an Aviatrix transit.
+- **Custom SNAT** (aviatrix mode only) so pods using a non-routable overlay CIDR are translated to the spoke gateway private IP before entering the transit fabric.
+- **Native-cloud route programming** (aws_tgw / aws_cloudwan mode, when a transit target ID is supplied) with `aws_route` resources on infra_private and pod_private for default + east-west destinations.
+
+## Transit type and pod-CIDR mode matrix
+
+The two most important variables are `transit_type` and `pod_cidr_mode`. Their interaction determines SNAT shape and route-table behavior.
+
+| transit_type | pod_cidr_mode | SNAT | Route programming | Typical use-case |
+|---|---|---|---|---|
+| `aws_tgw` (default) | `non_routable` (default) | `single_ip_snat = true` on spoke module | Nothing (standalone); or native routes when `aws_tgw_id` is set | Default standalone deployment; TGW attachment wired out-of-band |
+| `aws_tgw` | `routable` | `single_ip_snat = true` on spoke module | Pod east-west via TGW (native transit) when `aws_tgw_id` is set | Pod CIDRs are unique per spoke and advertised into TGW |
+| `aws_cloudwan` | `non_routable` | `single_ip_snat = true` on spoke module | Nothing (standalone); or native routes when `aws_cloudwan_core_network_arn` is set | Cloud WAN attachment wired out-of-band |
+| `aws_cloudwan` | `routable` | `single_ip_snat = true` on spoke module | Pod east-west via Cloud WAN core network when ARN is set | Pod CIDRs unique per spoke, advertised into Cloud WAN |
+| `aviatrix` | `non_routable` | Custom `aviatrix_gateway_snat` (3 policies) | Routes programmed by Aviatrix controller post-attach | Full Aviatrix fabric with overlapping pod CIDRs |
+| `aviatrix` | `routable` | Custom `aviatrix_gateway_snat` (2 policies, no infra-eth0) | Routes programmed by Aviatrix controller post-attach | Full Aviatrix fabric with unique pod CIDRs |
+
+### Standalone spoke (default)
+
+The default configuration (`transit_type = "aws_tgw"`, empty `aws_tgw_id`) deploys a standalone spoke with `single_ip_snat = true` and programs **no** route entries. The operator wires the TGW attachment and route-table entries out-of-band, then sets `aws_tgw_id` and re-applies to let the module take over route management.
+
+## Variables
+
+| Variable | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `name` | `string` | — | yes | Name prefix for all resources (e.g. `"frontend"`, `"team-a"`). |
+| `cluster_name` | `string` | — | yes | EKS cluster name. Used to tag subnets with `kubernetes.io/cluster/<name>=shared`. |
+| `primary_cidr` | `string` | — | yes | Primary VPC CIDR. Subnet math assumes /23 (produces /28 gateway, /26 LB, /26 infra subnets per AZ). |
+| `region` | `string` | — | yes | AWS region. AZs are derived as `<region>a` and `<region>b`. |
+| `aviatrix_aws_account_name` | `string` | — | yes | AWS account name as registered in the Aviatrix Controller. |
+| `pod_cidr` | `string` | `"100.64.0.0/16"` | no | Secondary CIDR for pod networking. May overlap across spokes (SNAT handles translation). |
+| `transit_type` | `string` | `"aws_tgw"` | no | Transit connectivity mode: `aviatrix`, `aws_tgw`, or `aws_cloudwan`. |
+| `pod_cidr_mode` | `string` | `"non_routable"` | no | Whether pod IPs are routable in the fabric: `non_routable` or `routable`. |
+| `transit_gw_name` | `string` | `""` | aviatrix only | Aviatrix transit gateway name. Required when `transit_type = "aviatrix"`; must be empty otherwise. |
+| `aws_tgw_id` | `string` | `""` | no | AWS Transit Gateway ID (e.g. `tgw-0abc...`). Optional when `transit_type = "aws_tgw"` (leave empty for standalone). Must be empty for other transit types. |
+| `aws_cloudwan_core_network_arn` | `string` | `""` | no | AWS Cloud WAN Core Network ARN. Optional when `transit_type = "aws_cloudwan"` (standalone if empty). Must be empty for other transit types. |
+| `east_west_cidrs` | `list(string)` | `["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]` | no | Destination CIDRs programmed on spoke route tables for east-west traffic (native modes only). |
+| `additional_cluster_names` | `list(string)` | `[]` | no | Extra cluster names for `kubernetes.io/cluster/<name>=shared` subnet tags (multi-cluster-per-VPC). |
+| `spoke_instance_size` | `string` | `"t3.medium"` | no | EC2 instance type for the Aviatrix spoke gateway. |
+| `spoke_ha_gw` | `bool` | `false` | no | Deploy an HA spoke gateway. |
+| `enable_vpc_dns_server` | `bool` | `true` | no | Use the VPC DNS server on the gateway (required for hostname SmartGroups and Route53 PHZ resolution). |
+| `tags` | `map(string)` | `{}` | no | Additional tags applied to all resources. |
+
+### Cross-field rules
+
+The module enforces `transit_type`-to-target-variable consistency via an internal validation variable (`_validate_transit_inputs`; do not set it):
+
+- `aviatrix`: `transit_gw_name` is **required** and non-empty; `aws_tgw_id` and `aws_cloudwan_core_network_arn` must be empty.
+- `aws_tgw`: `transit_gw_name` must be empty; `aws_cloudwan_core_network_arn` must be empty; `aws_tgw_id` is optional.
+- `aws_cloudwan`: `transit_gw_name` must be empty; `aws_tgw_id` must be empty; `aws_cloudwan_core_network_arn` is optional.
+
+## SNAT behavior
+
+### aviatrix mode
+
+A dedicated `aviatrix_gateway_snat` resource is created with `snat_mode = "customized_snat"` and three policy classes:
+
+| Policy | src_cidr | dst_cidr | interface | connection | Purpose |
+|---|---|---|---|---|---|
+| 1 | `var.pod_cidr` | `0.0.0.0/0` | (tunnel) | `var.transit_gw_name` | Pod east-west via Aviatrix transit — translate pod IP to spoke GW private IP before entering the fabric. |
+| 2 | `var.pod_cidr` | `0.0.0.0/0` | `eth0` | — | Pod internet egress — translate pod IP to spoke GW private IP before sending to IGW. |
+| 3 | each `infra_private` subnet CIDR | `0.0.0.0/0` | `eth0` | — | Node internet egress — translate node IP to spoke GW private IP (covers EKS node egress). |
+
+### aws_tgw / aws_cloudwan mode
+
+`single_ip_snat = true` is set on the mc-spoke module call. No `aviatrix_gateway_snat` resource is created. SNAT is performed by the Aviatrix gateway for all outbound traffic, masquerading as the gateway's private IP.
+
+## Route-table programming (native modes)
+
+Route entries are only programmed when `transit_type` is `aws_tgw` or `aws_cloudwan` AND the corresponding transit target ID/ARN is non-empty (`local.manage_native_routes = true`). With an empty target (standalone), the module programs nothing.
+
+The spoke gateway's primary ENI (`data.aws_instance.spoke[0].network_interface_id`) is used as the next-hop for non-transit routes.
+
+| Route table | Destination | Next hop | Condition |
+|---|---|---|---|
+| `avx_public` | Each CIDR in `east_west_cidrs` | TGW or Cloud WAN core network | aws_tgw or aws_cloudwan with target set |
+| `infra_private` | `0.0.0.0/0` | Spoke gateway ENI | aws_tgw or aws_cloudwan with target set |
+| `infra_private` | Each CIDR in `east_west_cidrs` | TGW or Cloud WAN core network | aws_tgw or aws_cloudwan with target set |
+| `pod_private` | `0.0.0.0/0` | Spoke gateway ENI | aws_tgw or aws_cloudwan with target set |
+| `pod_private` | Each CIDR in `east_west_cidrs` | Spoke gateway ENI | `pod_cidr_mode = "non_routable"` |
+| `pod_private` | Each CIDR in `east_west_cidrs` | TGW or Cloud WAN core network | `pod_cidr_mode = "routable"` |
+
+All route tables use `lifecycle { ignore_changes = [route] }` so Aviatrix controller-programmed RFC1918 routes (in aviatrix mode) are not removed on re-apply.
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `vpc_id` | VPC ID. |
+| `vpc_cidr` | Primary VPC CIDR. |
+| `pod_cidr` | Secondary VPC CIDR used for pod networking. |
+| `secondary_cidr` | Alias of `pod_cidr` (for callers that prefer this name). |
+| `availability_zones` | AZs used by this spoke (`[<region>a, <region>b]`). |
+| `avx_gateway_subnet_ids` | Aviatrix gateway subnet IDs (one per AZ). |
+| `avx_gateway_subnet_cidrs` | Aviatrix gateway subnet CIDR blocks (one per AZ). |
+| `lb_public_subnet_ids` | Load-balancer public subnet IDs (one per AZ). |
+| `lb_public_subnet_cidrs` | Load-balancer public subnet CIDR blocks. |
+| `infra_private_subnet_ids` | Infrastructure private subnet IDs (EKS node subnets). |
+| `infra_private_subnet_cidrs` | Infrastructure private subnet CIDR blocks. |
+| `pod_private_subnet_ids` | Pod private subnet IDs (from secondary CIDR); consumed by ENIConfig in nodes layer. |
+| `pod_private_subnet_cidrs` | Pod private subnet CIDR blocks. |
+| `infra_private_route_table_id` | Infrastructure private route table ID. |
+| `pod_private_route_table_id` | Pod private route table ID. |
+| `spoke_gateway_name` | Aviatrix spoke gateway name. |
+| `spoke_gateway_private_ip` | Aviatrix spoke gateway private IP (SNAT target for pod traffic). |
+| `spoke_gateway` | Full spoke gateway object from mc-spoke (for advanced callers). |
+| `spoke_vpc` | Spoke VPC object from mc-spoke. |
+
+## Example: Aviatrix transit (full attach)
+
+```hcl
+module "spoke_vpc" {
+  source = "../../modules/aws-eks-spoke-vpc"
+
+  name                      = "frontend"
+  cluster_name              = "frontend-cluster"
+  region                    = "us-east-1"
+  primary_cidr              = "10.1.0.0/23"
+  pod_cidr                  = "100.64.0.0/16"
+  aviatrix_aws_account_name = "my-aws-account"
+
+  transit_type    = "aviatrix"
+  transit_gw_name = "avx-transit-us-east-1"
+}
+```
+
+## Example: AWS TGW (standalone, wired out-of-band)
+
+```hcl
+module "spoke_vpc" {
+  source = "../../modules/aws-eks-spoke-vpc"
+
+  name                      = "backend"
+  cluster_name              = "backend-cluster"
+  region                    = "us-west-2"
+  primary_cidr              = "10.2.0.0/23"
+  aviatrix_aws_account_name = "my-aws-account"
+
+  transit_type = "aws_tgw"
+  # aws_tgw_id intentionally omitted — attachment wired out-of-band.
+  # Set aws_tgw_id = "tgw-0abc..." to have the module manage route entries.
+}
+```
+
+## Example: AWS TGW (module manages routes)
+
+```hcl
+module "spoke_vpc" {
+  source = "../../modules/aws-eks-spoke-vpc"
+
+  name                      = "backend"
+  cluster_name              = "backend-cluster"
+  region                    = "us-west-2"
+  primary_cidr              = "10.2.0.0/23"
+  aviatrix_aws_account_name = "my-aws-account"
+
+  transit_type = "aws_tgw"
+  aws_tgw_id   = "tgw-0abc1234def56789"
+
+  pod_cidr_mode   = "non_routable"
+  east_west_cidrs = ["10.0.0.0/8"]
+}
+```
+
+## Azure forward-looking note
+
+A future `modules/azure-aks-spoke-vnet/` module would mirror this taxonomy with the following mapping:
+
+| AWS concept | Azure equivalent |
+|---|---|
+| `aws_tgw_id` | `vnet_peer_id` + `next_hop_ip` |
+| `aws_cloudwan_core_network_arn` | (Cloud WAN has no Azure equivalent; use `vnet_peer_id`) |
+| `east_west_cidrs` + `aws_route` resources | UDR rules with the same destination set and next-hop IP |
+| `transit_type` enum values | Same values; `aws_cloudwan` would be unused on Azure |
+| `pod_cidr_mode` enum | Unchanged (`routable` / `non_routable`) |
+
+AWS-specific variable names (`aws_tgw_id`, `aws_cloudwan_core_network_arn`) remain AWS-specific. The Azure module would introduce `vnet_peer_id` and `next_hop_ip` instead.
+
+## Deferred / not yet implemented
+
+- **`az_count`**: AZ count is hardcoded to 2. A future `az_count` variable would generalize to N AZs (subnet CIDR math and route-table associations are the affected surfaces).
+- **`enable_public_lb_subnets`**: Public LB subnets are always created. A future toggle would make them optional for internal-only clusters.
+
+## Requirements
+
+| Tool | Version |
+|---|---|
+| Terraform | >= 1.9 |
+| AWS provider | ~> 6.0 |
+| Aviatrix provider | ~> 8.2.0 |
+| mc-spoke module | ~> 8.2.0 |

--- a/modules/aws-eks-spoke-vpc/main.tf
+++ b/modules/aws-eks-spoke-vpc/main.tf
@@ -226,10 +226,17 @@ module "spoke" {
   source  = "terraform-aviatrix-modules/mc-spoke/aviatrix"
   version = "~> 8.2.0"
 
-  cloud      = "AWS"
-  name       = "${var.name}-spoke"
-  account    = var.aviatrix_aws_account_name
-  region     = var.region
+  cloud   = "AWS"
+  name    = "${var.name}-spoke"
+  account = var.aviatrix_aws_account_name
+  region  = var.region
+
+  # Only attach to an Aviatrix transit in aviatrix mode. In native (aws_tgw /
+  # aws_cloudwan) modes the spoke is unattached; mc-spoke gates its
+  # aviatrix_spoke_transit_attachment on var.attached (default true), and that
+  # resource rejects an empty transit_gw_name at plan time -- so attached must
+  # be false here, not just transit_gw = "".
+  attached   = local.is_aviatrix
   transit_gw = local.is_aviatrix ? var.transit_gw_name : ""
 
   instance_size = var.spoke_instance_size

--- a/modules/aws-eks-spoke-vpc/main.tf
+++ b/modules/aws-eks-spoke-vpc/main.tf
@@ -230,12 +230,14 @@ module "spoke" {
   name       = "${var.name}-spoke"
   account    = var.aviatrix_aws_account_name
   region     = var.region
-  transit_gw = var.transit_gw_name
+  transit_gw = local.is_aviatrix ? var.transit_gw_name : ""
 
   instance_size = var.spoke_instance_size
   ha_gw         = var.spoke_ha_gw
 
   enable_vpc_dns_server = var.enable_vpc_dns_server
+
+  single_ip_snat = local.is_native
 
   use_existing_vpc = true
   vpc_id           = aws_vpc.this.id
@@ -260,6 +262,7 @@ module "spoke" {
 #####################
 
 resource "aviatrix_gateway_snat" "this" {
+  count     = local.is_aviatrix ? 1 : 0
   gw_name   = module.spoke.spoke_gateway.gw_name
   snat_mode = "customized_snat"
 

--- a/modules/aws-eks-spoke-vpc/main.tf
+++ b/modules/aws-eks-spoke-vpc/main.tf
@@ -1,0 +1,297 @@
+locals {
+  az_names = [
+    "${var.region}a",
+    "${var.region}b",
+  ]
+
+  default_tags = merge(var.tags, {
+    Name = var.name
+  })
+
+  is_aviatrix          = var.transit_type == "aviatrix"
+  is_native            = var.transit_type == "aws_tgw" || var.transit_type == "aws_cloudwan"
+  native_target        = var.transit_type == "aws_tgw" ? var.aws_tgw_id : var.aws_cloudwan_core_network_arn
+  manage_native_routes = local.is_native && local.native_target != ""
+
+  # Cluster names to tag subnets with for EKS auto-discovery.
+  cluster_names = distinct(concat([var.cluster_name], var.additional_cluster_names))
+}
+
+#####################
+# VPC + secondary CIDR for pods
+#####################
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.primary_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = local.default_tags
+}
+
+resource "aws_vpc_ipv4_cidr_block_association" "secondary" {
+  vpc_id     = aws_vpc.this.id
+  cidr_block = var.pod_cidr
+}
+
+#####################
+# Internet gateway + route tables
+#
+# RFC1918 routes on the private RT are programmed by the Aviatrix spoke
+# gateway after attach. ignore_changes prevents Terraform from removing
+# them on every plan.
+#####################
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-igw"
+  })
+}
+
+resource "aws_route_table" "avx_public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-avx-public-rt"
+    Type = "aviatrix-gateway"
+  })
+
+  lifecycle {
+    ignore_changes = [route]
+  }
+}
+
+resource "aws_route_table" "lb_public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-lb-public-rt"
+    Type = "load-balancer"
+  })
+
+  lifecycle {
+    ignore_changes = [route]
+  }
+}
+
+resource "aws_route_table" "infra_private" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-infra-private-rt"
+    Type = "infrastructure"
+  })
+
+  lifecycle {
+    ignore_changes = [route]
+  }
+}
+
+resource "aws_route_table" "pod_private" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-pod-private-rt"
+    Type = "pod"
+  })
+
+  lifecycle {
+    ignore_changes = [route]
+  }
+}
+
+#####################
+# Aviatrix gateway subnets (/28)
+#####################
+
+resource "aws_subnet" "avx_public" {
+  count                   = 2
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = cidrsubnet(var.primary_cidr, 5, count.index)
+  availability_zone       = local.az_names[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-avx-public-${local.az_names[count.index]}"
+    Type = "aviatrix-gateway"
+  })
+}
+
+resource "aws_route_table_association" "avx_public" {
+  count          = 2
+  subnet_id      = aws_subnet.avx_public[count.index].id
+  route_table_id = aws_route_table.avx_public.id
+}
+
+#####################
+# Load-balancer subnets (/26, public, ELB-tagged)
+#####################
+
+resource "aws_subnet" "lb_public" {
+  count                   = 2
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = cidrsubnet(var.primary_cidr, 3, count.index + 1)
+  availability_zone       = local.az_names[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(
+    var.tags,
+    {
+      Name                     = "${var.name}-lb-public-${local.az_names[count.index]}"
+      Type                     = "load-balancer"
+      "kubernetes.io/role/elb" = "1"
+    },
+    { for n in local.cluster_names : "kubernetes.io/cluster/${n}" => "shared" }
+  )
+}
+
+resource "aws_route_table_association" "lb_public" {
+  count          = 2
+  subnet_id      = aws_subnet.lb_public[count.index].id
+  route_table_id = aws_route_table.lb_public.id
+}
+
+#####################
+# Infrastructure subnets (/26, private, EKS node + internal-elb tagged)
+#####################
+
+resource "aws_subnet" "infra_private" {
+  count             = 2
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = cidrsubnet(var.primary_cidr, 3, count.index + 5)
+  availability_zone = local.az_names[count.index]
+
+  tags = merge(
+    var.tags,
+    {
+      Name                              = "${var.name}-infra-private-${local.az_names[count.index]}"
+      Type                              = "infrastructure"
+      "kubernetes.io/role/internal-elb" = "1"
+    },
+    { for n in local.cluster_names : "kubernetes.io/cluster/${n}" => "shared" }
+  )
+}
+
+resource "aws_route_table_association" "infra_private" {
+  count          = 2
+  subnet_id      = aws_subnet.infra_private[count.index].id
+  route_table_id = aws_route_table.infra_private.id
+}
+
+#####################
+# Pod subnets (/17, from secondary CIDR -- can overlap across spokes)
+#####################
+
+resource "aws_subnet" "pod_private" {
+  count             = 2
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = cidrsubnet(var.pod_cidr, 1, count.index)
+  availability_zone = local.az_names[count.index]
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.name}-pod-private-${local.az_names[count.index]}"
+      Type = "pod"
+    },
+    { for n in local.cluster_names : "kubernetes.io/cluster/${n}" => "shared" }
+  )
+
+  depends_on = [aws_vpc_ipv4_cidr_block_association.secondary]
+}
+
+resource "aws_route_table_association" "pod_private" {
+  count          = 2
+  subnet_id      = aws_subnet.pod_private[count.index].id
+  route_table_id = aws_route_table.pod_private.id
+}
+
+#####################
+# Aviatrix spoke gateway
+#####################
+
+module "spoke" {
+  source  = "terraform-aviatrix-modules/mc-spoke/aviatrix"
+  version = "~> 8.2.0"
+
+  cloud      = "AWS"
+  name       = "${var.name}-spoke"
+  account    = var.aviatrix_aws_account_name
+  region     = var.region
+  transit_gw = var.transit_gw_name
+
+  instance_size = var.spoke_instance_size
+  ha_gw         = var.spoke_ha_gw
+
+  enable_vpc_dns_server = var.enable_vpc_dns_server
+
+  use_existing_vpc = true
+  vpc_id           = aws_vpc.this.id
+  gw_subnet        = aws_subnet.avx_public[0].cidr_block
+  hagw_subnet      = aws_subnet.avx_public[1].cidr_block
+
+  skip_public_route_table_update = false
+}
+
+#####################
+# Custom SNAT for pod traffic
+#
+# Pods use a non-routable secondary CIDR (e.g. 100.64.0.0/16) that may
+# overlap with other spokes. Aviatrix SNAT translates pod source IPs to
+# the spoke gateway private IP before traffic enters transit -- this is
+# what lets multiple spokes share an overlay CIDR.
+#
+# Three policy classes:
+#   1. Pod CIDR -> any destination via transit GW connection
+#   2. Pod CIDR -> internet via eth0
+#   3. Each infra subnet -> internet via eth0 (for EKS node egress)
+#####################
+
+resource "aviatrix_gateway_snat" "this" {
+  gw_name   = module.spoke.spoke_gateway.gw_name
+  snat_mode = "customized_snat"
+
+  snat_policy {
+    src_cidr   = var.pod_cidr
+    dst_cidr   = "0.0.0.0/0"
+    protocol   = "all"
+    interface  = ""
+    connection = var.transit_gw_name
+    snat_ips   = module.spoke.spoke_gateway.private_ip
+  }
+
+  snat_policy {
+    src_cidr   = var.pod_cidr
+    dst_cidr   = "0.0.0.0/0"
+    protocol   = "all"
+    interface  = "eth0"
+    connection = ""
+    snat_ips   = module.spoke.spoke_gateway.private_ip
+  }
+
+  dynamic "snat_policy" {
+    for_each = aws_subnet.infra_private[*].cidr_block
+    content {
+      src_cidr   = snat_policy.value
+      dst_cidr   = "0.0.0.0/0"
+      protocol   = "all"
+      interface  = "eth0"
+      connection = ""
+      snat_ips   = module.spoke.spoke_gateway.private_ip
+    }
+  }
+
+  depends_on = [module.spoke]
+}

--- a/modules/aws-eks-spoke-vpc/main.tf
+++ b/modules/aws-eks-spoke-vpc/main.tf
@@ -298,3 +298,94 @@ resource "aviatrix_gateway_snat" "this" {
 
   depends_on = [module.spoke]
 }
+
+#####################
+# Native-cloud route programming (aws_tgw / aws_cloudwan)
+#
+# In native mode, the Aviatrix Controller does NOT program VPC route tables
+# (that only happens for aviatrix-transit spokes). This module programs them
+# instead, but ONLY when a transit target is actually supplied
+# (local.manage_native_routes). In the standalone default case (empty target),
+# nothing is programmed -- attachment + routes are wired out-of-band.
+#
+# The spoke gateway's primary ENI is the next hop for default + (some)
+# east-west routes. We source it deterministically from the gateway's EC2
+# instance id (cloud_instance_id, confirmed on the aviatrix_spoke_gateway
+# schema).
+#####################
+
+data "aws_instance" "spoke" {
+  count       = local.manage_native_routes ? 1 : 0
+  instance_id = module.spoke.spoke_gateway.cloud_instance_id
+}
+
+locals {
+  spoke_eni_id       = local.manage_native_routes ? data.aws_instance.spoke[0].network_interface_id : null
+  pod_ew_via_gateway = var.pod_cidr_mode == "non_routable"
+}
+
+# avx_public: east-west -> native transit (default route to IGW already on the RT).
+resource "aws_route" "avx_public_ew_tgw" {
+  for_each               = (local.manage_native_routes && var.transit_type == "aws_tgw") ? toset(var.east_west_cidrs) : toset([])
+  route_table_id         = aws_route_table.avx_public.id
+  destination_cidr_block = each.value
+  transit_gateway_id     = var.aws_tgw_id
+}
+
+resource "aws_route" "avx_public_ew_cwan" {
+  for_each               = (local.manage_native_routes && var.transit_type == "aws_cloudwan") ? toset(var.east_west_cidrs) : toset([])
+  route_table_id         = aws_route_table.avx_public.id
+  destination_cidr_block = each.value
+  core_network_arn       = var.aws_cloudwan_core_network_arn
+}
+
+# infra_private: default -> gateway ENI; east-west -> native transit.
+resource "aws_route" "infra_default" {
+  count                  = local.manage_native_routes ? 1 : 0
+  route_table_id         = aws_route_table.infra_private.id
+  destination_cidr_block = "0.0.0.0/0"
+  network_interface_id   = local.spoke_eni_id
+}
+
+resource "aws_route" "infra_ew_tgw" {
+  for_each               = (local.manage_native_routes && var.transit_type == "aws_tgw") ? toset(var.east_west_cidrs) : toset([])
+  route_table_id         = aws_route_table.infra_private.id
+  destination_cidr_block = each.value
+  transit_gateway_id     = var.aws_tgw_id
+}
+
+resource "aws_route" "infra_ew_cwan" {
+  for_each               = (local.manage_native_routes && var.transit_type == "aws_cloudwan") ? toset(var.east_west_cidrs) : toset([])
+  route_table_id         = aws_route_table.infra_private.id
+  destination_cidr_block = each.value
+  core_network_arn       = var.aws_cloudwan_core_network_arn
+}
+
+# pod_private: default -> gateway ENI always; east-west -> gateway ENI (non_routable) or native transit (routable).
+resource "aws_route" "pod_default" {
+  count                  = local.manage_native_routes ? 1 : 0
+  route_table_id         = aws_route_table.pod_private.id
+  destination_cidr_block = "0.0.0.0/0"
+  network_interface_id   = local.spoke_eni_id
+}
+
+resource "aws_route" "pod_ew_gateway" {
+  for_each               = (local.manage_native_routes && local.pod_ew_via_gateway) ? toset(var.east_west_cidrs) : toset([])
+  route_table_id         = aws_route_table.pod_private.id
+  destination_cidr_block = each.value
+  network_interface_id   = local.spoke_eni_id
+}
+
+resource "aws_route" "pod_ew_tgw" {
+  for_each               = (local.manage_native_routes && !local.pod_ew_via_gateway && var.transit_type == "aws_tgw") ? toset(var.east_west_cidrs) : toset([])
+  route_table_id         = aws_route_table.pod_private.id
+  destination_cidr_block = each.value
+  transit_gateway_id     = var.aws_tgw_id
+}
+
+resource "aws_route" "pod_ew_cwan" {
+  for_each               = (local.manage_native_routes && !local.pod_ew_via_gateway && var.transit_type == "aws_cloudwan") ? toset(var.east_west_cidrs) : toset([])
+  route_table_id         = aws_route_table.pod_private.id
+  destination_cidr_block = each.value
+  core_network_arn       = var.aws_cloudwan_core_network_arn
+}

--- a/modules/aws-eks-spoke-vpc/main.tf
+++ b/modules/aws-eks-spoke-vpc/main.tf
@@ -27,6 +27,21 @@ resource "aws_vpc" "this" {
   enable_dns_support   = true
 
   tags = local.default_tags
+
+  # Cross-field transit-input consistency (Terraform >= 1.2 precondition; chosen
+  # over a variable validation so the module can stay at required_version >= 1.5).
+  # aviatrix: transit_gw_name required, aws_* targets empty.
+  # aws_tgw / aws_cloudwan: their own target optional, the other two empty.
+  lifecycle {
+    precondition {
+      condition = (
+        var.transit_type == "aviatrix" ? (var.transit_gw_name != "" && var.aws_tgw_id == "" && var.aws_cloudwan_core_network_arn == "") :
+        var.transit_type == "aws_tgw" ? (var.transit_gw_name == "" && var.aws_cloudwan_core_network_arn == "") :
+        (var.transit_gw_name == "" && var.aws_tgw_id == "")
+      )
+      error_message = "Transit inputs inconsistent with transit_type. aviatrix: set transit_gw_name only (required). aws_tgw: aws_tgw_id optional, others empty. aws_cloudwan: aws_cloudwan_core_network_arn optional, others empty."
+    }
+  }
 }
 
 resource "aws_vpc_ipv4_cidr_block_association" "secondary" {

--- a/modules/aws-eks-spoke-vpc/outputs.tf
+++ b/modules/aws-eks-spoke-vpc/outputs.tf
@@ -1,0 +1,106 @@
+#####################
+# VPC
+#####################
+
+output "vpc_id" {
+  description = "VPC ID."
+  value       = aws_vpc.this.id
+}
+
+output "vpc_cidr" {
+  description = "Primary VPC CIDR."
+  value       = aws_vpc.this.cidr_block
+}
+
+output "pod_cidr" {
+  description = "Secondary VPC CIDR used for pod networking."
+  value       = var.pod_cidr
+}
+
+output "secondary_cidr" {
+  description = "Secondary VPC CIDR used for pod networking (alias of pod_cidr)."
+  value       = var.pod_cidr
+}
+
+output "availability_zones" {
+  description = "Availability zones used by this spoke."
+  value       = local.az_names
+}
+
+#####################
+# Subnets
+#####################
+
+output "avx_gateway_subnet_ids" {
+  description = "Aviatrix gateway subnet IDs (one per AZ)."
+  value       = aws_subnet.avx_public[*].id
+}
+
+output "avx_gateway_subnet_cidrs" {
+  description = "Aviatrix gateway subnet CIDR blocks (one per AZ)."
+  value       = aws_subnet.avx_public[*].cidr_block
+}
+
+output "lb_public_subnet_ids" {
+  description = "Load-balancer public subnet IDs (one per AZ)."
+  value       = aws_subnet.lb_public[*].id
+}
+
+output "lb_public_subnet_cidrs" {
+  description = "Load-balancer public subnet CIDR blocks."
+  value       = aws_subnet.lb_public[*].cidr_block
+}
+
+output "infra_private_subnet_ids" {
+  description = "Infrastructure private subnet IDs -- where EKS nodes live."
+  value       = aws_subnet.infra_private[*].id
+}
+
+output "infra_private_subnet_cidrs" {
+  description = "Infrastructure private subnet CIDR blocks."
+  value       = aws_subnet.infra_private[*].cidr_block
+}
+
+output "pod_private_subnet_ids" {
+  description = "Pod private subnet IDs (from secondary CIDR) -- consumed by ENIConfig in the nodes layer."
+  value       = aws_subnet.pod_private[*].id
+}
+
+output "pod_private_subnet_cidrs" {
+  description = "Pod private subnet CIDR blocks."
+  value       = aws_subnet.pod_private[*].cidr_block
+}
+
+output "infra_private_route_table_id" {
+  description = "Infrastructure private route table ID. Aviatrix (aviatrix mode) or this module (native mode) programs routes here."
+  value       = aws_route_table.infra_private.id
+}
+
+output "pod_private_route_table_id" {
+  description = "Pod private route table ID."
+  value       = aws_route_table.pod_private.id
+}
+
+#####################
+# Spoke gateway
+#####################
+
+output "spoke_gateway_name" {
+  description = "Aviatrix spoke gateway name."
+  value       = module.spoke.spoke_gateway.gw_name
+}
+
+output "spoke_gateway_private_ip" {
+  description = "Aviatrix spoke gateway private IP -- used as the SNAT target for pod traffic."
+  value       = module.spoke.spoke_gateway.private_ip
+}
+
+output "spoke_gateway" {
+  description = "Full spoke gateway object from the mc-spoke module -- exposed for advanced callers."
+  value       = module.spoke.spoke_gateway
+}
+
+output "spoke_vpc" {
+  description = "Spoke VPC object from the mc-spoke module."
+  value       = module.spoke.vpc
+}

--- a/modules/aws-eks-spoke-vpc/outputs.tf
+++ b/modules/aws-eks-spoke-vpc/outputs.tf
@@ -99,8 +99,3 @@ output "spoke_gateway" {
   description = "Full spoke gateway object from the mc-spoke module -- exposed for advanced callers."
   value       = module.spoke.spoke_gateway
 }
-
-output "spoke_vpc" {
-  description = "Spoke VPC object from the mc-spoke module."
-  value       = module.spoke.vpc
-}

--- a/modules/aws-eks-spoke-vpc/variables.tf
+++ b/modules/aws-eks-spoke-vpc/variables.tf
@@ -110,18 +110,8 @@ variable "tags" {
   default     = {}
 }
 
-# Cross-field validation: which transit-target inputs are allowed per transit_type.
-variable "_validate_transit_inputs" {
-  description = "Internal — do not set. Enforces transit_type ↔ target-input consistency."
-  type        = bool
-  default     = true
-
-  validation {
-    condition = var._validate_transit_inputs == (
-      var.transit_type == "aviatrix" ? (var.transit_gw_name != "" && var.aws_tgw_id == "" && var.aws_cloudwan_core_network_arn == "") :
-      var.transit_type == "aws_tgw" ? (var.transit_gw_name == "" && var.aws_cloudwan_core_network_arn == "") :
-      /* aws_cloudwan */ (var.transit_gw_name == "" && var.aws_tgw_id == "")
-    )
-    error_message = "Transit inputs inconsistent with transit_type. aviatrix: set transit_gw_name only (required). aws_tgw: aws_tgw_id optional, others empty. aws_cloudwan: aws_cloudwan_core_network_arn optional, others empty."
-  }
-}
+# NOTE: the cross-field transit-input consistency rule (which target inputs are
+# allowed per transit_type) is enforced by a lifecycle precondition on
+# aws_vpc.this in main.tf, not a variable validation -- variable validations
+# that reference other variables require Terraform >= 1.9, but this module
+# targets >= 1.5. Preconditions (>= 1.2) can reference multiple variables.

--- a/modules/aws-eks-spoke-vpc/variables.tf
+++ b/modules/aws-eks-spoke-vpc/variables.tf
@@ -117,7 +117,7 @@ variable "_validate_transit_inputs" {
   default     = true
 
   validation {
-    condition = (
+    condition = var._validate_transit_inputs == (
       var.transit_type == "aviatrix" ? (var.transit_gw_name != "" && var.aws_tgw_id == "" && var.aws_cloudwan_core_network_arn == "") :
       var.transit_type == "aws_tgw" ? (var.transit_gw_name == "" && var.aws_cloudwan_core_network_arn == "") :
       /* aws_cloudwan */ (var.transit_gw_name == "" && var.aws_tgw_id == "")

--- a/modules/aws-eks-spoke-vpc/variables.tf
+++ b/modules/aws-eks-spoke-vpc/variables.tf
@@ -1,0 +1,127 @@
+variable "name" {
+  description = "Name prefix for all resources in this spoke (e.g. \"frontend\", \"team-a\"). Used directly in resource names and tags."
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "EKS cluster name. Used to tag subnets with kubernetes.io/cluster/<name>=shared so EKS auto-discovery works for LB/Ingress placement."
+  type        = string
+}
+
+variable "primary_cidr" {
+  description = "Primary VPC CIDR. Subnet math assumes /23 and produces /28 Aviatrix-gateway, /26 load-balancer, /26 infrastructure subnets per AZ. Override at your own risk -- a different prefix length shifts all subnet sizes."
+  type        = string
+
+  validation {
+    condition     = can(cidrhost(var.primary_cidr, 0))
+    error_message = "Must be a valid IPv4 CIDR block."
+  }
+}
+
+variable "pod_cidr" {
+  description = "Secondary CIDR for pod networking (VPC CNI custom networking). Can overlap across spokes -- Aviatrix custom SNAT translates pod IPs to the spoke gateway IP before traffic leaves the VPC."
+  type        = string
+  default     = "100.64.0.0/16"
+}
+
+variable "region" {
+  description = "AWS region. Availability zones are derived as <region>a and <region>b."
+  type        = string
+}
+
+variable "aviatrix_aws_account_name" {
+  description = "AWS account name as registered in the Aviatrix Controller."
+  type        = string
+}
+
+variable "transit_type" {
+  description = "How this spoke reaches other VPCs. One of \"aviatrix\" (attach to an Aviatrix transit gateway), \"aws_tgw\" (AWS Transit Gateway), or \"aws_cloudwan\" (AWS Cloud WAN). Drives SNAT shape and route-table programming."
+  type        = string
+  default     = "aws_tgw"
+
+  validation {
+    condition     = contains(["aviatrix", "aws_tgw", "aws_cloudwan"], var.transit_type)
+    error_message = "transit_type must be one of: aviatrix, aws_tgw, aws_cloudwan."
+  }
+}
+
+variable "pod_cidr_mode" {
+  description = "Whether pod IPs are routable across the fabric. \"non_routable\" (default) forces all pod egress through the spoke gateway for SNAT; \"routable\" lets pods take the native-cloud transit path directly for east-west."
+  type        = string
+  default     = "non_routable"
+
+  validation {
+    condition     = contains(["routable", "non_routable"], var.pod_cidr_mode)
+    error_message = "pod_cidr_mode must be one of: routable, non_routable."
+  }
+}
+
+variable "transit_gw_name" {
+  description = "Aviatrix transit gateway name to attach this spoke to. Required iff transit_type = \"aviatrix\"."
+  type        = string
+  default     = ""
+}
+
+variable "aws_tgw_id" {
+  description = "AWS Transit Gateway ID (e.g. tgw-0abc...). Optional even when transit_type = \"aws_tgw\": leave empty for the standalone-spoke case (attachment + routes wired out-of-band). Must be empty for other transit types."
+  type        = string
+  default     = ""
+}
+
+variable "aws_cloudwan_core_network_arn" {
+  description = "AWS Cloud WAN Core Network ARN. Optional even when transit_type = \"aws_cloudwan\" (standalone case). Must be empty for other transit types."
+  type        = string
+  default     = ""
+}
+
+variable "east_west_cidrs" {
+  description = "East-west destination CIDRs programmed on the spoke route tables when transit_type is aws_tgw or aws_cloudwan."
+  type        = list(string)
+  default     = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+}
+
+variable "additional_cluster_names" {
+  description = "Extra cluster names to add as kubernetes.io/cluster/<name>=shared subnet tags, for multi-cluster-per-VPC patterns. The primary cluster_name is always tagged."
+  type        = list(string)
+  default     = []
+}
+
+variable "spoke_instance_size" {
+  description = "EC2 instance type for the Aviatrix spoke gateway."
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "spoke_ha_gw" {
+  description = "Whether to deploy an HA spoke gateway."
+  type        = bool
+  default     = false
+}
+
+variable "enable_vpc_dns_server" {
+  description = "Use the VPC DNS server for gateway management. Required for hostname SmartGroups and resolving Route53 private hosted zones from the gateway."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Additional tags applied to all resources."
+  type        = map(string)
+  default     = {}
+}
+
+# Cross-field validation: which transit-target inputs are allowed per transit_type.
+variable "_validate_transit_inputs" {
+  description = "Internal — do not set. Enforces transit_type ↔ target-input consistency."
+  type        = bool
+  default     = true
+
+  validation {
+    condition = (
+      var.transit_type == "aviatrix" ? (var.transit_gw_name != "" && var.aws_tgw_id == "" && var.aws_cloudwan_core_network_arn == "") :
+      var.transit_type == "aws_tgw" ? (var.transit_gw_name == "" && var.aws_cloudwan_core_network_arn == "") :
+      /* aws_cloudwan */ (var.transit_gw_name == "" && var.aws_tgw_id == "")
+    )
+    error_message = "Transit inputs inconsistent with transit_type. aviatrix: set transit_gw_name only (required). aws_tgw: aws_tgw_id optional, others empty. aws_cloudwan: aws_cloudwan_core_network_arn optional, others empty."
+  }
+}

--- a/modules/aws-eks-spoke-vpc/versions.tf
+++ b/modules/aws-eks-spoke-vpc/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.5"
 
   required_providers {
     aws = {

--- a/modules/aws-eks-spoke-vpc/versions.tf
+++ b/modules/aws-eks-spoke-vpc/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 8.2.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a single-cluster "spoke-in-a-box" EKS blueprint and three reusable repo-root modules, per the design spec (`docs/superpowers/specs/2026-06-04-aws-eks-singlecluster-design.md`).

- **`modules/aws-eks-spoke-vpc/`** — formalized with `transit_type` (aviatrix | aws_tgw | aws_cloudwan) + `pod_cidr_mode` (routable | non_routable) knobs, conditional SNAT, and native-cloud route programming. Cross-field validation enforces the transit-input matrix.
- **`modules/aws-eks-cluster/`, `modules/aws-eks-node-group/`** — hoisted from `blueprints/aws-eks-multicluster/modules/` to repo root (intentional, time-boxed duplication; README banners flag dual-maintenance until multicluster is retargeted on a follow-up branch).
- **`blueprints/aws-eks-singlecluster/`** — four layers (network → cluster → nodes → k8s-apps) consuming those modules. Slimmed DCF ruleset (threat prevention + egress allow-listing), ALB controller (ExternalDNS dropped), Gatus + dcf-crd. Default mode is a standalone `aws_tgw` spoke, ready to attach to any transit post-deploy.

## Validation

- `terraform fmt -check -recursive` clean; `terraform init`+`validate` green on all 3 modules + 3 leaves (fresh-checkout simulation).
- Repo `/validate-blueprint` gate: all Tier 1/2 pass.
- **Live end-to-end deploy against the GA lab controller (us-east-2):** network → cluster → nodes → k8s-apps, then clean reverse teardown (95 resources, no orphans). Nodes reached `Ready`; Gatus pods `1/1 Running`; DCF egress allow-list verified green and GeoBlock threat prevention actively blocking.

The live deploy caught and fixed three issues static validation could not:
1. mc-spoke needs `attached = false` for a standalone spoke (`transit_gw = ""` alone fails at plan time).
2. eks-cluster IRSA roles hit AWS's 38-char IAM `name_prefix` limit → `cluster_name = name_prefix`, capped ≤ 17 with validation.
3. Always-null `spoke_vpc` output dropped; cluster/nodes kubernetes provider pins aligned.

## Test Plan

- [x] `terraform validate` on all modules and layers
- [x] `/validate-blueprint aws-eks-singlecluster` (READY FOR QA)
- [x] Full deploy → app health (Gatus 1/1 Running) → DCF egress/threat verification → reverse destroy, no orphans
- [ ] CoPilot UI verification (Topology / FlowIQ / Security > DCF) — not run this pass; data-plane DCF behavior confirmed via Gatus
- [ ] Native-cloud path with a real TGW id (operator opt-in) — see noted latent duplicate-default-route follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)