### PR TITLE
aws-eks-spoke-vpc: don't manage default route in native modes (controller owns it)

### DIFF
--- a/modules/aws-eks-spoke-vpc/README.md
+++ b/modules/aws-eks-spoke-vpc/README.md
@@ -16,7 +16,7 @@ The module builds every layer needed between raw AWS account credentials and a r
 - **Internet gateway** attached to the public route tables.
 - **Aviatrix spoke gateway** (via the `terraform-aviatrix-modules/mc-spoke/aviatrix` module), optionally attached to an Aviatrix transit.
 - **Custom SNAT** (aviatrix mode only) so pods using a non-routable overlay CIDR are translated to the spoke gateway private IP before entering the transit fabric.
-- **Native-cloud route programming** (aws_tgw / aws_cloudwan mode, when a transit target ID is supplied) with `aws_route` resources on infra_private and pod_private for default + east-west destinations.
+- **Native-cloud route programming** (aws_tgw / aws_cloudwan mode, when a transit target ID is supplied): `aws_route` resources adding east-west destinations to the native transit. The default route stays controller-owned (see Route-table programming below).
 
 ## Transit type and pod-CIDR mode matrix
 
@@ -85,18 +85,17 @@ A dedicated `aviatrix_gateway_snat` resource is created with `snat_mode = "custo
 
 Route entries are only programmed when `transit_type` is `aws_tgw` or `aws_cloudwan` AND the corresponding transit target ID/ARN is non-empty (`local.manage_native_routes = true`). With an empty target (standalone), the module programs nothing.
 
-The spoke gateway's primary ENI (`data.aws_instance.spoke[0].network_interface_id`) is used as the next-hop for non-transit routes.
+**The default route is owned by the Aviatrix Controller, not this module.** Once the single-IP-SNAT spoke gateway is up, the controller programs `0.0.0.0/0 -> spoke gateway ENI` on the private route tables (verified on a live deploy), exactly as in aviatrix-transit mode. `lifecycle { ignore_changes = [route] }` preserves it. The module does **not** add a `0.0.0.0/0` route — doing so collides with the controller's (`RouteAlreadyExists`). The module only adds the east-west overrides below (all targeting the native transit, so no spoke-ENI lookup is needed):
 
 | Route table | Destination | Next hop | Condition |
 |---|---|---|---|
 | `avx_public` | Each CIDR in `east_west_cidrs` | TGW or Cloud WAN core network | aws_tgw or aws_cloudwan with target set |
-| `infra_private` | `0.0.0.0/0` | Spoke gateway ENI | aws_tgw or aws_cloudwan with target set |
 | `infra_private` | Each CIDR in `east_west_cidrs` | TGW or Cloud WAN core network | aws_tgw or aws_cloudwan with target set |
-| `pod_private` | `0.0.0.0/0` | Spoke gateway ENI | aws_tgw or aws_cloudwan with target set |
-| `pod_private` | Each CIDR in `east_west_cidrs` | Spoke gateway ENI | `pod_cidr_mode = "non_routable"` |
-| `pod_private` | Each CIDR in `east_west_cidrs` | TGW or Cloud WAN core network | `pod_cidr_mode = "routable"` |
+| `pod_private` | Each CIDR in `east_west_cidrs` | TGW or Cloud WAN core network | `pod_cidr_mode = "routable"` with target set |
 
-All route tables use `lifecycle { ignore_changes = [route] }` so Aviatrix controller-programmed RFC1918 routes (in aviatrix mode) are not removed on re-apply.
+For `pod_cidr_mode = "non_routable"` the module adds **no** pod-private east-west route: that traffic follows the controller's default route to the gateway, which SNATs it and forwards via the `avx_public` east-west route. The `0.0.0.0/0 -> spoke ENI` default route on `infra_private`/`pod_private` is the controller's in every mode.
+
+All route tables use `lifecycle { ignore_changes = [route] }` so Aviatrix controller-programmed routes are not removed on re-apply.
 
 ## Outputs
 

--- a/modules/aws-eks-spoke-vpc/main.tf
+++ b/modules/aws-eks-spoke-vpc/main.tf
@@ -324,29 +324,36 @@ resource "aviatrix_gateway_snat" "this" {
 #####################
 # Native-cloud route programming (aws_tgw / aws_cloudwan)
 #
-# In native mode, the Aviatrix Controller does NOT program VPC route tables
-# (that only happens for aviatrix-transit spokes). This module programs them
-# instead, but ONLY when a transit target is actually supplied
-# (local.manage_native_routes). In the standalone default case (empty target),
-# nothing is programmed -- attachment + routes are wired out-of-band.
+# Programmed ONLY when a transit target is supplied (local.manage_native_routes);
+# the standalone default (empty target) programs nothing -- attachment + routes
+# are wired out-of-band.
 #
-# The spoke gateway's primary ENI is the next hop for default + (some)
-# east-west routes. We source it deterministically from the gateway's EC2
-# instance id (cloud_instance_id, confirmed on the aviatrix_spoke_gateway
-# schema).
+# IMPORTANT: the default route (0.0.0.0/0 -> spoke gateway ENI) on the private
+# route tables is programmed by the Aviatrix Controller once the single-IP-SNAT
+# spoke gateway is up (verified on a live deploy), exactly as in aviatrix-transit
+# mode; lifecycle ignore_changes=[route] preserves it. This module must NOT also
+# manage the default route -- a module-owned 0.0.0.0/0 -> ENI route collides with
+# the controller's (RouteAlreadyExists) and would need a fragile ENI lookup.
+#
+# So the module only adds the east-west OVERRIDES the controller does not, all of
+# which target the native transit (no ENI involved):
+#   - avx_public:             east_west_cidrs -> native transit
+#                             (the gateway forwards SNAT'd pod/node E-W)
+#   - infra_private:          east_west_cidrs -> native transit
+#                             (nodes reach other VPCs directly)
+#   - pod_private (routable): east_west_cidrs -> native transit
+#                             (routable pods reach other VPCs directly)
+#   - pod_private (non_routable): nothing -- E-W follows the controller's default
+#                             route to the gateway, which SNATs and forwards via
+#                             the avx_public route above.
 #####################
 
-data "aws_instance" "spoke" {
-  count       = local.manage_native_routes ? 1 : 0
-  instance_id = module.spoke.spoke_gateway.cloud_instance_id
-}
-
 locals {
-  spoke_eni_id       = local.manage_native_routes ? data.aws_instance.spoke[0].network_interface_id : null
-  pod_ew_via_gateway = var.pod_cidr_mode == "non_routable"
+  # Routable pods send east-west straight to the native transit; non-routable
+  # pods must traverse the gateway (covered by the controller's default route).
+  pod_ew_to_transit = var.pod_cidr_mode == "routable"
 }
 
-# avx_public: east-west -> native transit (default route to IGW already on the RT).
 resource "aws_route" "avx_public_ew_tgw" {
   for_each               = (local.manage_native_routes && var.transit_type == "aws_tgw") ? toset(var.east_west_cidrs) : toset([])
   route_table_id         = aws_route_table.avx_public.id
@@ -359,14 +366,6 @@ resource "aws_route" "avx_public_ew_cwan" {
   route_table_id         = aws_route_table.avx_public.id
   destination_cidr_block = each.value
   core_network_arn       = var.aws_cloudwan_core_network_arn
-}
-
-# infra_private: default -> gateway ENI; east-west -> native transit.
-resource "aws_route" "infra_default" {
-  count                  = local.manage_native_routes ? 1 : 0
-  route_table_id         = aws_route_table.infra_private.id
-  destination_cidr_block = "0.0.0.0/0"
-  network_interface_id   = local.spoke_eni_id
 }
 
 resource "aws_route" "infra_ew_tgw" {
@@ -383,30 +382,15 @@ resource "aws_route" "infra_ew_cwan" {
   core_network_arn       = var.aws_cloudwan_core_network_arn
 }
 
-# pod_private: default -> gateway ENI always; east-west -> gateway ENI (non_routable) or native transit (routable).
-resource "aws_route" "pod_default" {
-  count                  = local.manage_native_routes ? 1 : 0
-  route_table_id         = aws_route_table.pod_private.id
-  destination_cidr_block = "0.0.0.0/0"
-  network_interface_id   = local.spoke_eni_id
-}
-
-resource "aws_route" "pod_ew_gateway" {
-  for_each               = (local.manage_native_routes && local.pod_ew_via_gateway) ? toset(var.east_west_cidrs) : toset([])
-  route_table_id         = aws_route_table.pod_private.id
-  destination_cidr_block = each.value
-  network_interface_id   = local.spoke_eni_id
-}
-
 resource "aws_route" "pod_ew_tgw" {
-  for_each               = (local.manage_native_routes && !local.pod_ew_via_gateway && var.transit_type == "aws_tgw") ? toset(var.east_west_cidrs) : toset([])
+  for_each               = (local.manage_native_routes && local.pod_ew_to_transit && var.transit_type == "aws_tgw") ? toset(var.east_west_cidrs) : toset([])
   route_table_id         = aws_route_table.pod_private.id
   destination_cidr_block = each.value
   transit_gateway_id     = var.aws_tgw_id
 }
 
 resource "aws_route" "pod_ew_cwan" {
-  for_each               = (local.manage_native_routes && !local.pod_ew_via_gateway && var.transit_type == "aws_cloudwan") ? toset(var.east_west_cidrs) : toset([])
+  for_each               = (local.manage_native_routes && local.pod_ew_to_transit && var.transit_type == "aws_cloudwan") ? toset(var.east_west_cidrs) : toset([])
   route_table_id         = aws_route_table.pod_private.id
   destination_cidr_block = each.value
   core_network_arn       = var.aws_cloudwan_core_network_arn


### PR DESCRIPTION
## Summary

Follow-up to #58, surfaced by the live deploy validation. In native modes (`aws_tgw` / `aws_cloudwan`) the `aws-eks-spoke-vpc` module added `0.0.0.0/0 -> spoke ENI` routes (`infra_default`, `pod_default`) on the private route tables. But the deploy proved the **Aviatrix Controller already programs that default route** once the single-IP-SNAT spoke gateway is up (even unattached), exactly as in aviatrix-transit mode. So on the native-with-TGW path (operator sets `aws_tgw_id`), the module's route would collide with the controller's → `RouteAlreadyExists`.

## Changes

- Remove `aws_route.infra_default` and `aws_route.pod_default` (controller owns `0.0.0.0/0`).
- Remove `aws_route.pod_ew_gateway` (non-routable pod E-W is already covered by the controller's default → gateway route).
- Remove `data.aws_instance.spoke` + the `spoke_eni_id` local — no ENI lookup is needed anymore (all module-added routes target the native transit).
- The module now only adds east-west overrides to TGW/Cloud WAN: `avx_public`, `infra_private`, and `pod_private` when `pod_cidr_mode = "routable"`.
- README route-table table updated to document that the default route is controller-owned.

Standalone default path is unchanged (`manage_native_routes = false` → no module routes; controller still programs the default, verified working end-to-end in #58).

## Test Plan

- [x] `terraform fmt` + `terraform validate` on the module
- [x] `/validate-blueprint aws-eks-singlecluster` → READY FOR QA
- [ ] Live native-with-TGW apply (operator opt-in path) — recommend verifying once a real TGW attachment is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)