### PR TITLE
azure-aks-singlecluster: live QA, fixes, promote to Available

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Blueprints are **complete, deployable lab environments** that demonstrate Aviatr
 | [aws-eks-multicluster](blueprints/aws-eks-multicluster/) | Multi-cluster EKS with Aviatrix transit and Distributed Cloud Firewall | AWS | Verified | ✅ Available |
 | [aws-eks-singlecluster](blueprints/aws-eks-singlecluster/) | Single-cluster EKS spoke-in-a-box with DCF egress filtering; attach to any transit | AWS | Community | ✅ Available |
 | [azure-aks-multicluster](blueprints/azure-aks-multicluster/) | Multi-cluster AKS with Aviatrix transit and DCF (Cilium overlay, AppGW + NGINX two-tier ingress) | Azure | Verified | ✅ Available |
-| [azure-aks-singlecluster](blueprints/azure-aks-singlecluster/) | Single AKS cluster spoke-in-a-box with DCF egress + threat prevention (Aviatrix 9.0 Single IP SNAT route-table selection) | Azure | Community | 🚧 Work in progress |
+| [azure-aks-singlecluster](blueprints/azure-aks-singlecluster/) | Single AKS cluster spoke-in-a-box with DCF egress + threat prevention (Aviatrix 9.0 Single IP SNAT route-table selection) | Azure | Community | ✅ Available |
 | [prevent-lateral-movement-vm-tags](blueprints/prevent-lateral-movement-vm-tags/) | Zero Trust segmentation using DCF and VM tags to prevent lateral movement | AWS | Community | ✅ Available |
 | [zero-trust-segmentation](blueprints/zero-trust-segmentation/) | Zero Trust workload segmentation with DCF SmartGroups | AWS | Community | ✅ Available |
 | [k8s-cluster-aas](blueprints/k8s-cluster-aas/) | Pattern A — dedicated cluster per team (VPC-level isolation) | AWS, Azure, GCP | — | 🚧 Work in progress |

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Blueprints are **complete, deployable lab environments** that demonstrate Aviatr
 | [aws-eks-multicluster](blueprints/aws-eks-multicluster/) | Multi-cluster EKS with Aviatrix transit and Distributed Cloud Firewall | AWS | Verified | ✅ Available |
 | [aws-eks-singlecluster](blueprints/aws-eks-singlecluster/) | Single-cluster EKS spoke-in-a-box with DCF egress filtering; attach to any transit | AWS | Community | ✅ Available |
 | [azure-aks-multicluster](blueprints/azure-aks-multicluster/) | Multi-cluster AKS with Aviatrix transit and DCF (Cilium overlay, AppGW + NGINX two-tier ingress) | Azure | Verified | ✅ Available |
+| [azure-aks-singlecluster](blueprints/azure-aks-singlecluster/) | Single AKS cluster spoke-in-a-box with DCF egress + threat prevention (Aviatrix 9.0 Single IP SNAT route-table selection) | Azure | Community | 🚧 Work in progress |
 | [prevent-lateral-movement-vm-tags](blueprints/prevent-lateral-movement-vm-tags/) | Zero Trust segmentation using DCF and VM tags to prevent lateral movement | AWS | Community | ✅ Available |
 | [zero-trust-segmentation](blueprints/zero-trust-segmentation/) | Zero Trust workload segmentation with DCF SmartGroups | AWS | Community | ✅ Available |
 | [k8s-cluster-aas](blueprints/k8s-cluster-aas/) | Pattern A — dedicated cluster per team (VPC-level isolation) | AWS, Azure, GCP | — | 🚧 Work in progress |

--- a/blueprints/aws-eks-singlecluster/network/dcf.tf
+++ b/blueprints/aws-eks-singlecluster/network/dcf.tf
@@ -263,6 +263,20 @@ resource "aviatrix_web_group" "eks_required" {
 }
 
 #####################
+# Enable Distributed Cloud Firewall (controller-wide)
+#
+# REQUIRED: without this, the ruleset below is configured but NOT enforced —
+# gateways pass all traffic (the egress allow-list "passes" only because nothing
+# is blocked, and the geo/threat DENY rules never fire). This is the global DCF
+# toggle; the ruleset depends_on it so enablement is sequenced first.
+# (Verified live: a standalone spoke does NOT enforce DCF until this is set.)
+#####################
+
+resource "aviatrix_distributed_firewalling_config" "enable" {
+  enable_distributed_firewalling = true
+}
+
+#####################
 # DCF Ruleset
 #####################
 
@@ -275,6 +289,8 @@ resource "aviatrix_dcf_ruleset" "k8s_demo" {
   # TODO: revert to data source once Controller returns correct ID
   # attach_to = data.aviatrix_dcf_attachment_point.tf_before_ui.id
   attach_to = "defa11a1-3000-4001-0000-000000000000"
+
+  depends_on = [aviatrix_distributed_firewalling_config.enable]
 
   #############################
   # THREAT PREVENTION (Priority 0-9)

--- a/blueprints/azure-aks-singlecluster/.gitignore
+++ b/blueprints/azure-aks-singlecluster/.gitignore
@@ -1,0 +1,34 @@
+# Deploy-blueprint env file
+.env.blueprint
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Log files
+*.log

--- a/blueprints/azure-aks-singlecluster/README.md
+++ b/blueprints/azure-aks-singlecluster/README.md
@@ -18,7 +18,7 @@ The blueprint deploys **standalone by default** (no transit attachment). Egress 
 
 A single spoke VNet carries two address spaces — a routable `/23` (`10.30.0.0/23`) and a dedicated pod CIDR (`100.64.0.0/16`) — carved into four subnets, each with its own route table:
 
-- **`<name>-avx-gw` (/28)** — Aviatrix spoke gateway. All cluster egress is SNAT'd here (`single_ip_snat`) and filtered by DCF. Route table is **excluded** from `private_route_table_config` (loop avoidance).
+- **`<name>-avx-gw` (/28)** — Aviatrix spoke gateway. In the default standalone posture, all internet-bound egress is Single-IP-SNAT'd here (`single_ip_snat`) and filtered by DCF; when attached to an Aviatrix transit (`transit_type = "aviatrix"`), east-west traffic is routed over the transit tunnel and only internet-bound egress is SNAT'd. Route table is **excluded** from `private_route_table_config` (loop avoidance).
 - **`<name>-ingress` (/25)** — internal Azure load balancer created by the in-cluster NGINX ingress controller. Route table is **excluded** so the LB replies directly to in-VNet clients (symmetric return path).
 - **`<name>-node` (/24)** — AKS system node pool VMs. Route table gets `0/0 → spoke GW`.
 - **`<name>-pod` (/16)** — pod IPs via Azure CNI pod-subnet mode + Cilium. Route table gets `0/0 → spoke GW`.

--- a/blueprints/azure-aks-singlecluster/README.md
+++ b/blueprints/azure-aks-singlecluster/README.md
@@ -7,6 +7,9 @@ The blueprint deploys **standalone by default** (no transit attachment). Egress 
 > [!NOTE]
 > **Live deploy-verified** (2026-06-05, Controller 9.0.10, provider 9.0.0, AKS 1.33). Full deploy → enforce → destroy cycle validated: the 9.0 Single-IP-SNAT route-table selection, AKS `userDefinedRouting` bring-up, Aviatrix onboarding, internal-LB ingress, and **DCF egress enforcement** (allow-list permits + datapath-confirmed deny) all work. Geo/ThreatIQ blocking additionally requires the Controller's GeoIP/ThreatGuard intelligence feed to be populated — a Controller-side prerequisite independent of this blueprint's (correct) DCF config.
 
+> [!IMPORTANT]
+> **Controller/provider 9.0 only (for now).** This version depends on 9.0-era features — the Single-IP-SNAT `private_route_table_config` explicit-route-table selection and the 9.0 DCF resources. It has **not** been validated against 8.2 or earlier. A future revision will add **backwards compatibility to 8.2** (a Single-IP-SNAT-only path with the older provider, without the 9.0 route-table-selection config). Until then, treat 9.0+ as a hard requirement.
+
 > [!TIP]
 > **🤖 Optimized for Claude Code** — Run `/deploy-blueprint azure-aks-singlecluster` for AI-guided deployment with prerequisite checks and automated orchestration, or `/analyze-blueprint azure-aks-singlecluster` for resource and cost details. [Get Claude Code](https://claude.ai/code)
 

--- a/blueprints/azure-aks-singlecluster/README.md
+++ b/blueprints/azure-aks-singlecluster/README.md
@@ -4,8 +4,8 @@ This blueprint deploys a **single AKS cluster** inside a self-contained "spoke-i
 
 The blueprint deploys **standalone by default** (no transit attachment). Egress is delivered entirely through the Aviatrix **9.0 Single IP SNAT explicit-route-table-selection** feature: the Controller programs `0.0.0.0/0 → spoke gateway` on the node and pod route tables only, leaving the gateway and ingress route tables untouched. It is built on two reusable modules — [`modules/azure-aks-spoke-vnet`](../../modules/azure-aks-spoke-vnet/README.md) and [`modules/azure-aks-cluster`](../../modules/azure-aks-cluster/README.md) — so an operator can attach the spoke to an Aviatrix transit post-deploy by setting one variable and re-applying. It is the Azure analogue of [`aws-eks-singlecluster`](../aws-eks-singlecluster/README.md) and a slimmed single-cluster derivative of [`azure-aks-multicluster`](../azure-aks-multicluster/README.md).
 
-> [!IMPORTANT]
-> **Work in progress — not yet deploy-verified.** The Terraform validates offline (`terraform validate`), but a full apply against a live Controller / Azure subscription has not yet been run. Treat cost figures and the egress allow-list as starting points to verify during your first deploy.
+> [!NOTE]
+> **Live deploy-verified** (2026-06-05, Controller 9.0.10, provider 9.0.0, AKS 1.33). Full deploy → enforce → destroy cycle validated: the 9.0 Single-IP-SNAT route-table selection, AKS `userDefinedRouting` bring-up, Aviatrix onboarding, internal-LB ingress, and **DCF egress enforcement** (allow-list permits + datapath-confirmed deny) all work. Geo/ThreatIQ blocking additionally requires the Controller's GeoIP/ThreatGuard intelligence feed to be populated — a Controller-side prerequisite independent of this blueprint's (correct) DCF config.
 
 > [!TIP]
 > **🤖 Optimized for Claude Code** — Run `/deploy-blueprint azure-aks-singlecluster` for AI-guided deployment with prerequisite checks and automated orchestration, or `/analyze-blueprint azure-aks-singlecluster` for resource and cost details. [Get Claude Code](https://claude.ai/code)
@@ -209,7 +209,7 @@ kubectl -n gatus port-forward svc/gatus 8080:8080
 | Variable | Description | Type | Default | Required |
 |----------|-------------|------|---------|----------|
 | `nginx_ingress_chart_version` | ingress-nginx Helm chart version | string | `"4.11.3"` | no |
-| `k8s_firewall_chart_version` | Aviatrix k8s-firewall Helm chart version | string | `"1.0.0"` | no |
+| `k8s_firewall_chart_version` | Aviatrix k8s-firewall Helm chart version (8.2.0 or 9.0.0) | string | `"9.0.0"` | no |
 | `nginx_lb_ip` | Static internal LB IP (inside the ingress subnet, above the Azure-reserved first 4 hosts) | string | `"10.30.0.200"` | no |
 
 ---
@@ -325,6 +325,12 @@ The mc-spoke module addresses the Azure VNet as `vnet_name:resource_group:vnet_g
 - The AKS API server `authorized_ip_ranges` **must include the spoke GW public IP** — nodes egress through it. The cluster module appends it automatically, so do not strip it. The cluster layer defaults `authorized_ip_ranges` to `0.0.0.0/0` for lab convenience; **this exposes the API server publicly — lock it down to your admin IP for non-lab use** (the spoke GW IP is still appended).
 - If provisioning stalls reaching package mirrors, the DCF egress allow-list may be missing an SNI. `acs-mirror.azureedge.net` / `packages.aks.azure.com` and the other Azure / AKS-required SNIs are included in `network/dcf.tf`; add any others your image needs.
 
+### AKS create fails with `ErrCode_InsufficientVCPUQuota`
+
+**Symptom:** the cluster layer apply fails creating the AKS cluster: `Insufficient vcpu quota requested 4, remaining 0 for family standardBSFamily`.
+
+**Cause / fix:** the subscription/region has no remaining vCPU quota for the node VM family (the default `Standard_B2s` is `standardBSFamily`). Either request a quota increase, or override the node size via `node_pool_config.vm_size` to a family with quota (e.g., `Standard_D2s_v3`). Check with `az vm list-usage --location <region> -o table`.
+
 ### GitHub Aviatrix WebGroup matches nothing
 
 **Symptom:** repo fetches to `github.com/AviatrixSystems/...` fail closed even though the WebGroup exists.
@@ -396,16 +402,17 @@ az group show --name "<name_prefix>-rg"   # expect: ResourceGroupNotFound
 
 | Component | Version |
 |-----------|---------|
-| Aviatrix Controller / CoPilot | 9.0.x (**9.0+ required**) |
+| Aviatrix Controller / CoPilot | 9.0.10 (**9.0+ required**) |
 | Aviatrix Terraform Provider | 9.0.0 |
-| Terraform | >= 1.7 |
-| azurerm Provider | ~> 4.0 |
+| Terraform | 1.14.0 (>= 1.7) |
+| azurerm Provider | 4.76.0 (~> 4.0) |
 | kubernetes Provider | ~> 2.30 |
 | helm Provider | ~> 2.16 |
 | `terraform-aviatrix-modules/mc-spoke/aviatrix` | 9.0.0 |
+| `k8s-firewall` Helm chart | 9.0.0 |
 | Kubernetes (AKS) | 1.33 |
 
-> **Status: work-in-progress / not yet deploy-verified.** Versions above are the pins the configuration targets; a full live deploy/destroy cycle has not yet been validated. The blueprint may work with other versions.
+> **Status: live deploy-verified (2026-06-05).** Full deploy → DCF enforcement → destroy cycle validated on the versions above. Geo/ThreatIQ blocking depends on the Controller's GeoIP/ThreatGuard feed being populated (see the note at the top). The blueprint may work with other versions.
 
 ---
 

--- a/blueprints/azure-aks-singlecluster/README.md
+++ b/blueprints/azure-aks-singlecluster/README.md
@@ -1,0 +1,418 @@
+# Single-Cluster AKS Spoke-in-a-Box Secured by the Aviatrix Cloud Native Security Fabric
+
+This blueprint deploys a **single AKS cluster** inside a self-contained "spoke-in-a-box" Azure VNet, fronted by an Aviatrix spoke gateway that performs **Distributed Cloud Firewall (DCF) egress filtering**. It demonstrates the Aviatrix Cloud Native Security Fabric (CNSF) for Kubernetes — threat prevention (GeoBlock + ThreatIQ), egress allow-listing with WebGroups (SNI / URL filtering), and Zero Trust enforcement — on a deliberately minimal Azure footprint.
+
+The blueprint deploys **standalone by default** (no transit attachment). Egress is delivered entirely through the Aviatrix **9.0 Single IP SNAT explicit-route-table-selection** feature: the Controller programs `0.0.0.0/0 → spoke gateway` on the node and pod route tables only, leaving the gateway and ingress route tables untouched. It is built on two reusable modules — [`modules/azure-aks-spoke-vnet`](../../modules/azure-aks-spoke-vnet/README.md) and [`modules/azure-aks-cluster`](../../modules/azure-aks-cluster/README.md) — so an operator can attach the spoke to an Aviatrix transit post-deploy by setting one variable and re-applying. It is the Azure analogue of [`aws-eks-singlecluster`](../aws-eks-singlecluster/README.md) and a slimmed single-cluster derivative of [`azure-aks-multicluster`](../azure-aks-multicluster/README.md).
+
+> [!IMPORTANT]
+> **Work in progress — not yet deploy-verified.** The Terraform validates offline (`terraform validate`), but a full apply against a live Controller / Azure subscription has not yet been run. Treat cost figures and the egress allow-list as starting points to verify during your first deploy.
+
+> [!TIP]
+> **🤖 Optimized for Claude Code** — Run `/deploy-blueprint azure-aks-singlecluster` for AI-guided deployment with prerequisite checks and automated orchestration, or `/analyze-blueprint azure-aks-singlecluster` for resource and cost details. [Get Claude Code](https://claude.ai/code)
+
+---
+
+## Architecture
+
+![Architecture Diagram](architecture.svg)
+
+A single spoke VNet carries two address spaces — a routable `/23` (`10.30.0.0/23`) and a dedicated pod CIDR (`100.64.0.0/16`) — carved into four subnets, each with its own route table:
+
+- **`<name>-avx-gw` (/28)** — Aviatrix spoke gateway. All cluster egress is SNAT'd here (`single_ip_snat`) and filtered by DCF. Route table is **excluded** from `private_route_table_config` (loop avoidance).
+- **`<name>-ingress` (/25)** — internal Azure load balancer created by the in-cluster NGINX ingress controller. Route table is **excluded** so the LB replies directly to in-VNet clients (symmetric return path).
+- **`<name>-node` (/24)** — AKS system node pool VMs. Route table gets `0/0 → spoke GW`.
+- **`<name>-pod` (/16)** — pod IPs via Azure CNI pod-subnet mode + Cilium. Route table gets `0/0 → spoke GW`.
+
+### Egress data flow
+
+```
+   Pod / Node (VNet IP)
+        │  UDR 0.0.0.0/0  (programmed by the Controller on node + pod route tables)
+        ▼
+   Aviatrix Spoke Gateway
+        │  DCF inspection (GeoBlock / ThreatIQ deny → egress allow-list)
+        │  Single IP SNAT (every workload egresses as the GW public IP)
+        ▼
+   Internet
+```
+
+The DCF ruleset blocks GeoBlocked countries (IR / KP / RU) and ThreatIQ (major/critical) destinations first, then permits only the Azure / AKS-required SNIs and a small allow-list of domains (kubernetes.io, npm, GitHub Aviatrix repos). There is **no default-deny rule** — a `0.0.0.0/0` deny would also match RFC1918 inter-VNet traffic, which would break east-west once a transit is attached.
+
+The spoke is **standalone by default** (`transit_type = "none"`) — there is no east-west connectivity until a transit target is supplied. The dashed line in the diagram shows the optional post-deploy Aviatrix transit attachment (`transit_type = "aviatrix"` + `transit_gw_name`).
+
+---
+
+## Prerequisites
+
+See [docs/prerequisites/](../../docs/prerequisites/README.md) for detailed install guides.
+
+### Aviatrix Infrastructure
+
+| Component | Requirement | Notes |
+|-----------|-------------|-------|
+| **[Aviatrix Control Plane](../../docs/prerequisites/aviatrix-controller.md)** | **9.0+ REQUIRED** | `private_route_table_config` + Single IP SNAT route-table selection on Azure are 9.0-only. On 8.2 the plan/apply will drift. Controller + CoPilot, or an Aviatrix Cloud Fabric subscription. |
+| **Azure account onboarded** | Azure access account registered in the Controller | Use the exact account name for `aviatrix_azure_account_name`. The account's service principal needs Contributor (or `listClusterUserCredential` at subscription scope) so the Controller can onboard the AKS cluster. |
+| **Aviatrix Terraform provider** | `~> 9.0` | Matches the Controller. |
+
+### Local Tools
+
+| Tool | Version | Installation | Purpose |
+|------|---------|--------------|---------|
+| **Terraform** | >= 1.7 | [Guide](../../docs/prerequisites/terraform.md) | Infrastructure provisioning |
+| **Azure CLI** | Latest | [Guide](../../docs/prerequisites/azure-cli.md) | `az login` auth + `az aks get-credentials` |
+| **kubectl** | Latest | [Guide](../../docs/prerequisites/kubectl.md) | Cluster interaction, applying k8s-apps |
+| **helm** | v3 | [Helm install](https://helm.sh/docs/intro/install/) | ingress-nginx / k8s-firewall charts (installed via Terraform) |
+
+### Required Access
+
+- An Azure subscription with quota for AKS, 2× `Standard_B2s` nodes, 1× `Standard_D2s_v3` gateway VM, a public IP, and a Standard internal load balancer.
+- `az login` completed (the `azurerm` provider uses the Azure CLI credential chain by default).
+- Aviatrix Controller credentials (IP / username / password) supplied via the `network/` and `cluster/` tfvars.
+
+---
+
+## Resources Created
+
+| Component | Resource | Qty | Size / Detail | Hourly | Monthly (~730h) |
+|-----------|----------|-----|---------------|--------|-----------------|
+| Aviatrix Spoke Gateway | VM | 1 | Standard_D2s_v3 (2 vCPU / 8 GB), single_ip_snat, no HA | ~$0.10 | ~$70 |
+| Spoke GW public IP | Public IP | 1 | Standard, static | ~$0.005 | ~$4 |
+| AKS Control Plane | AKS | 1 | Kubernetes 1.33 (free tier, Azure-managed) | $0 | $0 |
+| AKS Node Pool | VM | 2 (desired) | Standard_B2s, min 1 / max 3 | ~$0.10 | ~$70 |
+| Internal LB (NGINX ingress) | Load Balancer | 1 | Standard, internal | ~$0.025 | ~$18 |
+| VNet + subnets + route tables | Networking | 1 VNet | 4 subnet tiers, 4 route tables, no NAT Gateway | Free | $0 |
+| DCF SmartGroups / WebGroups / Ruleset | Aviatrix | — | Threat prevention + egress allow-list | — | — |
+| Node / pod managed disks | OS disk | ~2 | ~30 GB each | — | ~$5 |
+
+**Estimated cost:** **~$0.23/hour (~$170/month)** in East US 2 when running.
+
+> Figures are **approximate and vary by region** — verify in the [Azure Pricing Calculator](https://azure.microsoft.com/pricing/calculator/). Excludes Aviatrix licensing (PAYG or BYOL), load-balancer data-processing charges, and internet egress data transfer. No NAT Gateway is deployed — Aviatrix Single IP SNAT replaces it.
+
+---
+
+## Deployment
+
+The blueprint is a **4-layer** deployment. Deploy in order: **network → cluster → nodes → k8s-apps**.
+
+```
+network/    Layer 1  Spoke VNet (module), Aviatrix spoke GW (Single IP SNAT), DCF SmartGroups/WebGroups/Ruleset
+cluster/    Layer 2  AKS control plane, workload identity, role assignments, Controller onboarding
+nodes/      Layer 3  ingress-nginx (internal Azure LB) + Aviatrix k8s-firewall CRD controller (Helm)
+k8s-apps/   Layer 4  Gatus (kubectl apply); optional DCF CRD examples
+```
+
+Each layer reads the previous layer's outputs via `data "terraform_remote_state"` (local state only — no remote backend).
+
+> **Automated:** `/deploy-blueprint azure-aks-singlecluster` orchestrates all layers with prerequisite checks.
+
+### Step 0: Authenticate
+
+```bash
+az login
+az account set --subscription "<your-subscription>"
+```
+
+The Aviatrix Controller IP / username / password are supplied via tfvars (see below), not environment variables.
+
+### Step 1: Network layer (~5-8 min)
+
+```bash
+cd network/
+terraform init -upgrade
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars: aviatrix_azure_account_name, azure_region + aviatrix_azure_region
+# (BOTH region forms), name_prefix, and the aviatrix_controller_ip/username/password.
+# Leave transit_type = "none" for a standalone spoke.
+terraform apply
+```
+
+Creates: the spoke VNet (`10.30.0.0/23` + pod `100.64.0.0/16`), four subnets and route tables, the Aviatrix spoke gateway with Single IP SNAT, and the DCF ruleset (SmartGroups, WebGroups, threat-prevention + egress allow rules).
+
+### Step 2: Cluster layer (~10-15 min)
+
+```bash
+cd ../cluster/
+terraform init
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars: aviatrix_controller_ip/username/password,
+# aviatrix_controller_public_ip (for the AKS API allow-list), and
+# authorized_ip_ranges (lock down for non-lab use).
+terraform apply
+```
+
+Creates: the AKS control plane (K8s 1.33, Azure CNI pod-subnet mode + Cilium, `outbound_type = userDefinedRouting`), a user-assigned identity with Network Contributor over the VNet and node/pod route tables, the inline system node pool, and Aviatrix Controller onboarding.
+
+### Step 3: Nodes layer (~3-5 min)
+
+```bash
+cd ../nodes/
+terraform init
+cp terraform.tfvars.example terraform.tfvars
+terraform apply
+```
+
+Creates: the ingress-nginx Helm release (an **internal** Azure LB in the ingress subnet) and the Aviatrix k8s-firewall CRD controller Helm release.
+
+### Step 4: Configure kubectl + deploy k8s-apps (~1-2 min)
+
+```bash
+cd ../cluster/
+$(terraform output -raw configure_kubectl)   # az aks get-credentials ...
+kubectl get nodes   # should show 2 Ready nodes
+
+# Deploy Gatus (ClusterIP Service + NGINX Ingress)
+kubectl apply -f ../k8s-apps/gatus.yaml
+
+# Optional: apply the namespace-level DCF CRD examples
+kubectl apply -f ../k8s-apps/dcf-crd/
+
+# Reach the Gatus dashboard via the internal LB IP (from inside the VNet,
+# or port-forward):
+kubectl -n gatus port-forward svc/gatus 8080:8080
+```
+
+**Total deployment time:** ~20-30 minutes.
+
+---
+
+## Variables
+
+### Network layer (`network/`)
+
+| Variable | Description | Type | Default | Required |
+|----------|-------------|------|---------|----------|
+| `name_prefix` | Prefix for all resources; also the AKS cluster name (1-20 chars) | string | `"aks-single"` | no |
+| `azure_region` | Azure region (azurerm form, e.g. `eastus2`) | string | `"eastus2"` | no |
+| `aviatrix_azure_region` | Azure region (Aviatrix form, e.g. `East US 2`) | string | `"East US 2"` | no |
+| `aviatrix_azure_account_name` | Azure access account name as onboarded in the Controller | string | — | **yes** |
+| `vnet_cidr` | Routable /23 CIDR for the spoke VNet | string | `"10.30.0.0/23"` | no |
+| `pod_cidr` | Dedicated pod subnet CIDR | string | `"100.64.0.0/16"` | no |
+| `transit_type` | `none` (standalone) \| `aviatrix` (attach to transit) | string | `"none"` | no |
+| `transit_gw_name` | Aviatrix transit gateway name (required when `transit_type = aviatrix`) | string | `""` | no |
+| `aviatrix_controller_ip` | Aviatrix Controller IP / hostname | string | — | **yes** |
+| `aviatrix_username` | Controller username | string | — | **yes** |
+| `aviatrix_password` | Controller password (sensitive) | string | — | **yes** |
+
+### Cluster layer (`cluster/`)
+
+| Variable | Description | Type | Default | Required |
+|----------|-------------|------|---------|----------|
+| `kubernetes_version` | AKS Kubernetes version | string | `"1.33"` | no |
+| `node_pool_config` | System node pool sizing (`node_count`, `min_count`, `max_count`, `vm_size`) | object | `{2, 1, 3, "Standard_B2s"}` | no |
+| `authorized_ip_ranges` | Extra CIDRs allowed to reach the AKS API server (spoke GW IP appended automatically) | list(string) | `["0.0.0.0/0"]` | no |
+| `enable_aviatrix_onboarding` | Register the cluster with the Controller for K8s SmartGroups | bool | `true` | no |
+| `aviatrix_controller_public_ip` | Controller public egress IP for the AKS API allow-list when onboarding | string | `null` | no |
+| `aviatrix_controller_ip` / `aviatrix_username` / `aviatrix_password` | Controller credentials | string | — | **yes** |
+
+### Nodes layer (`nodes/`)
+
+| Variable | Description | Type | Default | Required |
+|----------|-------------|------|---------|----------|
+| `nginx_ingress_chart_version` | ingress-nginx Helm chart version | string | `"4.11.3"` | no |
+| `k8s_firewall_chart_version` | Aviatrix k8s-firewall Helm chart version | string | `"1.0.0"` | no |
+| `nginx_lb_ip` | Static internal LB IP (inside the ingress subnet, above the Azure-reserved first 4 hosts) | string | `"10.30.0.200"` | no |
+
+---
+
+## Outputs
+
+### Network layer
+
+| Output | Description |
+|--------|-------------|
+| `name_prefix` / `azure_region` | Naming + region passthrough |
+| `resource_group_name` | Spoke resource group |
+| `vnet_id` | Spoke VNet resource ID |
+| `cluster_name` | Derived AKS cluster name |
+| `node_subnet_id` / `pod_subnet_id` / `ingress_subnet_id` / `ingress_subnet_name` | Subnet IDs / ingress subnet name |
+| `node_route_table_id` / `pod_route_table_id` | Route table IDs (for AKS identity role assignments) |
+| `spoke_gateway_name` / `spoke_gateway_public_ip` | Aviatrix spoke gateway name + SNAT public IP |
+| `service_cidr` / `dns_service_ip` | Kubernetes service CIDR + DNS IP |
+| `dcf_ruleset_uuid` | UUID of the DCF egress ruleset |
+| `smartgroup_cluster_vpc_uuid` | UUID of the cluster VNet SmartGroup |
+
+### Cluster layer
+
+| Output | Description |
+|--------|-------------|
+| `cluster_id` / `cluster_name` | AKS cluster identity |
+| `oidc_issuer_url` | OIDC issuer (workload identity) |
+| `host` / `client_certificate` / `client_key` / `cluster_ca_certificate` | Kubeconfig material (sensitive) |
+| `configure_kubectl` | `az aks get-credentials` command |
+
+### Nodes layer
+
+| Output | Description |
+|--------|-------------|
+| `nginx_ingress_namespace` | ingress-nginx namespace |
+| `nginx_lb_ip` | Internal LB IP |
+| `k8s_firewall_namespace` | k8s-firewall namespace |
+
+---
+
+## Test Scenarios
+
+### Scenario 1: Egress allow-list (DCF permits)
+
+The Gatus dashboard's **Egress** group probes `kubernetes.io`, `registry.npmjs.org`, and the Aviatrix GitHub repo — all explicitly allow-listed via WebGroups in `network/dcf.tf`.
+
+```bash
+kubectl -n gatus port-forward svc/gatus 8080:8080   # open http://localhost:8080
+```
+
+**Expected:** all Egress endpoints are **green** (reachable).
+
+### Scenario 2: Threat prevention (DCF blocks)
+
+The **Threats** group probes a GeoBlocked destination (Iran) and a threat-intel sample IP, matched by the GeoBlock (IR / KP / RU) and ThreatIQ (major/critical) SmartGroups.
+
+**Expected:** Threat endpoints are **red / blocked**. The threat-feed IP must be present in your current ThreatIQ feed — update it in `k8s-apps/gatus.yaml` if your feed differs, or rely on the GeoBlock probe.
+
+### Scenario 3: Verify in CoPilot
+
+1. **Security > Distributed Cloud Firewall** — confirm the `<name_prefix>-egress` ruleset and its rules (GeoBlock deny, ThreatIQ deny, then the egress permits).
+2. **FlowIQ** — generate traffic from Gatus and confirm permitted flows for allow-listed domains and dropped flows for the threat / geo destinations.
+3. **Topology** — confirm the spoke gateway and VNet appear (and the transit edge once attached).
+
+### Scenario 4: East-west after attaching to a transit
+
+The spoke is standalone by default (no east-west). To validate east-west:
+
+```bash
+cd network/
+# In terraform.tfvars set transit_type = "aviatrix" and transit_gw_name = "<your-transit>", then:
+terraform apply
+```
+
+The Controller then programs east-west routes. Verify reachability to another spoke / VNet behind the same transit.
+
+---
+
+## CoPilot Verification
+
+| View | What to confirm |
+|------|-----------------|
+| **Topology** | Spoke gateway + VNet visible; transit edge appears once attached |
+| **FlowIQ** | Permitted egress to allow-listed domains; dropped flows to threat / geo destinations |
+| **Security > DCF** | `<name_prefix>-egress` ruleset, SmartGroups (cluster VNet, GeoBlock, ThreatIQ), WebGroups |
+| **Security > Threat Prevention** | GeoBlock / ThreatIQ hits on the blocked probes |
+
+---
+
+## Troubleshooting
+
+### Aviatrix-programmed 0/0 route drifts or is missing (Controller < 9.0)
+
+**Symptom:** `terraform plan` keeps proposing to remove the `0.0.0.0/0 → spoke GW` route, or it never appears.
+
+**Cause:** `private_route_table_config` and Single IP SNAT route-table selection on Azure are **9.0-only**. On Controller 8.2 the feature is not honored. **This blueprint requires Controller / CoPilot 9.0+.** Upgrade the Controller; do not remove the `lifecycle { ignore_changes = [route] }` blocks on the route tables.
+
+### Region name duality
+
+**Symptom:** the spoke gateway lands in a different region than the VNet, or the Controller rejects the region.
+
+**Cause:** Azure needs two region forms. `azure_region` is the azurerm form (`eastus2`); `aviatrix_azure_region` is the Aviatrix form (`East US 2`). **Both are required** and must refer to the same region.
+
+### `vpc_id` format for the spoke
+
+The mc-spoke module addresses the Azure VNet as `vnet_name:resource_group:vnet_guid` (not an Azure resource ID). The module builds this automatically; if you reference the spoke from other Aviatrix resources, use the `aviatrix_vpc_id` output, not `vnet_id`.
+
+### AKS nodes never become Ready / CSE bootstrap fails
+
+**Symptom:** node provisioning stalls; the kubelet custom-script-extension (CSE) bootstrap times out.
+
+**Cause / fix:**
+- The AKS API server `authorized_ip_ranges` **must include the spoke GW public IP** — nodes egress through it. The cluster module appends it automatically, so do not strip it. The cluster layer defaults `authorized_ip_ranges` to `0.0.0.0/0` for lab convenience; **this exposes the API server publicly — lock it down to your admin IP for non-lab use** (the spoke GW IP is still appended).
+- If provisioning stalls reaching package mirrors, the DCF egress allow-list may be missing an SNI. `acs-mirror.azureedge.net` / `packages.aks.azure.com` and the other Azure / AKS-required SNIs are included in `network/dcf.tf`; add any others your image needs.
+
+### GitHub Aviatrix WebGroup matches nothing
+
+**Symptom:** repo fetches to `github.com/AviatrixSystems/...` fail closed even though the WebGroup exists.
+
+**Cause:** that WebGroup uses **URL-path filtering** (`urlfilter`), and path-level matching requires L7 / DPI. Verify on the live Controller that the path match is actually evaluated for your traffic; if not, fall back to an SNI (`snifilter = "github.com"`) match or widen the rule.
+
+### Aviatrix onboarding fails (Entra-only auth)
+
+**Symptom:** `aviatrix_kubernetes_cluster` errors fetching kubeconfig.
+
+**Cause:** the Controller fetches a **local-account kubeconfig** via ARM `listClusterUserCredential`. Entra-ID-only AKS auth is **not supported** — the cluster must use Kubernetes RBAC with local accounts, and the Controller's public egress IP must be in `authorized_ip_ranges` (set `aviatrix_controller_public_ip`).
+
+### Layer ordering / count errors
+
+**Cause:** layers deployed out of order. Always deploy **network → cluster → nodes**, and confirm the prior layer's `terraform.tfstate` exists before the next.
+
+---
+
+## Cleanup
+
+Destroy in **reverse order**. Remove Kubernetes LoadBalancer / Ingress resources and the k8s-firewall CRDs first so the internal Azure LB is torn down before its subnet, and so the CRD finalizers don't block deletion.
+
+```bash
+# Step 1: remove k8s-apps and the internal LB
+kubectl delete -f k8s-apps/dcf-crd/   # remove CRD policies first (finalizers)
+kubectl delete -f k8s-apps/gatus.yaml
+kubectl delete svc --all -n ingress-nginx   # delete the internal LB service
+sleep 60                                     # wait for the Azure LB to detach
+
+# Step 2: nodes layer (ingress-nginx + k8s-firewall Helm releases)
+cd nodes/ && terraform destroy
+
+# Step 3: cluster layer (AKS, identity, onboarding)
+cd ../cluster/ && terraform destroy
+
+# Step 4: network layer (spoke GW, VNet, DCF policies)
+cd ../network/ && terraform destroy
+```
+
+### Pod-subnet delegation caveat (`SubnetMissingRequiredDelegation`)
+
+AKS attaches a `Microsoft.ContainerService/managedClusters` delegation to the pod subnet in pod-subnet mode. The module already sets `lifecycle { ignore_changes = [delegation] }` on the pod subnet, but the **network destroy can still fail** on the pod subnet / route-table association if the AKS service-association link lingers after the cluster layer is destroyed.
+
+If `terraform destroy` on the `network/` layer fails with `SubnetMissingRequiredDelegation`:
+
+```bash
+# Destroy everything EXCEPT the pod subnet first, give Azure time to release the
+# service-association link, then destroy the remainder.
+cd network/
+terraform destroy -target=module.spoke_vnet.module.spoke \
+                  -target=module.spoke_vnet.azurerm_subnet_route_table_association.pod
+# wait a few minutes for AKS to fully release the pod subnet, then:
+terraform destroy
+```
+
+(See the `azure_aks_pod_subnet_delegation_drift` learning for background.)
+
+### Verify cleanup
+
+```bash
+az group show --name "<name_prefix>-rg"   # expect: ResourceGroupNotFound
+```
+
+> If a destroy leaves stale DCF SmartGroups / WebGroups on the Controller, remove them from CoPilot **Security > DCF**.
+
+---
+
+## Tested With
+
+| Component | Version |
+|-----------|---------|
+| Aviatrix Controller / CoPilot | 9.0.x (**9.0+ required**) |
+| Aviatrix Terraform Provider | 9.0.0 |
+| Terraform | >= 1.7 |
+| azurerm Provider | ~> 4.0 |
+| kubernetes Provider | ~> 2.30 |
+| helm Provider | ~> 2.16 |
+| `terraform-aviatrix-modules/mc-spoke/aviatrix` | 9.0.0 |
+| Kubernetes (AKS) | 1.33 |
+
+> **Status: work-in-progress / not yet deploy-verified.** Versions above are the pins the configuration targets; a full live deploy/destroy cycle has not yet been validated. The blueprint may work with other versions.
+
+---
+
+## Related
+
+- [`modules/azure-aks-spoke-vnet`](../../modules/azure-aks-spoke-vnet/README.md) — the spoke-in-a-box VNet module (Single IP SNAT + `private_route_table_config` route-table selection).
+- [`modules/azure-aks-cluster`](../../modules/azure-aks-cluster/README.md) — the AKS cluster module (Azure CNI + Cilium, workload identity, Aviatrix onboarding).
+- [`aws-eks-singlecluster`](../aws-eks-singlecluster/README.md) — the AWS analogue this blueprint mirrors.
+- [`azure-aks-multicluster`](../azure-aks-multicluster/README.md) — the multi-cluster Azure blueprint this is derived from.
+- `k8s-apps/dcf-crd/` — standalone FirewallPolicy / WebGroupPolicy CRD examples for in-cluster, namespace-level controls.

--- a/blueprints/azure-aks-singlecluster/architecture.svg
+++ b/blueprints/azure-aks-singlecluster/architecture.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 660" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#37474f"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#2e7d32"/>
+    </marker>
+    <marker id="arrowDash" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#90a4ae"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="960" height="660" fill="#fafafa"/>
+  <text x="480" y="32" text-anchor="middle" font-size="21" font-weight="bold" fill="#263238">azure-aks-singlecluster — AKS spoke-in-a-box with Aviatrix DCF egress filtering</text>
+
+  <!-- Internet -->
+  <ellipse cx="120" cy="92" rx="72" ry="28" fill="#eceff1" stroke="#607d8b" stroke-width="2"/>
+  <text x="120" y="98" text-anchor="middle" font-size="15" fill="#263238">Internet</text>
+
+  <!-- Internet <-> spoke GW public IP -->
+  <line x1="120" y1="120" x2="120" y2="298" stroke="#2e7d32" stroke-width="2" marker-end="url(#arrowGreen)"/>
+  <text x="128" y="210" font-size="10" fill="#2e7d32" transform="rotate(90 128 210)">DCF-filtered egress via spoke GW public IP (Single IP SNAT)</text>
+
+  <!-- VNet box -->
+  <rect x="40" y="150" width="660" height="470" rx="10" fill="#e3f2fd" stroke="#1976d2" stroke-width="2"/>
+  <text x="60" y="176" font-size="16" font-weight="bold" fill="#0d47a1">Spoke VNet  10.30.0.0/23 + pod 100.64.0.0/16  (East US 2)</text>
+
+  <!-- gateway subnet w/ spoke GW -->
+  <rect x="60" y="196" width="300" height="100" rx="6" fill="#fff" stroke="#1976d2" stroke-width="1.5"/>
+  <text x="72" y="216" font-size="12" fill="#1565c0">avx-gw subnet  /28   (rt: NO 0/0 — loop avoidance)</text>
+  <rect x="72" y="226" width="276" height="58" rx="5" fill="#e8f5e9" stroke="#2e7d32" stroke-width="2"/>
+  <text x="210" y="250" text-anchor="middle" font-size="13" font-weight="bold" fill="#1b5e20">Aviatrix Spoke Gateway</text>
+  <text x="210" y="268" text-anchor="middle" font-size="11" fill="#33691e">Standard_D2s_v3 · DCF inspect · single_ip_snat</text>
+
+  <!-- ingress subnet w/ internal LB -->
+  <rect x="380" y="196" width="300" height="100" rx="6" fill="#fff" stroke="#1976d2" stroke-width="1.5"/>
+  <text x="392" y="216" font-size="12" fill="#1565c0">ingress subnet  /25   (rt: NO 0/0 — symmetric LB return)</text>
+  <rect x="392" y="226" width="276" height="58" rx="5" fill="#fff8e1" stroke="#f9a825" stroke-width="2"/>
+  <text x="530" y="250" text-anchor="middle" font-size="13" font-weight="bold" fill="#e65100">Internal Azure LB</text>
+  <text x="530" y="268" text-anchor="middle" font-size="11" fill="#ef6c00">NGINX ingress (private, in-VNet only)</text>
+
+  <!-- node subnet -->
+  <rect x="60" y="316" width="300" height="100" rx="6" fill="#fff" stroke="#1976d2" stroke-width="1.5"/>
+  <text x="72" y="336" font-size="12" fill="#1565c0">node subnet  /24   (rt: 0/0 -&gt; spoke GW)</text>
+  <rect x="72" y="346" width="276" height="58" rx="5" fill="#ede7f6" stroke="#5e35b1" stroke-width="2"/>
+  <text x="210" y="370" text-anchor="middle" font-size="13" font-weight="bold" fill="#4527a0">AKS System Node Pool</text>
+  <text x="210" y="388" text-anchor="middle" font-size="11" fill="#512da8">2x Standard_B2s (min 1 / max 3)</text>
+
+  <!-- pod subnet -->
+  <rect x="380" y="316" width="300" height="100" rx="6" fill="#fff" stroke="#1976d2" stroke-width="1.5"/>
+  <text x="392" y="336" font-size="12" fill="#1565c0">pod subnet  /16   (rt: 0/0 -&gt; spoke GW)</text>
+  <rect x="392" y="346" width="276" height="58" rx="5" fill="#e1f5fe" stroke="#0288d1" stroke-width="2"/>
+  <text x="530" y="370" text-anchor="middle" font-size="13" font-weight="bold" fill="#01579b">Pods  100.64.0.0/16</text>
+  <text x="530" y="388" text-anchor="middle" font-size="11" fill="#0277bd">Azure CNI pod-subnet mode + Cilium</text>
+
+  <!-- AKS control plane -->
+  <rect x="60" y="436" width="620" height="84" rx="6" fill="#fce4ec" stroke="#c2185b" stroke-width="2"/>
+  <text x="370" y="464" text-anchor="middle" font-size="14" font-weight="bold" fill="#880e4f">AKS Control Plane (Azure-managed, K8s 1.33)</text>
+  <text x="370" y="486" text-anchor="middle" font-size="11" fill="#ad1457">OIDC / workload identity · outbound_type = userDefinedRouting</text>
+  <text x="370" y="504" text-anchor="middle" font-size="11" fill="#ad1457">Onboarded to Aviatrix Controller (local-account kubeconfig)</text>
+
+  <!-- legend: route programming -->
+  <rect x="60" y="538" width="620" height="64" rx="6" fill="#f1f8e9" stroke="#7cb342" stroke-width="1.5"/>
+  <text x="72" y="558" font-size="12" font-weight="bold" fill="#33691e">Aviatrix 9.0 Single IP SNAT + private_route_table_config</text>
+  <text x="72" y="576" font-size="11" fill="#33691e">Controller programs 0.0.0.0/0 -&gt; spoke GW on node + pod route tables ONLY.</text>
+  <text x="72" y="592" font-size="11" fill="#33691e">gateway + ingress route tables excluded. NO default-deny in the DCF ruleset.</text>
+
+  <!-- node/pod egress -> spoke GW -->
+  <line x1="210" y1="346" x2="210" y2="284" stroke="#2e7d32" stroke-width="2" marker-end="url(#arrowGreen)"/>
+  <path d="M392 360 C 330 360, 300 300, 290 284" fill="none" stroke="#2e7d32" stroke-width="2" marker-end="url(#arrowGreen)"/>
+
+  <!-- Transit (faded, optional) -->
+  <rect x="760" y="300" width="160" height="130" rx="10" fill="#f5f5f5" stroke="#bdbdbd" stroke-width="2" stroke-dasharray="6 4"/>
+  <text x="840" y="350" text-anchor="middle" font-size="15" font-weight="bold" fill="#9e9e9e">Transit</text>
+  <text x="840" y="374" text-anchor="middle" font-size="11" fill="#9e9e9e">Aviatrix</text>
+  <text x="840" y="392" text-anchor="middle" font-size="10" fill="#9e9e9e">(optional)</text>
+
+  <!-- dashed arrow spoke GW -> transit -->
+  <path d="M350 255 C 540 255, 620 360, 758 360" fill="none" stroke="#90a4ae" stroke-width="2.5" stroke-dasharray="8 5" marker-end="url(#arrowDash)"/>
+  <text x="560" y="240" text-anchor="middle" font-size="11" fill="#607d8b">attach to transit (transit_type = aviatrix)</text>
+
+  <text x="480" y="646" text-anchor="middle" font-size="11" fill="#78909c">Default: standalone spoke (transit_type = none). Filtered internet egress only; no east-west until a transit is attached. Requires Controller 9.0+.</text>
+</svg>

--- a/blueprints/azure-aks-singlecluster/cluster/data.tf
+++ b/blueprints/azure-aks-singlecluster/cluster/data.tf
@@ -1,0 +1,6 @@
+data "terraform_remote_state" "network" {
+  backend = "local"
+  config = {
+    path = "../network/terraform.tfstate"
+  }
+}

--- a/blueprints/azure-aks-singlecluster/cluster/main.tf
+++ b/blueprints/azure-aks-singlecluster/cluster/main.tf
@@ -1,0 +1,46 @@
+provider "azurerm" {
+  features {}
+}
+
+provider "aviatrix" {
+  controller_ip           = var.aviatrix_controller_ip
+  username                = var.aviatrix_username
+  password                = var.aviatrix_password
+  skip_version_validation = true
+}
+
+locals {
+  net = data.terraform_remote_state.network.outputs
+}
+
+module "cluster" {
+  source = "../../../modules/azure-aks-cluster"
+
+  cluster_name        = local.net.cluster_name
+  azure_region        = local.net.azure_region
+  resource_group_name = local.net.resource_group_name
+
+  vnet_id             = local.net.vnet_id
+  node_subnet_id      = local.net.node_subnet_id
+  pod_subnet_id       = local.net.pod_subnet_id
+  node_route_table_id = local.net.node_route_table_id
+  pod_route_table_id  = local.net.pod_route_table_id
+
+  kubernetes_version = var.kubernetes_version
+  node_pool_config   = var.node_pool_config
+
+  service_cidr   = local.net.service_cidr
+  dns_service_ip = local.net.dns_service_ip
+
+  authorized_ip_ranges    = var.authorized_ip_ranges
+  spoke_gateway_public_ip = local.net.spoke_gateway_public_ip
+
+  enable_aviatrix_onboarding    = var.enable_aviatrix_onboarding
+  aviatrix_controller_public_ip = var.aviatrix_controller_public_ip
+
+  tags = {
+    Environment = "demo"
+    Blueprint   = "azure-aks-singlecluster"
+    Terraform   = "true"
+  }
+}

--- a/blueprints/azure-aks-singlecluster/cluster/outputs.tf
+++ b/blueprints/azure-aks-singlecluster/cluster/outputs.tf
@@ -1,0 +1,35 @@
+output "cluster_id" {
+  value = module.cluster.cluster_id
+}
+
+output "cluster_name" {
+  value = module.cluster.cluster_name
+}
+
+output "oidc_issuer_url" {
+  value = module.cluster.oidc_issuer_url
+}
+
+output "host" {
+  value     = module.cluster.host
+  sensitive = true
+}
+
+output "client_certificate" {
+  value     = module.cluster.client_certificate
+  sensitive = true
+}
+
+output "client_key" {
+  value     = module.cluster.client_key
+  sensitive = true
+}
+
+output "cluster_ca_certificate" {
+  value     = module.cluster.cluster_ca_certificate
+  sensitive = true
+}
+
+output "configure_kubectl" {
+  value = module.cluster.configure_kubectl
+}

--- a/blueprints/azure-aks-singlecluster/cluster/terraform.tfvars.example
+++ b/blueprints/azure-aks-singlecluster/cluster/terraform.tfvars.example
@@ -1,0 +1,19 @@
+kubernetes_version = "1.33"
+
+node_pool_config = {
+  node_count = 2
+  min_count  = 1
+  max_count  = 3
+  vm_size    = "Standard_B2s"
+}
+
+# Lock this down to your admin IP for non-lab use.
+authorized_ip_ranges = ["0.0.0.0/0"]
+
+# Onboard the cluster into the Aviatrix Controller for K8s SmartGroups.
+enable_aviatrix_onboarding    = true
+aviatrix_controller_public_ip = "x.x.x.x"
+
+aviatrix_controller_ip = "x.x.x.x"
+aviatrix_username      = "admin"
+aviatrix_password      = "REPLACE_ME"

--- a/blueprints/azure-aks-singlecluster/cluster/variables.tf
+++ b/blueprints/azure-aks-singlecluster/cluster/variables.tf
@@ -1,0 +1,50 @@
+variable "kubernetes_version" {
+  description = "AKS Kubernetes version."
+  type        = string
+  default     = "1.33"
+}
+
+variable "node_pool_config" {
+  type = object({
+    node_count = number
+    min_count  = number
+    max_count  = number
+    vm_size    = string
+  })
+  default = {
+    node_count = 2
+    min_count  = 1
+    max_count  = 3
+    vm_size    = "Standard_B2s"
+  }
+}
+
+variable "authorized_ip_ranges" {
+  description = "Extra CIDRs allowed to reach the AKS API server."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "enable_aviatrix_onboarding" {
+  type    = bool
+  default = true
+}
+
+variable "aviatrix_controller_public_ip" {
+  description = "Controller public egress IP for AKS API allowlist when onboarding."
+  type        = string
+  default     = null
+}
+
+variable "aviatrix_controller_ip" {
+  type = string
+}
+
+variable "aviatrix_username" {
+  type = string
+}
+
+variable "aviatrix_password" {
+  type      = string
+  sensitive = true
+}

--- a/blueprints/azure-aks-singlecluster/cluster/variables.tf
+++ b/blueprints/azure-aks-singlecluster/cluster/variables.tf
@@ -5,6 +5,7 @@ variable "kubernetes_version" {
 }
 
 variable "node_pool_config" {
+  description = "AKS system node pool sizing."
   type = object({
     node_count = number
     min_count  = number
@@ -26,8 +27,9 @@ variable "authorized_ip_ranges" {
 }
 
 variable "enable_aviatrix_onboarding" {
-  type    = bool
-  default = true
+  description = "Register the AKS cluster with the Aviatrix Controller for K8s SmartGroups."
+  type        = bool
+  default     = true
 }
 
 variable "aviatrix_controller_public_ip" {
@@ -37,14 +39,17 @@ variable "aviatrix_controller_public_ip" {
 }
 
 variable "aviatrix_controller_ip" {
-  type = string
+  description = "Aviatrix Controller IP/hostname."
+  type        = string
 }
 
 variable "aviatrix_username" {
-  type = string
+  description = "Aviatrix Controller username."
+  type        = string
 }
 
 variable "aviatrix_password" {
-  type      = string
-  sensitive = true
+  description = "Aviatrix Controller password."
+  type        = string
+  sensitive   = true
 }

--- a/blueprints/azure-aks-singlecluster/cluster/versions.tf
+++ b/blueprints/azure-aks-singlecluster/cluster/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 9.0"
+    }
+  }
+}

--- a/blueprints/azure-aks-singlecluster/k8s-apps/dcf-crd/README.md
+++ b/blueprints/azure-aks-singlecluster/k8s-apps/dcf-crd/README.md
@@ -96,7 +96,7 @@ spec:
 | File | Purpose |
 |------|---------|
 | `firewallpolicy-infosec.yaml` | Allow infosec pods to access VirusTotal |
-| `webgrouppolicy-dev.yaml` | Allow dev namespace to access package registries |
+| `webgrouppolicy-dev.yaml` | Allow gatus namespace pods to access package registries |
 
 ## Applying Policies
 

--- a/blueprints/azure-aks-singlecluster/k8s-apps/dcf-crd/README.md
+++ b/blueprints/azure-aks-singlecluster/k8s-apps/dcf-crd/README.md
@@ -1,0 +1,144 @@
+# Aviatrix DCF Kubernetes CRD Policies
+
+This directory contains example Kubernetes CRD-based policies for Aviatrix Distributed Cloud Firewall (DCF).
+
+## Overview
+
+While base DCF policies are managed via Terraform (see `network/dcf.tf`), K8s CRD-based policies allow:
+
+- **Namespace-level control**: Apply policies scoped to specific namespaces
+- **Pod-label targeting**: Target pods by labels without needing Aviatrix-registered K8s clusters
+- **Self-service**: Allow dev teams to manage their own egress rules
+- **Temporary policies**: Quick changes without Terraform apply cycles
+
+## Prerequisites
+
+Install the Aviatrix K8s Firewall CRDs (already deployed by the nodes layer via Helm):
+
+```bash
+helm install --repo https://aviatrixsystems.github.io/k8s-firewall-charts k8s-firewall k8s-firewall
+```
+
+Verify CRD installation:
+
+```bash
+kubectl get crds | grep aviatrix
+```
+
+Expected output:
+```
+firewallpolicies.networking.aviatrix.com        2025-01-27T00:00:00Z
+webgrouppolicies.networking.aviatrix.com        2025-01-27T00:00:00Z
+```
+
+## Available CRDs
+
+### FirewallPolicy
+
+Full-featured firewall policy with SmartGroups and WebGroups defined inline.
+
+```yaml
+apiVersion: networking.aviatrix.com/v1alpha1
+kind: FirewallPolicy
+metadata:
+  name: my-policy
+  namespace: my-namespace
+spec:
+  rules:
+    - name: rule-name
+      selector:
+        matchLabels:
+          app: my-app
+      action: permit
+      protocol: tcp
+      ports:
+        - "443"
+      destinationSmartGroups:
+        - name: my-smartgroup
+      webGroups:
+        - name: my-webgroup
+
+  webGroups:
+    - name: my-webgroup
+      domains:
+        - "example.com"
+
+  smartGroups:
+    - name: my-smartgroup
+      selectors:
+        - cidr: 0.0.0.0/0
+```
+
+### WebGroupPolicy
+
+Simplified policy for web/HTTPS egress filtering.
+
+```yaml
+apiVersion: networking.aviatrix.com/v1alpha1
+kind: WebGroupPolicy
+metadata:
+  name: my-web-policy
+  namespace: my-namespace
+spec:
+  selector:
+    matchLabels:
+      app: my-app
+  action: permit
+  protocol: tcp
+  ports:
+    - "443"
+  domains:
+    - "api.example.com"
+```
+
+## Examples in This Directory
+
+| File | Purpose |
+|------|---------|
+| `firewallpolicy-infosec.yaml` | Allow infosec pods to access VirusTotal |
+| `webgrouppolicy-dev.yaml` | Allow dev namespace to access package registries |
+
+## Applying Policies
+
+```bash
+# Configure kubectl for the AKS cluster (run after the cluster layer deploys)
+az aks get-credentials --resource-group <name_prefix>-rg --name <name_prefix>
+
+# Apply the infosec FirewallPolicy
+kubectl apply -f firewallpolicy-infosec.yaml
+
+# Apply the dev WebGroupPolicy
+kubectl apply -f webgrouppolicy-dev.yaml
+```
+
+## Verifying Policies
+
+```bash
+# Check policy status
+kubectl get firewallpolicies -A
+kubectl get webgrouppolicies -A
+
+# Check events for policy sync status
+kubectl get events -n <namespace> --field-selector reason=CreatePolicySuccess
+```
+
+## Policy Priority
+
+CRD-based policies are inserted at priority 50-99 in the DCF ruleset hierarchy:
+
+| Priority | Policy Type |
+|----------|-------------|
+| 0-1 | Threat Prevention (Terraform) |
+| 20-32 | Azure Required Services + Explicit Egress Allow (Terraform) |
+| **50-99** | **K8s CRD Policies** |
+
+> The base ruleset does not include a default-deny catch-all (a dst `0.0.0.0/0` deny
+> would also match RFC1918 inter-VNet traffic). CRD policies in the 50-99 band add
+> granular namespace-scoped rules on top of the Terraform-managed baseline.
+
+## Cleanup
+
+```bash
+kubectl delete -f firewallpolicy-infosec.yaml
+kubectl delete -f webgrouppolicy-dev.yaml
+```

--- a/blueprints/azure-aks-singlecluster/k8s-apps/dcf-crd/firewallpolicy-infosec.yaml
+++ b/blueprints/azure-aks-singlecluster/k8s-apps/dcf-crd/firewallpolicy-infosec.yaml
@@ -1,0 +1,49 @@
+#####################
+# FirewallPolicy CRD Example - InfoSec Namespace
+#
+# This policy demonstrates K8s-native DCF policy management.
+# Pods with label "app: infosec" can access security tools like VirusTotal.
+#
+# Prerequisites:
+#   helm install --repo https://aviatrixsystems.github.io/k8s-firewall-charts k8s-firewall k8s-firewall
+#
+# Apply:
+#   kubectl apply -f firewallpolicy-infosec.yaml
+#
+# Verify:
+#   kubectl get firewallpolicies -n gatus
+#   kubectl get events -n gatus
+#####################
+
+apiVersion: networking.aviatrix.com/v1alpha1
+kind: FirewallPolicy
+metadata:
+  name: infosec-egress
+  namespace: gatus
+spec:
+  rules:
+    - name: allow-virustotal
+      logging: true
+      selector:
+        matchLabels:
+          app: infosec
+      action: permit
+      protocol: tcp
+      ports:
+        - "443"
+      destinationSmartGroups:
+        - name: public-internet
+      webGroups:
+        - name: security-tools
+
+  webGroups:
+    - name: security-tools
+      domains:
+        - "www.virustotal.com"
+        - "virustotal.com"
+        - "*.virustotal.com"
+
+  smartGroups:
+    - name: public-internet
+      selectors:
+        - cidr: 0.0.0.0/0

--- a/blueprints/azure-aks-singlecluster/k8s-apps/dcf-crd/webgrouppolicy-dev.yaml
+++ b/blueprints/azure-aks-singlecluster/k8s-apps/dcf-crd/webgrouppolicy-dev.yaml
@@ -1,0 +1,50 @@
+#####################
+# WebGroupPolicy CRD Example - Dev Namespace
+#
+# This policy allows pods in the dev namespace to access
+# additional development resources not covered by the base Terraform policy.
+#
+# Use case: Developer needs to access a new API temporarily for testing.
+# Instead of modifying Terraform, apply a CRD-based policy.
+#
+# Prerequisites:
+#   helm install --repo https://aviatrixsystems.github.io/k8s-firewall-charts k8s-firewall k8s-firewall
+#
+# Apply:
+#   kubectl apply -f webgrouppolicy-dev.yaml
+#
+# Verify:
+#   kubectl get webgrouppolicies -n dev
+#   kubectl get events -n dev
+#####################
+
+apiVersion: networking.aviatrix.com/v1alpha1
+kind: WebGroupPolicy
+metadata:
+  name: dev-external-apis
+  namespace: dev
+spec:
+  selector:
+    matchLabels:
+      environment: development
+
+  action: permit
+  protocol: tcp
+  ports:
+    - "443"
+  logging: true
+
+  domains:
+    # Package registries
+    - "pypi.org"
+    - "*.pypi.org"
+    - "files.pythonhosted.org"
+    # Docker Hub
+    - "hub.docker.com"
+    - "registry-1.docker.io"
+    - "*.docker.io"
+    # GitHub (broader access for dev)
+    - "github.com"
+    - "*.github.com"
+    - "raw.githubusercontent.com"
+    - "api.github.com"

--- a/blueprints/azure-aks-singlecluster/k8s-apps/dcf-crd/webgrouppolicy-dev.yaml
+++ b/blueprints/azure-aks-singlecluster/k8s-apps/dcf-crd/webgrouppolicy-dev.yaml
@@ -1,10 +1,10 @@
 #####################
-# WebGroupPolicy CRD Example - Dev Namespace
+# WebGroupPolicy CRD Example - Gatus Namespace
 #
-# This policy allows pods in the dev namespace to access
+# This policy allows pods in the gatus namespace to access
 # additional development resources not covered by the base Terraform policy.
 #
-# Use case: Developer needs to access a new API temporarily for testing.
+# Use case: Operator needs to grant a running pod access to a new API temporarily.
 # Instead of modifying Terraform, apply a CRD-based policy.
 #
 # Prerequisites:
@@ -14,15 +14,15 @@
 #   kubectl apply -f webgrouppolicy-dev.yaml
 #
 # Verify:
-#   kubectl get webgrouppolicies -n dev
-#   kubectl get events -n dev
+#   kubectl get webgrouppolicies -n gatus
+#   kubectl get events -n gatus
 #####################
 
 apiVersion: networking.aviatrix.com/v1alpha1
 kind: WebGroupPolicy
 metadata:
   name: dev-external-apis
-  namespace: dev
+  namespace: gatus
 spec:
   selector:
     matchLabels:

--- a/blueprints/azure-aks-singlecluster/k8s-apps/gatus.yaml
+++ b/blueprints/azure-aks-singlecluster/k8s-apps/gatus.yaml
@@ -1,0 +1,162 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gatus
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gatus
+  namespace: gatus
+data:
+  config.yaml: |
+    storage:
+      type: memory
+    metrics: true
+    endpoints:
+      # Egress - Allowed Traffic (expect green / PERMIT by DCF ruleset)
+      - name: "kubernetes.io"
+        group: "Egress"
+        url: "https://kubernetes.io"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      - name: "registry.npmjs.org"
+        group: "Egress"
+        url: "https://registry.npmjs.org"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      - name: "github.com/.../avxlabs-docs"
+        group: "Egress"
+        url: "https://github.com/AviatrixSystems/avxlabs-docs"
+        interval: 60s
+        client:
+          insecure: true
+        conditions: ["[STATUS] == 200"]
+
+      # Threats - Should be BLOCKED by DCF (expect red / DENY)
+      - name: "GeoBlock - Iran"
+        group: "Threats"
+        url: "icmp://www.irna.ir"
+        interval: 60s
+        conditions: ["[CONNECTED] == true"]
+
+      # NOTE: Confirm this IP appears in your active Aviatrix ThreatIQ feed before
+      # running a demo. Replace with a current entry from the ThreatIQ feed if needed.
+      - name: "Threat Feed - Malicious IP"
+        group: "Threats"
+        url: "icmp://185.38.148.2"
+        interval: 60s
+        conditions: ["[CONNECTED] == true"]
+
+    ui:
+      logo: "https://aviatrix.com/wp-content/uploads/2019/10/cropped-Aviatrix-Logo@2x-1-32x32.png"
+      header: "AKS Single Cluster - ${HOSTNAME}"
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gatus
+  namespace: gatus
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gatus
+  namespace: gatus
+  labels:
+    app: gatus
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: gatus
+  template:
+    metadata:
+      name: gatus
+      labels:
+        app: gatus
+        aviatrix.com/app: gatus
+    spec:
+      serviceAccountName: gatus
+      terminationGracePeriodSeconds: 5
+      containers:
+        - image: twinproduction/gatus:v5.14.0
+          imagePullPolicy: IfNotPresent
+          name: gatus
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 250m
+              memory: 100M
+            requests:
+              cpu: 50m
+              memory: 30M
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 5
+          volumeMounts:
+            - mountPath: /config
+              name: gatus-config
+      volumes:
+        - configMap:
+            name: gatus
+          name: gatus-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gatus
+  namespace: gatus
+  labels:
+    app: gatus
+    service: gatus
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: gatus
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gatus
+  namespace: gatus
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gatus
+                port:
+                  number: 8080

--- a/blueprints/azure-aks-singlecluster/network/dcf.tf
+++ b/blueprints/azure-aks-singlecluster/network/dcf.tf
@@ -68,6 +68,8 @@ resource "aviatrix_web_group" "azure_required" {
     match_expressions { snifilter = "registry.k8s.io" }
     match_expressions { snifilter = "archive.ubuntu.com" }
     match_expressions { snifilter = "security.ubuntu.com" }
+    match_expressions { snifilter = "acs-mirror.azureedge.net" }
+    match_expressions { snifilter = "packages.aks.azure.com" }
   }
 }
 
@@ -101,7 +103,8 @@ resource "aviatrix_web_group" "github_aviatrix" {
 
 resource "aviatrix_dcf_ruleset" "egress" {
   name = "${var.name_prefix}-egress"
-  # Attachment point: TERRAFORM_BEFORE_UI_MANAGED (hardcoded UUID — see aws-eks-singlecluster note)
+  # Attachment point: TERRAFORM_BEFORE_UI_MANAGED. Hardcoded UUID because the
+  # TERRAFORM_BEFORE_UI_MANAGED data source returns an incorrect ID on the controller.
   attach_to = "defa11a1-3000-4001-0000-000000000000"
 
   rules {

--- a/blueprints/azure-aks-singlecluster/network/dcf.tf
+++ b/blueprints/azure-aks-singlecluster/network/dcf.tf
@@ -98,6 +98,19 @@ resource "aviatrix_web_group" "github_aviatrix" {
 }
 
 #####################
+# Enable Distributed Cloud Firewall (controller-wide)
+#
+# REQUIRED: without this, the ruleset below is configured but NOT enforced —
+# gateways pass all traffic (the allow-list "works" only because nothing is
+# blocked, and the geo/threat DENY rules never fire). This is the global DCF
+# toggle; the ruleset depends_on it so enablement is sequenced first.
+#####################
+
+resource "aviatrix_distributed_firewalling_config" "enable" {
+  enable_distributed_firewalling = true
+}
+
+#####################
 # DCF Ruleset (threat prevention + egress allow-list, no default deny)
 #####################
 
@@ -106,6 +119,8 @@ resource "aviatrix_dcf_ruleset" "egress" {
   # Attachment point: TERRAFORM_BEFORE_UI_MANAGED. Hardcoded UUID because the
   # TERRAFORM_BEFORE_UI_MANAGED data source returns an incorrect ID on the controller.
   attach_to = "defa11a1-3000-4001-0000-000000000000"
+
+  depends_on = [aviatrix_distributed_firewalling_config.enable]
 
   rules {
     name             = "Block GeoBlocked Countries"

--- a/blueprints/azure-aks-singlecluster/network/dcf.tf
+++ b/blueprints/azure-aks-singlecluster/network/dcf.tf
@@ -1,0 +1,190 @@
+#####################
+# SmartGroups
+#####################
+
+resource "aviatrix_smart_group" "cluster_vpc" {
+  name = "sg-${var.name_prefix}-vnet"
+  selector {
+    match_expressions {
+      type = "vpc"
+      name = "${var.name_prefix}-vnet"
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "geo_blocked" {
+  name = "sg-${var.name_prefix}-geo-blocked"
+  selector {
+    match_expressions {
+      external = "geo"
+      ext_args = { country_iso_code = "IR" }
+    }
+    match_expressions {
+      external = "geo"
+      ext_args = { country_iso_code = "KP" }
+    }
+    match_expressions {
+      external = "geo"
+      ext_args = { country_iso_code = "RU" }
+    }
+  }
+}
+
+resource "aviatrix_smart_group" "threat_intel" {
+  name = "sg-${var.name_prefix}-threat-intel"
+  selector {
+    match_expressions {
+      external = "threatiq"
+      ext_args = { severity = "major" }
+    }
+    match_expressions {
+      external = "threatiq"
+      ext_args = { severity = "critical" }
+    }
+  }
+}
+
+locals {
+  # Built-in "Public Internet" SmartGroup UUID (matches all non-RFC1918 IPs).
+  public_internet_uuid = "def000ad-0000-0000-0000-000000000001"
+}
+
+#####################
+# WebGroups - Allowed Egress
+#####################
+
+resource "aviatrix_web_group" "azure_required" {
+  name = "wg-${var.name_prefix}-azure-required"
+  selector {
+    match_expressions { snifilter = "*.azmk8s.io" }
+    match_expressions { snifilter = "*.azurecr.io" }
+    match_expressions { snifilter = "mcr.microsoft.com" }
+    match_expressions { snifilter = "*.data.mcr.microsoft.com" }
+    match_expressions { snifilter = "management.azure.com" }
+    match_expressions { snifilter = "login.microsoftonline.com" }
+    match_expressions { snifilter = "packages.microsoft.com" }
+    match_expressions { snifilter = "*.blob.core.windows.net" }
+    match_expressions { snifilter = "*.pkg.dev" }
+    match_expressions { snifilter = "registry.k8s.io" }
+    match_expressions { snifilter = "archive.ubuntu.com" }
+    match_expressions { snifilter = "security.ubuntu.com" }
+  }
+}
+
+resource "aviatrix_web_group" "kubernetes_io" {
+  name = "wg-${var.name_prefix}-kubernetes-io"
+  selector {
+    match_expressions { snifilter = "kubernetes.io" }
+  }
+}
+
+resource "aviatrix_web_group" "npm_registry" {
+  name = "wg-${var.name_prefix}-npm-registry"
+  selector {
+    match_expressions { snifilter = "registry.npmjs.org" }
+    match_expressions { snifilter = "npmjs.org" }
+    match_expressions { snifilter = "www.npmjs.com" }
+  }
+}
+
+resource "aviatrix_web_group" "github_aviatrix" {
+  name = "wg-${var.name_prefix}-github-aviatrix"
+  selector {
+    match_expressions { urlfilter = "github.com/AviatrixSystems/terraform-provider-aviatrix" }
+    match_expressions { urlfilter = "github.com/AviatrixSystems/avxlabs-docs" }
+  }
+}
+
+#####################
+# DCF Ruleset (threat prevention + egress allow-list, no default deny)
+#####################
+
+resource "aviatrix_dcf_ruleset" "egress" {
+  name = "${var.name_prefix}-egress"
+  # Attachment point: TERRAFORM_BEFORE_UI_MANAGED (hardcoded UUID — see aws-eks-singlecluster note)
+  attach_to = "defa11a1-3000-4001-0000-000000000000"
+
+  rules {
+    name             = "Block GeoBlocked Countries"
+    action           = "DENY"
+    priority         = 0
+    protocol         = "ANY"
+    logging          = true
+    src_smart_groups = [aviatrix_smart_group.cluster_vpc.uuid]
+    dst_smart_groups = [aviatrix_smart_group.geo_blocked.uuid]
+  }
+
+  rules {
+    name             = "Block Threat Intel IPs"
+    action           = "DENY"
+    priority         = 1
+    protocol         = "ANY"
+    logging          = true
+    src_smart_groups = [aviatrix_smart_group.cluster_vpc.uuid]
+    dst_smart_groups = [aviatrix_smart_group.threat_intel.uuid]
+  }
+
+  rules {
+    name                 = "Azure Required Services"
+    action               = "PERMIT"
+    priority             = 20
+    protocol             = "TCP"
+    logging              = true
+    src_smart_groups     = [aviatrix_smart_group.cluster_vpc.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.azure_required.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  rules {
+    name                 = "Allow kubernetes-io"
+    action               = "PERMIT"
+    priority             = 30
+    protocol             = "TCP"
+    logging              = true
+    src_smart_groups     = [aviatrix_smart_group.cluster_vpc.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.kubernetes_io.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  rules {
+    name                 = "Allow GitHub Aviatrix Repos"
+    action               = "PERMIT"
+    priority             = 31
+    protocol             = "TCP"
+    logging              = true
+    watch                = true
+    src_smart_groups     = [aviatrix_smart_group.cluster_vpc.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.github_aviatrix.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  rules {
+    name                 = "Allow npm Registry"
+    action               = "PERMIT"
+    priority             = 32
+    protocol             = "TCP"
+    logging              = true
+    src_smart_groups     = [aviatrix_smart_group.cluster_vpc.uuid]
+    dst_smart_groups     = [local.public_internet_uuid]
+    web_groups           = [aviatrix_web_group.npm_registry.uuid]
+    flow_app_requirement = "APP_UNSPECIFIED"
+    port_ranges {
+      lo = 443
+    }
+  }
+
+  # Priority 50-99 reserved for k8s-firewall CRD injections (see k8s-apps/dcf-crd/).
+  # NO default-deny: dst 0.0.0.0/0 would also match RFC1918 inter-VNet traffic.
+}

--- a/blueprints/azure-aks-singlecluster/network/main.tf
+++ b/blueprints/azure-aks-singlecluster/network/main.tf
@@ -1,0 +1,38 @@
+provider "azurerm" {
+  features {}
+}
+
+provider "aviatrix" {
+  controller_ip           = var.aviatrix_controller_ip
+  username                = var.aviatrix_username
+  password                = var.aviatrix_password
+  skip_version_validation = true
+}
+
+locals {
+  cluster_name = var.name_prefix
+
+  common_tags = {
+    Environment = "demo"
+    Blueprint   = "azure-aks-singlecluster"
+    Terraform   = "true"
+  }
+}
+
+module "spoke_vnet" {
+  source = "../../../modules/azure-aks-spoke-vnet"
+
+  name         = var.name_prefix
+  cluster_name = local.cluster_name
+  vnet_cidr    = var.vnet_cidr
+  pod_cidr     = var.pod_cidr
+
+  azure_region          = var.azure_region
+  aviatrix_azure_region = var.aviatrix_azure_region
+
+  aviatrix_azure_account_name = var.aviatrix_azure_account_name
+  transit_type                = var.transit_type
+  transit_gw_name             = var.transit_gw_name
+
+  tags = local.common_tags
+}

--- a/blueprints/azure-aks-singlecluster/network/outputs.tf
+++ b/blueprints/azure-aks-singlecluster/network/outputs.tf
@@ -1,0 +1,67 @@
+output "name_prefix" {
+  value = var.name_prefix
+}
+
+output "azure_region" {
+  value = var.azure_region
+}
+
+output "resource_group_name" {
+  value = module.spoke_vnet.resource_group_name
+}
+
+output "vnet_id" {
+  value = module.spoke_vnet.vnet_id
+}
+
+output "cluster_name" {
+  value = local.cluster_name
+}
+
+output "node_subnet_id" {
+  value = module.spoke_vnet.node_subnet_id
+}
+
+output "pod_subnet_id" {
+  value = module.spoke_vnet.pod_subnet_id
+}
+
+output "ingress_subnet_id" {
+  value = module.spoke_vnet.ingress_subnet_id
+}
+
+output "ingress_subnet_name" {
+  value = module.spoke_vnet.ingress_subnet_name
+}
+
+output "node_route_table_id" {
+  value = module.spoke_vnet.node_route_table_id
+}
+
+output "pod_route_table_id" {
+  value = module.spoke_vnet.pod_route_table_id
+}
+
+output "spoke_gateway_name" {
+  value = module.spoke_vnet.spoke_gateway_name
+}
+
+output "spoke_gateway_public_ip" {
+  value = module.spoke_vnet.spoke_gateway_public_ip
+}
+
+output "service_cidr" {
+  value = "172.16.0.0/16"
+}
+
+output "dns_service_ip" {
+  value = "172.16.0.10"
+}
+
+output "dcf_ruleset_uuid" {
+  value = aviatrix_dcf_ruleset.egress.id
+}
+
+output "smartgroup_cluster_vpc_uuid" {
+  value = aviatrix_smart_group.cluster_vpc.uuid
+}

--- a/blueprints/azure-aks-singlecluster/network/outputs.tf
+++ b/blueprints/azure-aks-singlecluster/network/outputs.tf
@@ -51,11 +51,11 @@ output "spoke_gateway_public_ip" {
 }
 
 output "service_cidr" {
-  value = "172.16.0.0/16"
+  value = var.service_cidr
 }
 
 output "dns_service_ip" {
-  value = "172.16.0.10"
+  value = var.dns_service_ip
 }
 
 output "dcf_ruleset_uuid" {

--- a/blueprints/azure-aks-singlecluster/network/terraform.tfvars.example
+++ b/blueprints/azure-aks-singlecluster/network/terraform.tfvars.example
@@ -1,0 +1,23 @@
+# Azure region (both forms required)
+azure_region          = "eastus2"
+aviatrix_azure_region = "East US 2"
+
+# Aviatrix Azure access account as onboarded in the Controller
+aviatrix_azure_account_name = "Azure"
+
+# Resource naming
+name_prefix = "aks-single"
+
+# CIDRs
+vnet_cidr = "10.30.0.0/23"
+pod_cidr  = "100.64.0.0/16"
+
+# Transit posture: "none" = standalone egress via Single IP SNAT (default),
+# "aviatrix" = attach to an existing Aviatrix transit (set transit_gw_name).
+transit_type    = "none"
+transit_gw_name = ""
+
+# Aviatrix Controller credentials
+aviatrix_controller_ip = "x.x.x.x"
+aviatrix_username      = "admin"
+aviatrix_password      = "REPLACE_ME"

--- a/blueprints/azure-aks-singlecluster/network/variables.tf
+++ b/blueprints/azure-aks-singlecluster/network/variables.tf
@@ -38,6 +38,18 @@ variable "pod_cidr" {
   default     = "100.64.0.0/16"
 }
 
+variable "service_cidr" {
+  description = "Kubernetes service CIDR (must not overlap vnet_cidr or pod_cidr)."
+  type        = string
+  default     = "172.16.0.0/16"
+}
+
+variable "dns_service_ip" {
+  description = "Kubernetes DNS service IP (within service_cidr)."
+  type        = string
+  default     = "172.16.0.10"
+}
+
 variable "transit_type" {
   description = "'none' for standalone (Single IP SNAT egress only) or 'aviatrix' to attach to an Aviatrix transit."
   type        = string

--- a/blueprints/azure-aks-singlecluster/network/variables.tf
+++ b/blueprints/azure-aks-singlecluster/network/variables.tf
@@ -1,0 +1,67 @@
+variable "name_prefix" {
+  description = "Prefix for all resources. Also used as the AKS cluster name."
+  type        = string
+  default     = "aks-single"
+
+  validation {
+    condition     = length(var.name_prefix) >= 1 && length(var.name_prefix) <= 20
+    error_message = "name_prefix must be 1-20 characters."
+  }
+}
+
+variable "azure_region" {
+  description = "Azure region (azurerm form, e.g. eastus2)."
+  type        = string
+  default     = "eastus2"
+}
+
+variable "aviatrix_azure_region" {
+  description = "Azure region (Aviatrix form, e.g. East US 2)."
+  type        = string
+  default     = "East US 2"
+}
+
+variable "aviatrix_azure_account_name" {
+  description = "Azure access account name as onboarded in the Aviatrix Controller."
+  type        = string
+}
+
+variable "vnet_cidr" {
+  description = "Routable /23 CIDR for the spoke VNet."
+  type        = string
+  default     = "10.30.0.0/23"
+}
+
+variable "pod_cidr" {
+  description = "Dedicated pod subnet CIDR."
+  type        = string
+  default     = "100.64.0.0/16"
+}
+
+variable "transit_type" {
+  description = "'none' for standalone (Single IP SNAT egress only) or 'aviatrix' to attach to an Aviatrix transit."
+  type        = string
+  default     = "none"
+}
+
+variable "transit_gw_name" {
+  description = "Aviatrix transit gateway name (required when transit_type = aviatrix)."
+  type        = string
+  default     = ""
+}
+
+variable "aviatrix_controller_ip" {
+  description = "Aviatrix Controller IP/hostname."
+  type        = string
+}
+
+variable "aviatrix_username" {
+  description = "Aviatrix Controller username."
+  type        = string
+}
+
+variable "aviatrix_password" {
+  description = "Aviatrix Controller password."
+  type        = string
+  sensitive   = true
+}

--- a/blueprints/azure-aks-singlecluster/network/versions.tf
+++ b/blueprints/azure-aks-singlecluster/network/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 9.0"
+    }
+  }
+}

--- a/blueprints/azure-aks-singlecluster/nodes/data.tf
+++ b/blueprints/azure-aks-singlecluster/nodes/data.tf
@@ -1,0 +1,13 @@
+data "terraform_remote_state" "network" {
+  backend = "local"
+  config = {
+    path = "../network/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "cluster" {
+  backend = "local"
+  config = {
+    path = "../cluster/terraform.tfstate"
+  }
+}

--- a/blueprints/azure-aks-singlecluster/nodes/helm.tf
+++ b/blueprints/azure-aks-singlecluster/nodes/helm.tf
@@ -1,0 +1,39 @@
+#####################
+# NGINX Ingress Controller (internal Azure LB in the ingress subnet)
+#####################
+resource "helm_release" "nginx_ingress" {
+  name             = "ingress-nginx"
+  repository       = "https://kubernetes.github.io/ingress-nginx"
+  chart            = "ingress-nginx"
+  version          = var.nginx_ingress_chart_version
+  namespace        = "ingress-nginx"
+  create_namespace = true
+
+  values = [
+    yamlencode({
+      controller = {
+        service = {
+          loadBalancerIP = var.nginx_lb_ip
+          annotations = {
+            "service.beta.kubernetes.io/azure-load-balancer-internal"        = "true"
+            "service.beta.kubernetes.io/azure-load-balancer-internal-subnet" = local.net.ingress_subnet_name
+            "service.beta.kubernetes.io/azure-load-balancer-ip-address"      = var.nginx_lb_ip
+          }
+        }
+        metrics = { enabled = true }
+      }
+    })
+  ]
+}
+
+#####################
+# Aviatrix K8s Firewall (DCF CRD controller)
+#####################
+resource "helm_release" "k8s_firewall" {
+  name             = "k8s-firewall"
+  repository       = "https://aviatrixsystems.github.io/k8s-firewall-charts"
+  chart            = "k8s-firewall"
+  version          = var.k8s_firewall_chart_version
+  namespace        = "aviatrix-firewall"
+  create_namespace = true
+}

--- a/blueprints/azure-aks-singlecluster/nodes/main.tf
+++ b/blueprints/azure-aks-singlecluster/nodes/main.tf
@@ -1,0 +1,20 @@
+locals {
+  net     = data.terraform_remote_state.network.outputs
+  cluster = data.terraform_remote_state.cluster.outputs
+}
+
+provider "kubernetes" {
+  host                   = local.cluster.host
+  client_certificate     = base64decode(local.cluster.client_certificate)
+  client_key             = base64decode(local.cluster.client_key)
+  cluster_ca_certificate = base64decode(local.cluster.cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = local.cluster.host
+    client_certificate     = base64decode(local.cluster.client_certificate)
+    client_key             = base64decode(local.cluster.client_key)
+    cluster_ca_certificate = base64decode(local.cluster.cluster_ca_certificate)
+  }
+}

--- a/blueprints/azure-aks-singlecluster/nodes/outputs.tf
+++ b/blueprints/azure-aks-singlecluster/nodes/outputs.tf
@@ -1,0 +1,11 @@
+output "nginx_ingress_namespace" {
+  value = helm_release.nginx_ingress.namespace
+}
+
+output "nginx_lb_ip" {
+  value = var.nginx_lb_ip
+}
+
+output "k8s_firewall_namespace" {
+  value = helm_release.k8s_firewall.namespace
+}

--- a/blueprints/azure-aks-singlecluster/nodes/terraform.tfvars.example
+++ b/blueprints/azure-aks-singlecluster/nodes/terraform.tfvars.example
@@ -1,0 +1,6 @@
+nginx_ingress_chart_version = "4.11.3"
+k8s_firewall_chart_version  = "1.0.0"
+
+# Static internal LB IP — must be inside the ingress subnet (default 10.30.0.128/25)
+# and above the Azure-reserved first four addresses.
+nginx_lb_ip = "10.30.0.200"

--- a/blueprints/azure-aks-singlecluster/nodes/terraform.tfvars.example
+++ b/blueprints/azure-aks-singlecluster/nodes/terraform.tfvars.example
@@ -1,5 +1,5 @@
 nginx_ingress_chart_version = "4.11.3"
-k8s_firewall_chart_version  = "1.0.0"
+k8s_firewall_chart_version  = "9.0.0"
 
 # Static internal LB IP — must be inside the ingress subnet (default 10.30.0.128/25)
 # and above the Azure-reserved first four addresses.

--- a/blueprints/azure-aks-singlecluster/nodes/variables.tf
+++ b/blueprints/azure-aks-singlecluster/nodes/variables.tf
@@ -4,8 +4,11 @@ variable "nginx_ingress_chart_version" {
 }
 
 variable "k8s_firewall_chart_version" {
+  # Published versions: 8.2.0 or 9.0.0
+  # (https://aviatrixsystems.github.io/k8s-firewall-charts/index.yaml).
+  # Match the Controller major version (9.0.x here).
   type    = string
-  default = "1.0.0"
+  default = "9.0.0"
 }
 
 variable "nginx_lb_ip" {

--- a/blueprints/azure-aks-singlecluster/nodes/variables.tf
+++ b/blueprints/azure-aks-singlecluster/nodes/variables.tf
@@ -1,0 +1,15 @@
+variable "nginx_ingress_chart_version" {
+  type    = string
+  default = "4.11.3"
+}
+
+variable "k8s_firewall_chart_version" {
+  type    = string
+  default = "1.0.0"
+}
+
+variable "nginx_lb_ip" {
+  description = "Static private IP for the internal NGINX LB (must be inside the ingress subnet, outside Azure-reserved first 4 hosts)."
+  type        = string
+  default     = "10.30.0.200"
+}

--- a/blueprints/azure-aks-singlecluster/nodes/versions.tf
+++ b/blueprints/azure-aks-singlecluster/nodes/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.30"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.16"
+    }
+  }
+}

--- a/blueprints/azure-aks-singlecluster/nodes/versions.tf
+++ b/blueprints/azure-aks-singlecluster/nodes/versions.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 1.7"
 
   required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 4.0"
-    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "~> 2.30"

--- a/blueprints/azure-aks-singlecluster/terraform.tfvars.example
+++ b/blueprints/azure-aks-singlecluster/terraform.tfvars.example
@@ -1,0 +1,77 @@
+# Consolidated example for azure-aks-singlecluster.
+#
+# This blueprint is a 4-layer deployment. Each layer reads its OWN
+# terraform.tfvars (network/, cluster/, nodes/). Copy the relevant block
+# into each layer's terraform.tfvars, or copy each layer's own
+# terraform.tfvars.example. This file is a single-page reference of every
+# value an operator must set.
+#
+# Deployment order: network -> cluster -> nodes -> (manual) k8s-apps.
+
+#############################################
+# network/terraform.tfvars
+#############################################
+
+# Azure region — BOTH forms are required (azurerm vs Aviatrix Controller).
+azure_region          = "eastus2"   # azurerm form
+aviatrix_azure_region = "East US 2"  # Aviatrix form
+
+# Aviatrix Azure access account as onboarded in the Controller.
+aviatrix_azure_account_name = "Azure"
+
+# Resource naming (also used as the AKS cluster name). 1-20 chars.
+name_prefix = "aks-single"
+
+# CIDRs. vnet_cidr is the routable /23 (gateway, ingress, node subnets);
+# pod_cidr is the dedicated pod subnet (Azure CNI pod-subnet mode).
+vnet_cidr = "10.30.0.0/23"
+pod_cidr  = "100.64.0.0/16"
+
+# Transit posture: "none" = standalone egress via Single IP SNAT (default),
+# "aviatrix" = attach to an existing Aviatrix transit (set transit_gw_name).
+transit_type    = "none"
+transit_gw_name = ""
+
+# Aviatrix Controller credentials (network + cluster layers).
+aviatrix_controller_ip = "x.x.x.x"
+aviatrix_username      = "admin"
+aviatrix_password      = "REPLACE_ME"
+
+#############################################
+# cluster/terraform.tfvars
+#############################################
+
+kubernetes_version = "1.33"
+
+node_pool_config = {
+  node_count = 2
+  min_count  = 1
+  max_count  = 3
+  vm_size    = "Standard_B2s"
+}
+
+# AKS API server allow-list. Defaults to 0.0.0.0/0 for lab convenience —
+# this exposes the API server publicly. Lock it down to your admin IP for
+# non-lab use. The spoke GW public IP (and controller IP when onboarding)
+# are appended automatically by the cluster module.
+authorized_ip_ranges = ["0.0.0.0/0"]
+
+# Onboard the cluster into the Aviatrix Controller for K8s SmartGroups.
+enable_aviatrix_onboarding    = true
+aviatrix_controller_public_ip = "x.x.x.x"
+
+# Controller credentials are also required in the cluster layer (shared).
+# aviatrix_controller_ip = "x.x.x.x"
+# aviatrix_username      = "admin"
+# aviatrix_password      = "REPLACE_ME"
+
+#############################################
+# nodes/terraform.tfvars
+#############################################
+
+nginx_ingress_chart_version = "4.11.3"
+k8s_firewall_chart_version  = "1.0.0"
+
+# Static internal LB IP — must be inside the ingress subnet (default
+# 10.30.0.128/25) and above the Azure-reserved first four addresses.
+nginx_lb_ip = "10.30.0.200"

--- a/blueprints/azure-aks-singlecluster/terraform.tfvars.example
+++ b/blueprints/azure-aks-singlecluster/terraform.tfvars.example
@@ -70,7 +70,7 @@ aviatrix_controller_public_ip = "x.x.x.x"
 #############################################
 
 nginx_ingress_chart_version = "4.11.3"
-k8s_firewall_chart_version  = "1.0.0"
+k8s_firewall_chart_version  = "9.0.0"
 
 # Static internal LB IP — must be inside the ingress subnet (default
 # 10.30.0.128/25) and above the Azure-reserved first four addresses.

--- a/modules/azure-aks-cluster/README.md
+++ b/modules/azure-aks-cluster/README.md
@@ -1,0 +1,125 @@
+> **AZURE MODULE — mirrors `modules/aws-eks-cluster/` for Azure.** The design intent, variable taxonomy, and output names track the AWS module. Azure-specific differences (the system node pool lives inline in `azurerm_kubernetes_cluster` rather than in a separate node-group module, Azure CNI pod-subnet mode + Cilium instead of AWS VPC CNI custom networking, workload identity instead of IRSA) are documented below. Changes to shared behaviour should be reflected in both modules.
+
+# azure-aks-cluster
+
+Terraform module that provisions a single AKS cluster shaped for Aviatrix Distributed Cloud Firewall (DCF) egress filtering, with the system node pool inline, workload identity enabled, and optional Aviatrix Controller onboarding for Kubernetes-typed SmartGroups.
+
+## What this module creates
+
+- **User-assigned managed identity** for the AKS control plane.
+- **Three role assignments** (all `Network Contributor`) granting the AKS identity rights over:
+  - the spoke VNet (`var.vnet_id`) — to manage NICs and internal load balancers,
+  - the node route table (`var.node_route_table_id`),
+  - the pod route table (`var.pod_route_table_id`).
+- **AKS cluster** (`azurerm_kubernetes_cluster`) with:
+  - **Inline system node pool** (`default_node_pool`) — Azure requires the node pool be declared in the cluster, so unlike the AWS module there is no separate node-group module. Autoscaling is enabled, `max_pods = 250`, and `node_count` drift is ignored.
+  - **OIDC issuer + workload identity** enabled (the Azure equivalent of AWS IRSA).
+  - **Azure CNI pod-subnet mode + Cilium** (`network_plugin = "azure"`, `network_policy = "cilium"`, `network_data_plane = "cilium"`). Pods get real VNet addresses from `var.pod_subnet_id`, so packets reach the Aviatrix spoke gateway with their original pod IP (no node-level SNAT).
+  - **`outbound_type = "userDefinedRouting"`** — all egress follows the controller-programmed `0.0.0.0/0 → spoke GW` route on the node and pod route tables (programmed by the network layer / `azure-aks-spoke-vnet` module).
+  - **API server authorized IP ranges** = `var.authorized_ip_ranges` + the spoke gateway public IP + (when onboarding) the controller public IP. The spoke GW public IP is mandatory: nodes egress through it, so the kubelet CSE bootstrap fails without it.
+- **Aviatrix Kubernetes cluster onboarding** (`aviatrix_kubernetes_cluster`), gated by `var.enable_aviatrix_onboarding`.
+
+## Egress / SNAT design
+
+This cluster is designed to sit behind an Aviatrix spoke gateway using the 9.0 Single IP SNAT explicit-route-table-selection feature (see `modules/azure-aks-spoke-vnet`). Pod IPs come from a dedicated VNet subnet (pod-subnet mode), so Azure routes pod packets natively to the spoke gateway where DCF inspection and SNAT occur.
+
+```
+Pod / Node (VNet IP) → UDR 0.0.0.0/0 → Aviatrix Spoke GW → DCF inspect → Single IP SNAT → Internet
+```
+
+## Aviatrix Controller onboarding requirement
+
+When `enable_aviatrix_onboarding = true`, the controller fetches a kubeconfig from the AKS cluster and connects to the API server. This imposes requirements **not enforced by Terraform** (pre-checks for the operator):
+
+- The Aviatrix Azure access account's service principal must have `Microsoft.ContainerService/managedClusters/listClusterUserCredential/action` at subscription scope (Contributor includes it). The controller calls ARM `listClusterUserCredential` to obtain a **local-account kubeconfig**.
+- The cluster **must use Kubernetes RBAC with local accounts**. **Entra-ID-only auth is NOT supported** — the returned kubeconfig would contain `exec` entries the controller cannot process.
+- The controller's public egress IP must be in the AKS API server's `authorized_ip_ranges`. Set `aviatrix_controller_public_ip` so it is appended automatically.
+
+## Requirements
+
+- **Aviatrix Controller / CoPilot 9.0+** (matches the `aviatrix ~> 9.0` provider pin and the spoke module's Single IP SNAT route-table selection).
+- Providers: `azurerm ~> 4.0`, `aviatrix ~> 9.0`. This module declares only `required_providers`; provider configuration is supplied by the consuming blueprint layer.
+
+## Usage
+
+```hcl
+module "cluster" {
+  source = "../../../modules/azure-aks-cluster"
+
+  cluster_name        = "aks-single"
+  azure_region        = "eastus2"
+  resource_group_name = module.spoke_vnet.resource_group_name
+
+  vnet_id             = module.spoke_vnet.vnet_id
+  node_subnet_id      = module.spoke_vnet.node_subnet_id
+  pod_subnet_id       = module.spoke_vnet.pod_subnet_id
+  node_route_table_id = module.spoke_vnet.node_route_table_id
+  pod_route_table_id  = module.spoke_vnet.pod_route_table_id
+
+  kubernetes_version = "1.33"
+  node_pool_config = {
+    node_count = 2
+    min_count  = 1
+    max_count  = 3
+    vm_size    = "Standard_B2s"
+  }
+
+  service_cidr   = "172.16.0.0/16"
+  dns_service_ip = "172.16.0.10"
+
+  authorized_ip_ranges    = ["0.0.0.0/0"]
+  spoke_gateway_public_ip = module.spoke_vnet.spoke_gateway_public_ip
+
+  enable_aviatrix_onboarding    = true
+  aviatrix_controller_public_ip = "x.x.x.x"
+
+  tags = {
+    Environment = "demo"
+    Blueprint   = "azure-aks-singlecluster"
+  }
+}
+```
+
+## Post-deployment
+
+Fetch kubeconfig (also surfaced as the `configure_kubectl` output):
+
+```bash
+az aks get-credentials --resource-group <rg> --name <cluster_name>
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| `cluster_name` | AKS cluster name. | `string` | — | yes |
+| `azure_region` | Azure region (azurerm form, e.g. `eastus2`). | `string` | — | yes |
+| `resource_group_name` | Resource group to create the AKS cluster in (the spoke VNet's RG). | `string` | — | yes |
+| `vnet_id` | Spoke VNet resource ID (for the AKS identity Network Contributor role). | `string` | — | yes |
+| `node_subnet_id` | Subnet ID for AKS node VMs. | `string` | — | yes |
+| `pod_subnet_id` | Subnet ID for AKS pods (pod-subnet mode). | `string` | — | yes |
+| `node_route_table_id` | Node route table ID (for the AKS identity Network Contributor role). | `string` | — | yes |
+| `pod_route_table_id` | Pod route table ID (for the AKS identity Network Contributor role). | `string` | — | yes |
+| `kubernetes_version` | AKS Kubernetes version. | `string` | `"1.33"` | no |
+| `node_pool_config` | System/user node pool sizing (`node_count`, `min_count`, `max_count`, `vm_size`). | `object` | `{ node_count = 2, min_count = 1, max_count = 3, vm_size = "Standard_B2s" }` | no |
+| `service_cidr` | Kubernetes service CIDR (must not overlap VNet or pod CIDR). | `string` | `"172.16.0.0/16"` | no |
+| `dns_service_ip` | Kubernetes DNS service IP (within `service_cidr`). | `string` | `"172.16.0.10"` | no |
+| `authorized_ip_ranges` | Extra CIDRs allowed to reach the AKS API server. The spoke GW public IP and (optionally) controller IP are appended automatically. | `list(string)` | `["0.0.0.0/0"]` | no |
+| `spoke_gateway_public_ip` | Spoke gateway public IP, appended to AKS API `authorized_ip_ranges` so node CSE bootstrap succeeds. | `string` | — | yes |
+| `enable_aviatrix_onboarding` | Register the AKS cluster with the Aviatrix Controller for K8s SmartGroups. | `bool` | `true` | no |
+| `aviatrix_controller_public_ip` | Controller public egress IP, appended to AKS API `authorized_ip_ranges` when onboarding. | `string` | `null` | no |
+| `tags` | Tags applied to created resources. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description | Sensitive |
+|------|-------------|:---------:|
+| `cluster_id` | AKS cluster resource ID. | no |
+| `cluster_name` | AKS cluster name. | no |
+| `oidc_issuer_url` | OIDC issuer URL (for workload identity federation). | no |
+| `kubelet_identity_object_id` | Object ID of the kubelet managed identity. | no |
+| `host` | AKS API server host. | yes |
+| `client_certificate` | Kubeconfig client certificate. | yes |
+| `client_key` | Kubeconfig client key. | yes |
+| `cluster_ca_certificate` | Kubeconfig cluster CA certificate. | yes |
+| `configure_kubectl` | `az aks get-credentials` command to fetch kubeconfig. | no |

--- a/modules/azure-aks-cluster/main.tf
+++ b/modules/azure-aks-cluster/main.tf
@@ -1,0 +1,89 @@
+# User-assigned managed identity for the AKS control plane.
+resource "azurerm_user_assigned_identity" "aks" {
+  name                = "${var.cluster_name}-identity"
+  location            = var.azure_region
+  resource_group_name = var.resource_group_name
+  tags                = var.tags
+}
+
+resource "azurerm_role_assignment" "aks_vnet_contributor" {
+  scope                = var.vnet_id
+  role_definition_name = "Network Contributor"
+  principal_id         = azurerm_user_assigned_identity.aks.principal_id
+}
+
+resource "azurerm_role_assignment" "aks_node_rt" {
+  scope                = var.node_route_table_id
+  role_definition_name = "Network Contributor"
+  principal_id         = azurerm_user_assigned_identity.aks.principal_id
+}
+
+resource "azurerm_role_assignment" "aks_pod_rt" {
+  scope                = var.pod_route_table_id
+  role_definition_name = "Network Contributor"
+  principal_id         = azurerm_user_assigned_identity.aks.principal_id
+}
+
+resource "azurerm_kubernetes_cluster" "aks" {
+  name                = var.cluster_name
+  location            = var.azure_region
+  resource_group_name = var.resource_group_name
+  dns_prefix          = var.cluster_name
+  kubernetes_version  = var.kubernetes_version
+  tags                = var.tags
+
+  oidc_issuer_enabled       = true
+  workload_identity_enabled = true
+
+  default_node_pool {
+    name                 = "system"
+    vm_size              = var.node_pool_config.vm_size
+    node_count           = var.node_pool_config.node_count
+    min_count            = var.node_pool_config.min_count
+    max_count            = var.node_pool_config.max_count
+    auto_scaling_enabled = true
+    vnet_subnet_id       = var.node_subnet_id
+    pod_subnet_id        = var.pod_subnet_id
+    max_pods             = 250
+
+    upgrade_settings {
+      max_surge = "10%"
+    }
+  }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.aks.id]
+  }
+
+  network_profile {
+    network_plugin     = "azure"
+    network_policy     = "cilium"
+    network_data_plane = "cilium"
+    service_cidr       = var.service_cidr
+    dns_service_ip     = var.dns_service_ip
+    # All egress routes through the Aviatrix spoke gateway via the controller-
+    # programmed 0/0 route on the node + pod route tables (network layer).
+    outbound_type = "userDefinedRouting"
+  }
+
+  api_server_access_profile {
+    authorized_ip_ranges = concat(
+      var.authorized_ip_ranges,
+      ["${var.spoke_gateway_public_ip}/32"],
+      var.enable_aviatrix_onboarding && var.aviatrix_controller_public_ip != null
+      ? ["${var.aviatrix_controller_public_ip}/32"]
+      : [],
+    )
+  }
+
+  depends_on = [
+    azurerm_role_assignment.aks_vnet_contributor,
+    azurerm_role_assignment.aks_node_rt,
+    azurerm_role_assignment.aks_pod_rt,
+  ]
+
+  lifecycle {
+    ignore_changes = [default_node_pool[0].node_count]
+  }
+}

--- a/modules/azure-aks-cluster/onboarding.tf
+++ b/modules/azure-aks-cluster/onboarding.tf
@@ -1,0 +1,34 @@
+#####################
+# Aviatrix Controller Onboarding
+#
+# Registers the AKS cluster with the Aviatrix Controller so DCF SmartGroups
+# can target Kubernetes-typed selectors (cluster, namespace, service, pod)
+# instead of just VNet selectors.
+#
+# Auth flow (per docs.aviatrix.com/docs/enterprise/8.2/guides/security/dcf/kubernetes-onboard):
+#   1. Controller calls ARM listClusterUserCredential/action via the Aviatrix
+#      Azure access account's service principal to fetch a local-account
+#      kubeconfig from the AKS cluster.
+#   2. Controller connects to the AKS API server FQDN with that kubeconfig.
+#
+# Requirements (NOT enforced by Terraform — pre-checks for the operator):
+#   - Aviatrix Azure access account onboarded (see network/main.tf, var.aviatrix_azure_account_name).
+#   - That account's SP has Microsoft.ContainerService/managedClusters/listClusterUserCredential/action
+#     at subscription scope. Contributor includes it.
+#   - AKS cluster uses Kubernetes RBAC with local accounts. Entra-ID-only
+#     auth is NOT supported — the kubeconfig returned would contain `exec`
+#     entries the controller cannot process.
+#   - Controller's public egress IP is in the AKS API server's authorized_ip_ranges
+#     (see var.aviatrix_controller_public_ip).
+#####################
+
+resource "aviatrix_kubernetes_cluster" "this" {
+  count = var.enable_aviatrix_onboarding ? 1 : 0
+
+  # Docs require lowercased cluster_id. azurerm_kubernetes_cluster.id is
+  # mixed-case ("/subscriptions/.../Microsoft.ContainerService/managedClusters/...").
+  cluster_id          = lower(azurerm_kubernetes_cluster.aks.id)
+  use_csp_credentials = true
+
+  depends_on = [azurerm_kubernetes_cluster.aks]
+}

--- a/modules/azure-aks-cluster/outputs.tf
+++ b/modules/azure-aks-cluster/outputs.tf
@@ -1,0 +1,40 @@
+output "cluster_id" {
+  value = azurerm_kubernetes_cluster.aks.id
+}
+
+output "cluster_name" {
+  value = azurerm_kubernetes_cluster.aks.name
+}
+
+output "oidc_issuer_url" {
+  value = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+}
+
+output "kubelet_identity_object_id" {
+  value = azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id
+}
+
+output "host" {
+  value     = azurerm_kubernetes_cluster.aks.kube_config[0].host
+  sensitive = true
+}
+
+output "client_certificate" {
+  value     = azurerm_kubernetes_cluster.aks.kube_config[0].client_certificate
+  sensitive = true
+}
+
+output "client_key" {
+  value     = azurerm_kubernetes_cluster.aks.kube_config[0].client_key
+  sensitive = true
+}
+
+output "cluster_ca_certificate" {
+  value     = azurerm_kubernetes_cluster.aks.kube_config[0].cluster_ca_certificate
+  sensitive = true
+}
+
+output "configure_kubectl" {
+  description = "Command to fetch kubeconfig for this cluster."
+  value       = "az aks get-credentials --resource-group ${var.resource_group_name} --name ${var.cluster_name}"
+}

--- a/modules/azure-aks-cluster/variables.tf
+++ b/modules/azure-aks-cluster/variables.tf
@@ -45,7 +45,7 @@ variable "kubernetes_version" {
 }
 
 variable "node_pool_config" {
-  description = "System/user node pool sizing."
+  description = "AKS system node pool sizing."
   type = object({
     node_count = number
     min_count  = number
@@ -73,9 +73,9 @@ variable "dns_service_ip" {
 }
 
 variable "authorized_ip_ranges" {
-  description = "Extra CIDRs allowed to reach the AKS API server. The spoke GW public IP and (optionally) controller IP are appended automatically."
+  description = "Extra CIDRs allowed to reach the AKS API server. The module always appends the spoke GW public IP and (when onboarding) the controller IP, so the empty-list default is least-privilege: only those /32s can reach the API server."
   type        = list(string)
-  default     = ["0.0.0.0/0"]
+  default     = []
 }
 
 variable "spoke_gateway_public_ip" {

--- a/modules/azure-aks-cluster/variables.tf
+++ b/modules/azure-aks-cluster/variables.tf
@@ -1,0 +1,102 @@
+variable "cluster_name" {
+  description = "AKS cluster name."
+  type        = string
+}
+
+variable "azure_region" {
+  description = "Azure region (azurerm form, e.g. eastus2)."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group to create the AKS cluster in (the spoke VNet's RG)."
+  type        = string
+}
+
+variable "vnet_id" {
+  description = "Spoke VNet resource ID (for the AKS identity Network Contributor role)."
+  type        = string
+}
+
+variable "node_subnet_id" {
+  description = "Subnet ID for AKS node VMs."
+  type        = string
+}
+
+variable "pod_subnet_id" {
+  description = "Subnet ID for AKS pods (pod-subnet mode)."
+  type        = string
+}
+
+variable "node_route_table_id" {
+  description = "Node route table ID (for the AKS identity Network Contributor role)."
+  type        = string
+}
+
+variable "pod_route_table_id" {
+  description = "Pod route table ID (for the AKS identity Network Contributor role)."
+  type        = string
+}
+
+variable "kubernetes_version" {
+  description = "AKS Kubernetes version."
+  type        = string
+  default     = "1.33"
+}
+
+variable "node_pool_config" {
+  description = "System/user node pool sizing."
+  type = object({
+    node_count = number
+    min_count  = number
+    max_count  = number
+    vm_size    = string
+  })
+  default = {
+    node_count = 2
+    min_count  = 1
+    max_count  = 3
+    vm_size    = "Standard_B2s"
+  }
+}
+
+variable "service_cidr" {
+  description = "Kubernetes service CIDR (must not overlap VNet or pod CIDR)."
+  type        = string
+  default     = "172.16.0.0/16"
+}
+
+variable "dns_service_ip" {
+  description = "Kubernetes DNS service IP (within service_cidr)."
+  type        = string
+  default     = "172.16.0.10"
+}
+
+variable "authorized_ip_ranges" {
+  description = "Extra CIDRs allowed to reach the AKS API server. The spoke GW public IP and (optionally) controller IP are appended automatically."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "spoke_gateway_public_ip" {
+  description = "Spoke gateway public IP, appended to AKS API authorized_ip_ranges so node CSE bootstrap succeeds."
+  type        = string
+}
+
+variable "enable_aviatrix_onboarding" {
+  description = "Register the AKS cluster with the Aviatrix Controller for K8s SmartGroups."
+  type        = bool
+  default     = true
+}
+
+variable "aviatrix_controller_public_ip" {
+  description = "Controller public egress IP, appended to AKS API authorized_ip_ranges when onboarding."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags applied to created resources."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/azure-aks-cluster/versions.tf
+++ b/modules/azure-aks-cluster/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 9.0"
+    }
+  }
+}

--- a/modules/azure-aks-spoke-vnet/README.md
+++ b/modules/azure-aks-spoke-vnet/README.md
@@ -1,0 +1,150 @@
+> **AZURE MODULE — mirrors `modules/aws-eks-spoke-vpc/` for Azure.** The design intent, variable taxonomy, and output names track the AWS module. Azure-specific differences (UDR route tables instead of AWS route tables, `private_route_table_config` instead of `lifecycle`-only route management, `vpc_id` as `vnet_name:rg:guid`) are documented below. Changes to shared behaviour should be reflected in both modules.
+
+# azure-aks-spoke-vnet
+
+Terraform module that provisions a "spoke-in-a-box" Azure VNet shaped for AKS workloads and wired with an Aviatrix spoke gateway using the Aviatrix 9.0 Single IP SNAT explicit-route-table-selection feature.
+
+## What this module creates
+
+- **Resource group** containing all spoke resources.
+- **VNet** with two address spaces: a routable `/23` (for gateway, ingress, and node subnets) and a dedicated pod CIDR (for Azure CNI pod-subnet mode).
+- **Four subnets:**
+  - `<name>-avx-gw` `/28` — Aviatrix spoke gateway (carved as `cidrsubnet(vnet_cidr, 5, 0)`).
+  - `<name>-ingress` `/25` — Internal NGINX load balancer (carved as `cidrsubnet(vnet_cidr, 2, 1)`).
+  - `<name>-node` `/24` — AKS node pool VMs (carved as `cidrsubnet(vnet_cidr, 1, 1)`).
+  - `<name>-pod` — Full pod CIDR address space; AKS allocates pod IPs here in pod-subnet mode.
+- **Four route tables** (one per subnet), all with `lifecycle { ignore_changes = [route] }` so Aviatrix controller-programmed routes survive re-apply.
+- **Route table associations** linking each subnet to its route table.
+- **Aviatrix spoke gateway** (via `terraform-aviatrix-modules/mc-spoke/aviatrix` 9.0.0) with `single_ip_snat = true` and `private_route_table_config` pointing at the node and pod route tables.
+
+## Single IP SNAT + `private_route_table_config` design
+
+Aviatrix 9.0 introduced `private_route_table_config` on the mc-spoke module for Azure. It tells the Aviatrix Controller which route tables to program with `0.0.0.0/0 → spoke gateway` after the gateway comes up.
+
+**Only the node and pod route tables are included.** The gateway and ingress route tables are deliberately excluded:
+
+| Route table | In `private_route_table_config`? | Reason |
+|---|---|---|
+| `<name>-gateway-rt` | No | Loop avoidance: the spoke GW lives in this subnet. |
+| `<name>-ingress-rt` | No | Symmetric return path: the internal NGINX LB must reply directly to clients inside the VNet, not via the spoke GW. |
+| `<name>-node-rt` | Yes | All node egress (kubelet, system daemons, internet) flows through the GW for DCF inspection + SNAT. |
+| `<name>-pod-rt` | Yes | All pod egress flows through the GW; pod CIDRs (100.64.0.0/16) are SNAT'd to the GW private IP before leaving the VNet. |
+
+The result is Single IP SNAT: every pod and node appears to the internet as the spoke gateway's single public IP, without requiring a custom `aviatrix_gateway_snat` resource.
+
+## Requirements
+
+| Tool | Version |
+|---|---|
+| Terraform | >= 1.7 |
+| Aviatrix provider | ~> 9.0 |
+| Azure provider | ~> 4.0 |
+| mc-spoke module | 9.0.0 |
+| **Aviatrix Controller** | **9.0+** (required for `private_route_table_config` and Single IP SNAT on Azure) |
+
+## Variables
+
+| Variable | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `name` | `string` | — | yes | Base name for the spoke VNet, resource group, and gateway. |
+| `cluster_name` | `string` | — | yes | AKS cluster name, used for subnet/resource tagging. |
+| `vnet_cidr` | `string` | `"10.30.0.0/23"` | no | Routable /23 CIDR for the VNet (gateway, ingress, node subnets carved from this). |
+| `pod_cidr` | `string` | `"100.64.0.0/16"` | no | Dedicated pod subnet CIDR (Azure CNI pod-subnet mode), added as a 2nd VNet address space. |
+| `azure_region` | `string` | — | yes | Azure region in azurerm form (e.g. `eastus2`). |
+| `aviatrix_azure_region` | `string` | — | yes | Azure region in Aviatrix form (e.g. `East US 2`). Both forms are required because the azurerm and Aviatrix providers use different formats. |
+| `aviatrix_azure_account_name` | `string` | — | yes | Name of the Azure access account onboarded in the Aviatrix Controller. |
+| `transit_type` | `string` | `"none"` | no | `"none"` = standalone (Single IP SNAT egress only); `"aviatrix"` = attach to an Aviatrix transit gateway. |
+| `transit_gw_name` | `string` | `""` | aviatrix only | Aviatrix transit gateway name to attach to. Required when `transit_type = "aviatrix"`. |
+| `tags` | `map(string)` | `{}` | no | Tags applied to created resources. |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `resource_group_name` | Resource group containing the spoke VNet. |
+| `vnet_id` | Azure resource ID of the spoke VNet. |
+| `vnet_name` | Name of the spoke VNet. |
+| `aviatrix_vpc_id` | Aviatrix `vpc_id` form: `vnet_name:resource_group:guid`. Required when referencing the spoke in other Aviatrix resources. |
+| `gateway_subnet_id` | Subnet ID of the Aviatrix gateway subnet. |
+| `ingress_subnet_id` | Subnet ID of the ingress subnet (internal NGINX LB). |
+| `ingress_subnet_name` | Name of the ingress subnet (used by Helm ingress-nginx annotations). |
+| `node_subnet_id` | Subnet ID for AKS node VMs. |
+| `pod_subnet_id` | Subnet ID for AKS pods (pod-subnet mode). |
+| `node_route_table_id` | Node route table ID (used for AKS identity Network Contributor role assignment). |
+| `pod_route_table_id` | Pod route table ID (used for AKS identity Network Contributor role assignment). |
+| `spoke_gateway_name` | Name of the Aviatrix spoke gateway. |
+| `spoke_gateway_public_ip` | Public IP of the spoke gateway. Pass to `authorized_ip_ranges` in the AKS cluster so node CSE bootstrap succeeds. |
+| `spoke_gateway_private_ip` | Private IP of the spoke gateway (sensitive). |
+| `spoke_gateway` | Full Aviatrix spoke gateway object from mc-spoke (sensitive; for advanced callers). |
+
+## Usage example: standalone (Single IP SNAT egress)
+
+```hcl
+module "spoke_vnet" {
+  source = "../../modules/azure-aks-spoke-vnet"
+
+  name         = "aks-single"
+  cluster_name = "aks-single"
+  vnet_cidr    = "10.30.0.0/23"
+  pod_cidr     = "100.64.0.0/16"
+
+  azure_region          = "eastus2"
+  aviatrix_azure_region = "East US 2"
+
+  aviatrix_azure_account_name = "Azure"
+
+  # Default: standalone — no transit attachment.
+  # transit_type    = "none"
+  # transit_gw_name = ""
+
+  tags = {
+    Environment = "demo"
+    Blueprint   = "azure-aks-singlecluster"
+  }
+}
+```
+
+## Usage example: attached to an Aviatrix transit
+
+```hcl
+module "spoke_vnet" {
+  source = "../../modules/azure-aks-spoke-vnet"
+
+  name         = "aks-single"
+  cluster_name = "aks-single"
+  vnet_cidr    = "10.30.0.0/23"
+
+  azure_region          = "eastus2"
+  aviatrix_azure_region = "East US 2"
+
+  aviatrix_azure_account_name = "Azure"
+
+  transit_type    = "aviatrix"
+  transit_gw_name = "avx-transit-eastus2"
+
+  tags = { Environment = "demo" }
+}
+```
+
+## Region name duality
+
+Azure requires two region name formats that differ between providers:
+
+| Format | Example | Used by |
+|---|---|---|
+| `azure_region` (azurerm) | `"eastus2"` | `azurerm_resource_group`, `azurerm_virtual_network`, etc. |
+| `aviatrix_azure_region` (Aviatrix) | `"East US 2"` | mc-spoke `region` argument, Aviatrix Controller API |
+
+Always supply both. A mismatch causes the spoke gateway to be deployed in a different region than the VNet.
+
+## Pod subnet delegation drift
+
+AKS automatically attaches a `Microsoft.ContainerService/managedClusters` delegation to the pod subnet when the cluster starts in pod-subnet mode. The `lifecycle { ignore_changes = [delegation] }` block on `azurerm_subnet.pod` prevents Terraform from removing this delegation on subsequent applies (Azure rejects the removal with `SubnetMissingRequiredDelegation` while AKS holds the service association link).
+
+When destroying, delete the AKS cluster before running `terraform destroy` on this module. If `terraform destroy` still fails on the pod subnet, use `-target` to destroy all other resources first:
+
+```bash
+terraform destroy -target=module.spoke -target=azurerm_subnet_route_table_association.pod
+# Then after AKS is fully gone:
+terraform destroy
+```

--- a/modules/azure-aks-spoke-vnet/main.tf
+++ b/modules/azure-aks-spoke-vnet/main.tf
@@ -1,0 +1,166 @@
+locals {
+  rg_name   = "${var.name}-rg"
+  vnet_name = "${var.name}-vnet"
+
+  # Subnet layout carved from the /23 vnet_cidr:
+  #   gateway: cidrsubnet(x,5,0) = first /28   (Aviatrix spoke gateway)
+  #   ingress: cidrsubnet(x,2,1) = second /25  (internal NGINX LB)
+  #   node:    cidrsubnet(x,1,1) = second /24  (AKS node pool)
+  gateway_subnet = cidrsubnet(var.vnet_cidr, 5, 0)
+  ingress_subnet = cidrsubnet(var.vnet_cidr, 2, 1)
+  node_subnet    = cidrsubnet(var.vnet_cidr, 1, 1)
+}
+
+resource "azurerm_resource_group" "this" {
+  name     = local.rg_name
+  location = var.azure_region
+  tags     = merge(var.tags, { Name = local.rg_name })
+}
+
+resource "azurerm_virtual_network" "this" {
+  name                = local.vnet_name
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  address_space       = [var.vnet_cidr, var.pod_cidr]
+  tags                = merge(var.tags, { Name = local.vnet_name, Cluster = var.cluster_name })
+}
+
+resource "azurerm_subnet" "gateway" {
+  name                 = "${var.name}-avx-gw"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = [local.gateway_subnet]
+}
+
+resource "azurerm_subnet" "ingress" {
+  name                 = "${var.name}-ingress"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = [local.ingress_subnet]
+}
+
+resource "azurerm_subnet" "node" {
+  name                 = "${var.name}-node"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = [local.node_subnet]
+}
+
+resource "azurerm_subnet" "pod" {
+  name                 = "${var.name}-pod"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = [var.pod_cidr]
+
+  # AKS attaches a Microsoft.ContainerService/managedClusters delegation in
+  # pod-subnet mode. Ignore it so later applies don't try to remove it (which
+  # Azure rejects with SubnetMissingRequiredDelegation while AKS holds the link).
+  lifecycle {
+    ignore_changes = [delegation]
+  }
+}
+
+# Route tables. The Aviatrix controller programs 0/0 -> spoke GW on the node and
+# pod tables (selected via mc-spoke private_route_table_config). All tables ignore
+# route changes so controller-programmed routes survive terraform apply.
+resource "azurerm_route_table" "gateway" {
+  name                = "${var.name}-gateway-rt"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = var.tags
+  lifecycle {
+    ignore_changes = [route]
+  }
+}
+
+resource "azurerm_route_table" "ingress" {
+  name                = "${var.name}-ingress-rt"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = var.tags
+  lifecycle {
+    ignore_changes = [route]
+  }
+}
+
+resource "azurerm_route_table" "node" {
+  name                = "${var.name}-node-rt"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = var.tags
+  lifecycle {
+    ignore_changes = [route]
+  }
+}
+
+resource "azurerm_route_table" "pod" {
+  name                = "${var.name}-pod-rt"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = var.tags
+  lifecycle {
+    ignore_changes = [route]
+  }
+}
+
+resource "azurerm_subnet_route_table_association" "gateway" {
+  subnet_id      = azurerm_subnet.gateway.id
+  route_table_id = azurerm_route_table.gateway.id
+}
+
+resource "azurerm_subnet_route_table_association" "ingress" {
+  subnet_id      = azurerm_subnet.ingress.id
+  route_table_id = azurerm_route_table.ingress.id
+}
+
+resource "azurerm_subnet_route_table_association" "node" {
+  subnet_id      = azurerm_subnet.node.id
+  route_table_id = azurerm_route_table.node.id
+}
+
+resource "azurerm_subnet_route_table_association" "pod" {
+  subnet_id      = azurerm_subnet.pod.id
+  route_table_id = azurerm_route_table.pod.id
+}
+
+module "spoke" {
+  source  = "terraform-aviatrix-modules/mc-spoke/aviatrix"
+  version = "9.0.0"
+
+  cloud            = "Azure"
+  name             = var.name
+  region           = var.aviatrix_azure_region
+  account          = var.aviatrix_azure_account_name
+  use_existing_vpc = true
+  vpc_id           = format("%s:%s:%s", azurerm_virtual_network.this.name, azurerm_resource_group.this.name, azurerm_virtual_network.this.guid)
+  gw_subnet        = azurerm_subnet.gateway.address_prefixes[0]
+  hagw_subnet      = azurerm_subnet.gateway.address_prefixes[0]
+  ha_gw            = false
+
+  single_ip_snat = true
+  private_route_table_config = [
+    "${azurerm_route_table.node.name}:${azurerm_resource_group.this.name}",
+    "${azurerm_route_table.pod.name}:${azurerm_resource_group.this.name}",
+  ]
+
+  attached   = var.transit_type == "aviatrix"
+  transit_gw = var.transit_type == "aviatrix" ? var.transit_gw_name : ""
+
+  tags = var.tags
+
+  depends_on = [
+    azurerm_subnet_route_table_association.node,
+    azurerm_subnet_route_table_association.pod,
+    azurerm_subnet_route_table_association.gateway,
+  ]
+}
+
+# Fail fast if attaching to a transit without naming it.
+resource "terraform_data" "validate_transit" {
+  lifecycle {
+    precondition {
+      condition     = var.transit_type != "aviatrix" || length(var.transit_gw_name) > 0
+      error_message = "transit_gw_name is required when transit_type = aviatrix."
+    }
+  }
+}

--- a/modules/azure-aks-spoke-vnet/outputs.tf
+++ b/modules/azure-aks-spoke-vnet/outputs.tf
@@ -55,12 +55,16 @@ output "pod_route_table_id" {
 
 output "spoke_gateway_name" {
   description = "Name of the Aviatrix spoke gateway."
-  value       = module.spoke.spoke_gateway.gw_name
+  # mc-spoke marks the whole spoke_gateway object sensitive; the gateway name is
+  # not a secret and is needed as a plain value by downstream layers / the README.
+  value = nonsensitive(module.spoke.spoke_gateway.gw_name)
 }
 
 output "spoke_gateway_public_ip" {
   description = "Public IP of the spoke gateway (for AKS API authorized_ip_ranges)."
-  value       = module.spoke.spoke_gateway.public_ip
+  # Not a secret: consumed by the cluster layer as an AKS API authorized_ip_range
+  # (a plain CIDR list). Unwrap so sensitivity does not propagate downstream.
+  value = nonsensitive(module.spoke.spoke_gateway.public_ip)
 }
 
 output "spoke_gateway_private_ip" {

--- a/modules/azure-aks-spoke-vnet/outputs.tf
+++ b/modules/azure-aks-spoke-vnet/outputs.tf
@@ -9,7 +9,8 @@ output "vnet_id" {
 }
 
 output "vnet_name" {
-  value = azurerm_virtual_network.this.name
+  description = "Name of the spoke VNet."
+  value       = azurerm_virtual_network.this.name
 }
 
 output "aviatrix_vpc_id" {
@@ -18,31 +19,38 @@ output "aviatrix_vpc_id" {
 }
 
 output "gateway_subnet_id" {
-  value = azurerm_subnet.gateway.id
+  description = "Subnet ID of the Aviatrix gateway subnet."
+  value       = azurerm_subnet.gateway.id
 }
 
 output "ingress_subnet_id" {
-  value = azurerm_subnet.ingress.id
+  description = "Subnet ID of the ingress subnet (internal NGINX LB)."
+  value       = azurerm_subnet.ingress.id
 }
 
 output "ingress_subnet_name" {
-  value = azurerm_subnet.ingress.name
+  description = "Name of the ingress subnet (used by Helm ingress-nginx annotations)."
+  value       = azurerm_subnet.ingress.name
 }
 
 output "node_subnet_id" {
-  value = azurerm_subnet.node.id
+  description = "Subnet ID for AKS node VMs."
+  value       = azurerm_subnet.node.id
 }
 
 output "pod_subnet_id" {
-  value = azurerm_subnet.pod.id
+  description = "Subnet ID for AKS pods (pod-subnet mode)."
+  value       = azurerm_subnet.pod.id
 }
 
 output "node_route_table_id" {
-  value = azurerm_route_table.node.id
+  description = "Node route table ID (Aviatrix programs 0/0 -> spoke GW here)."
+  value       = azurerm_route_table.node.id
 }
 
 output "pod_route_table_id" {
-  value = azurerm_route_table.pod.id
+  description = "Pod route table ID (Aviatrix programs 0/0 -> spoke GW here)."
+  value       = azurerm_route_table.pod.id
 }
 
 output "spoke_gateway_name" {

--- a/modules/azure-aks-spoke-vnet/outputs.tf
+++ b/modules/azure-aks-spoke-vnet/outputs.tf
@@ -1,0 +1,68 @@
+output "resource_group_name" {
+  description = "Resource group containing the spoke VNet."
+  value       = azurerm_resource_group.this.name
+}
+
+output "vnet_id" {
+  description = "Azure resource ID of the spoke VNet."
+  value       = azurerm_virtual_network.this.id
+}
+
+output "vnet_name" {
+  value = azurerm_virtual_network.this.name
+}
+
+output "aviatrix_vpc_id" {
+  description = "Aviatrix vpc_id form (vnet_name:rg:guid)."
+  value       = format("%s:%s:%s", azurerm_virtual_network.this.name, azurerm_resource_group.this.name, azurerm_virtual_network.this.guid)
+}
+
+output "gateway_subnet_id" {
+  value = azurerm_subnet.gateway.id
+}
+
+output "ingress_subnet_id" {
+  value = azurerm_subnet.ingress.id
+}
+
+output "ingress_subnet_name" {
+  value = azurerm_subnet.ingress.name
+}
+
+output "node_subnet_id" {
+  value = azurerm_subnet.node.id
+}
+
+output "pod_subnet_id" {
+  value = azurerm_subnet.pod.id
+}
+
+output "node_route_table_id" {
+  value = azurerm_route_table.node.id
+}
+
+output "pod_route_table_id" {
+  value = azurerm_route_table.pod.id
+}
+
+output "spoke_gateway_name" {
+  description = "Name of the Aviatrix spoke gateway."
+  value       = module.spoke.spoke_gateway.gw_name
+}
+
+output "spoke_gateway_public_ip" {
+  description = "Public IP of the spoke gateway (for AKS API authorized_ip_ranges)."
+  value       = module.spoke.spoke_gateway.public_ip
+}
+
+output "spoke_gateway_private_ip" {
+  description = "Private IP of the spoke gateway."
+  value       = module.spoke.spoke_gateway.private_ip
+  sensitive   = true
+}
+
+output "spoke_gateway" {
+  description = "Full Aviatrix spoke gateway object."
+  value       = module.spoke.spoke_gateway
+  sensitive   = true
+}

--- a/modules/azure-aks-spoke-vnet/variables.tf
+++ b/modules/azure-aks-spoke-vnet/variables.tf
@@ -1,0 +1,59 @@
+variable "name" {
+  description = "Base name for the spoke VNet, resource group, and gateway."
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "AKS cluster name, used for subnet/resource tagging."
+  type        = string
+}
+
+variable "vnet_cidr" {
+  description = "Routable /23 CIDR for the VNet (gateway, ingress, node subnets carved from this)."
+  type        = string
+  default     = "10.30.0.0/23"
+}
+
+variable "pod_cidr" {
+  description = "Dedicated pod subnet CIDR (Azure CNI pod-subnet mode), added as a 2nd VNet address space."
+  type        = string
+  default     = "100.64.0.0/16"
+}
+
+variable "azure_region" {
+  description = "Azure region in azurerm form (e.g. eastus2)."
+  type        = string
+}
+
+variable "aviatrix_azure_region" {
+  description = "Azure region in Aviatrix form (e.g. East US 2)."
+  type        = string
+}
+
+variable "aviatrix_azure_account_name" {
+  description = "Name of the Azure access account onboarded in the Aviatrix Controller."
+  type        = string
+}
+
+variable "transit_type" {
+  description = "How the spoke connects to the fabric. 'none' = standalone (Single IP SNAT egress only); 'aviatrix' = attach to an Aviatrix transit gateway."
+  type        = string
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "aviatrix"], var.transit_type)
+    error_message = "transit_type must be one of: none, aviatrix."
+  }
+}
+
+variable "transit_gw_name" {
+  description = "Aviatrix transit gateway name to attach to. Required when transit_type = aviatrix."
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Tags applied to created resources."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/azure-aks-spoke-vnet/variables.tf
+++ b/modules/azure-aks-spoke-vnet/variables.tf
@@ -12,12 +12,22 @@ variable "vnet_cidr" {
   description = "Routable /23 CIDR for the VNet (gateway, ingress, node subnets carved from this)."
   type        = string
   default     = "10.30.0.0/23"
+
+  validation {
+    condition     = can(cidrhost(var.vnet_cidr, 0)) && tonumber(split("/", var.vnet_cidr)[1]) == 23
+    error_message = "vnet_cidr must be a valid IPv4 /23 CIDR block (the subnet layout assumes a /23)."
+  }
 }
 
 variable "pod_cidr" {
   description = "Dedicated pod subnet CIDR (Azure CNI pod-subnet mode), added as a 2nd VNet address space."
   type        = string
   default     = "100.64.0.0/16"
+
+  validation {
+    condition     = can(cidrhost(var.pod_cidr, 0))
+    error_message = "pod_cidr must be a valid IPv4 CIDR block."
+  }
 }
 
 variable "azure_region" {

--- a/modules/azure-aks-spoke-vnet/versions.tf
+++ b/modules/azure-aks-spoke-vnet/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 9.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Live QA of the `azure-aks-singlecluster` blueprint (single AKS spoke-in-a-box with DCF egress filtering via Aviatrix 9.0 Single-IP-SNAT route-table selection). Full deploy → enforce → destroy cycle run against a live lab; three real bugs found and fixed; blueprint promoted from 🚧 to ✅ Available.

**Verified live** (Controller 9.0.10, provider 9.0.0, azurerm 4.76.0, AKS 1.33, Azure eastus2):
- 4-layer deploy → destroy (clean, no orphans)
- 9.0 Single-IP-SNAT route-table selection (`0/0 → spoke GW` on node+pod RTs only; gateway/ingress excluded)
- AKS `userDefinedRouting` bring-up, nodes Ready, Aviatrix Controller onboarding
- ingress-nginx internal Azure LB; k8s-firewall CRDs
- **DCF egress enforcement on a standalone (non-transit) spoke** — datapath-confirmed via eBPF `dst_cidrs` + a deterministic CIDR-deny test
- Egress allow-list permits (kubernetes.io / npm / GitHub) green under real enforcement

## Fixes

1. **Missing DCF enable (critical):** `network/dcf.tf` lacked `aviatrix_distributed_firewalling_config { enable_distributed_firewalling = true }`. Without it the ruleset is configured but **never enforced** (egress allow-list "passes" trivially; geo/threat DENY rules never fire). Verified live: a standalone spoke does not enforce DCF until this global toggle is set. **Same fix applied to `aws-eks-singlecluster`** (same latent bug; code-only, not live re-tested).
2. **k8s-firewall Helm chart `1.0.0` → `9.0.0`:** the pinned version does not exist; the repo publishes only 8.2.0/9.0.0. Matched to the Controller major.
3. **Sensitive-output error:** `nonsensitive()` on the module's `spoke_gateway_name` / `spoke_gateway_public_ip` (mc-spoke marks the gateway object sensitive; these aren't secrets, and the cluster layer needs the public IP as a plain CIDR for `authorized_ip_ranges`). `terraform validate` does not catch this.

## Notes / caveats

- **Geo/ThreatIQ blocking not demonstrable on the lab controller:** the GeoIP/ThreatGuard intelligence feed is not populated, so the geo/threat SmartGroups compile to zero CIDRs (datapath-confirmed: `dst_cidrs` held only the Public-Internet coverage, no IR/KP/RU prefixes). The blueprint's DCF config is correct; this is a Controller-side prerequisite.
- **9.0-only:** documented in the README. 8.2 backwards-compatibility (Single-IP-SNAT-only path) is a planned follow-up. Kept the deprecated `aviatrix_distributed_firewalling_config` (live-verified, consistent with the multicluster blueprints, and R3.0+ vs `aviatrix_config_feature` which is 9.0.0+).

## Test Plan

- [x] `terraform fmt -check -recursive` clean
- [x] `terraform validate` passes (network/cluster/nodes)
- [x] Full live deploy → DCF enforcement verified → destroy, no orphans
- [ ] Geo/ThreatIQ blocking (blocked on Controller GeoIP/ThreatGuard feed; config verified correct)
- [ ] aws-eks-singlecluster DCF-enable fix live re-test (code-only this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)