### PR TITLE
azure-aks-singlecluster: add Controller 8.2 variant (azure-aks-spoke-vnet-82)

### DIFF
--- a/blueprints/azure-aks-singlecluster/README.md
+++ b/blueprints/azure-aks-singlecluster/README.md
@@ -8,7 +8,12 @@ The blueprint deploys **standalone by default** (no transit attachment). Egress 
 > **Live deploy-verified** (2026-06-05, Controller 9.0.10, provider 9.0.0, AKS 1.33). Full deploy → enforce → destroy cycle validated: the 9.0 Single-IP-SNAT route-table selection, AKS `userDefinedRouting` bring-up, Aviatrix onboarding, internal-LB ingress, and **DCF egress enforcement** (allow-list permits + datapath-confirmed deny) all work. Geo/ThreatIQ blocking additionally requires the Controller's GeoIP/ThreatGuard intelligence feed to be populated — a Controller-side prerequisite independent of this blueprint's (correct) DCF config.
 
 > [!IMPORTANT]
-> **Controller/provider 9.0 only (for now).** This version depends on 9.0-era features — the Single-IP-SNAT `private_route_table_config` explicit-route-table selection and the 9.0 DCF resources. It has **not** been validated against 8.2 or earlier. A future revision will add **backwards compatibility to 8.2** (a Single-IP-SNAT-only path with the older provider, without the 9.0 route-table-selection config). Until then, treat 9.0+ as a hard requirement.
+> **Defaults to Controller/provider 9.0; an 8.2 path is supported.** As shipped, this blueprint targets **Controller 9.0+** using Single-IP-SNAT `private_route_table_config` explicit-route-table selection. For an **Aviatrix Controller 8.2** — which does *not* honor that 9.0 selection — deploy the 8.2 variant with three edits (live-verified 2026-06-08 on Controller 8.2.10):
+> 1. `network/versions.tf` **and** `cluster/versions.tf`: set the aviatrix provider to `version = "~> 8.2.0"`.
+> 2. `network/main.tf`: point the spoke module at the 8.2 variant — `source = "../../../modules/azure-aks-spoke-vnet-82"`. It does Single IP SNAT via a blackhole `0.0.0.0/0 → None` placeholder that the 8.2 controller auto-selects (no `private_route_table_config`).
+> 3. `nodes`: set `k8s_firewall_chart_version = "8.2.0"` to match the controller major.
+>
+> These can't be a single runtime toggle: mc-spoke 9.0.0 (which provides `private_route_table_config`) requires provider `>= 9.0.0`, and the provider major must match the controller — so the version pins are a static, deploy-time choice. Details: [`modules/azure-aks-spoke-vnet-82`](../../modules/azure-aks-spoke-vnet-82/README.md).
 
 > [!TIP]
 > **🤖 Optimized for Claude Code** — Run `/deploy-blueprint azure-aks-singlecluster` for AI-guided deployment with prerequisite checks and automated orchestration, or `/analyze-blueprint azure-aks-singlecluster` for resource and cost details. [Get Claude Code](https://claude.ai/code)
@@ -421,7 +426,8 @@ az group show --name "<name_prefix>-rg"   # expect: ResourceGroupNotFound
 
 ## Related
 
-- [`modules/azure-aks-spoke-vnet`](../../modules/azure-aks-spoke-vnet/README.md) — the spoke-in-a-box VNet module (Single IP SNAT + `private_route_table_config` route-table selection).
+- [`modules/azure-aks-spoke-vnet`](../../modules/azure-aks-spoke-vnet/README.md) — the spoke-in-a-box VNet module for **Controller 9.0+** (Single IP SNAT + `private_route_table_config` route-table selection). Default.
+- [`modules/azure-aks-spoke-vnet-82`](../../modules/azure-aks-spoke-vnet-82/README.md) — the **Controller 8.2** variant of the spoke module (Single IP SNAT + blackhole `0/0 → None` route auto-selection; no `private_route_table_config`). Used by the 8.2 path above.
 - [`modules/azure-aks-cluster`](../../modules/azure-aks-cluster/README.md) — the AKS cluster module (Azure CNI + Cilium, workload identity, Aviatrix onboarding).
 - [`aws-eks-singlecluster`](../aws-eks-singlecluster/README.md) — the AWS analogue this blueprint mirrors.
 - [`azure-aks-multicluster`](../azure-aks-multicluster/README.md) — the multi-cluster Azure blueprint this is derived from.

--- a/modules/azure-aks-cluster/versions.tf
+++ b/modules/azure-aks-cluster/versions.tf
@@ -7,8 +7,12 @@ terraform {
       version = "~> 4.0"
     }
     aviatrix = {
-      source  = "AviatrixSystems/aviatrix"
-      version = "~> 9.0"
+      source = "AviatrixSystems/aviatrix"
+      # Cross-major: this module only uses aviatrix_kubernetes_cluster (present in
+      # 8.2 and 9.0). The effective provider is pinned by the consuming blueprint
+      # layer (~> 9.0 by default, ~> 8.2.0 for the Controller-8.2 path), so this
+      # constraint stays permissive to support both without editing the module.
+      version = ">= 8.2, < 10.0"
     }
   }
 }

--- a/modules/azure-aks-spoke-vnet-82/README.md
+++ b/modules/azure-aks-spoke-vnet-82/README.md
@@ -1,0 +1,152 @@
+> **AZURE MODULE — mirrors `modules/aws-eks-spoke-vpc/` for Azure.** The design intent, variable taxonomy, and output names track the AWS module. Azure-specific differences (UDR route tables with blackhole `0/0 → None` placeholders for controller auto-selection, `vpc_id` as `vnet_name:rg:guid`) are documented below. Changes to shared behaviour should be reflected in both modules.
+
+# azure-aks-spoke-vnet-82 (Aviatrix Controller 8.2)
+
+Terraform module that provisions a "spoke-in-a-box" Azure VNet shaped for AKS workloads and wired with an Aviatrix spoke gateway using Single IP SNAT. Egress route tables are selected by the controller via a blackhole `0/0 → None` placeholder.
+
+> **This is the Controller 8.2 variant.** It is pinned to the 8.2 provider / mc-spoke `~> 8.2.0` and relies on the 8.2 controller auto-selecting route tables by their blackhole placeholder. **A 9.0.x controller does NOT honor that auto-selection** (live-verified 2026-06-08: node/pod tables keep their `0/0 → None` drop route), so on Controller 9.0+ use the sibling [`azure-aks-spoke-vnet`](../azure-aks-spoke-vnet/README.md), which uses the explicit `private_route_table_config`. The two cannot be merged into one config: mc-spoke 9.0.0 requires provider `>= 9.0.0`, so the provider pin (which must match the controller major) forces the split.
+
+## What this module creates
+
+- **Resource group** containing all spoke resources.
+- **VNet** with two address spaces: a routable `/23` (for gateway, ingress, and node subnets) and a dedicated pod CIDR (for Azure CNI pod-subnet mode).
+- **Four subnets:**
+  - `<name>-avx-gw` `/28` — Aviatrix spoke gateway (carved as `cidrsubnet(vnet_cidr, 5, 0)`).
+  - `<name>-ingress` `/25` — Internal NGINX load balancer (carved as `cidrsubnet(vnet_cidr, 2, 1)`).
+  - `<name>-node` `/24` — AKS node pool VMs (carved as `cidrsubnet(vnet_cidr, 1, 1)`).
+  - `<name>-pod` — Full pod CIDR address space; AKS allocates pod IPs here in pod-subnet mode.
+- **Four route tables** (one per subnet), all with `lifecycle { ignore_changes = [route] }` so Aviatrix controller-programmed routes survive re-apply. The node and pod tables carry a blackhole `0.0.0.0/0 → None` placeholder; the gateway and ingress tables are bare.
+- **Route table associations** linking each subnet to its route table.
+- **Aviatrix spoke gateway** (via `terraform-aviatrix-modules/mc-spoke/aviatrix ~> 8.2.0`) with `single_ip_snat = true`. The controller auto-selects the node and pod route tables by their blackhole placeholder route.
+
+## Single IP SNAT + blackhole route-table selection
+
+When `single_ip_snat` is enabled, the Aviatrix Controller programs `0.0.0.0/0 → spoke gateway` into the VNet's "private" route tables. It identifies those tables by the presence of an existing default route — the conventional `0.0.0.0/0 → None` (blackhole) placeholder. The module puts that placeholder on the node and pod tables only; the controller rewrites it to `0/0 → spoke GW` and `lifecycle { ignore_changes = [route] }` keeps that in place. This is the pre-9.0 mechanism. **It is honored by an 8.2 controller (live-verified 2026-06-08 on Controller 8.2.10) but NOT by a 9.0.x controller** — 9.0 replaced the blackhole auto-detection with the explicit `private_route_table_config` selection used by the sibling `azure-aks-spoke-vnet` module. Do not deploy this variant against a 9.0 controller: the node/pod `0/0 → None` placeholder is a drop route, so egress would be blackholed.
+
+**Only the node and pod route tables get the placeholder.** The gateway and ingress tables stay bare and are never selected:
+
+| Route table | Blackhole placeholder? | Reason |
+|---|---|---|
+| `<name>-gateway-rt` | No | Loop avoidance: the spoke GW lives in this subnet and needs real internet egress. |
+| `<name>-ingress-rt` | No | Symmetric return path: the internal NGINX LB must reply directly to clients inside the VNet, not via the spoke GW. |
+| `<name>-node-rt` | Yes | All node egress (kubelet, system daemons, internet) flows through the GW for DCF inspection + SNAT. |
+| `<name>-pod-rt` | Yes | All pod egress flows through the GW; pod CIDRs (100.64.0.0/16) are SNAT'd to the GW private IP before leaving the VNet. |
+
+The result is Single IP SNAT: every pod and node appears to the internet as the spoke gateway's single public IP, without requiring a custom `aviatrix_gateway_snat` resource.
+
+## Requirements
+
+| Tool | Version |
+|---|---|
+| Terraform | >= 1.7 |
+| Aviatrix provider | ~> 8.2.0 |
+| Azure provider | ~> 4.0 |
+| mc-spoke module | ~> 8.2.0 |
+| **Aviatrix Controller** | **8.2 only** (relies on 8.2 blackhole route auto-selection; 9.0.x does not honor it — use the `azure-aks-spoke-vnet` sibling on 9.0+) |
+
+## Variables
+
+| Variable | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `name` | `string` | — | yes | Base name for the spoke VNet, resource group, and gateway. |
+| `cluster_name` | `string` | — | yes | AKS cluster name, used for subnet/resource tagging. |
+| `vnet_cidr` | `string` | `"10.30.0.0/23"` | no | Routable /23 CIDR for the VNet (gateway, ingress, node subnets carved from this). |
+| `pod_cidr` | `string` | `"100.64.0.0/16"` | no | Dedicated pod subnet CIDR (Azure CNI pod-subnet mode), added as a 2nd VNet address space. |
+| `azure_region` | `string` | — | yes | Azure region in azurerm form (e.g. `eastus2`). |
+| `aviatrix_azure_region` | `string` | — | yes | Azure region in Aviatrix form (e.g. `East US 2`). Both forms are required because the azurerm and Aviatrix providers use different formats. |
+| `aviatrix_azure_account_name` | `string` | — | yes | Name of the Azure access account onboarded in the Aviatrix Controller. |
+| `transit_type` | `string` | `"none"` | no | `"none"` = standalone (Single IP SNAT egress only); `"aviatrix"` = attach to an Aviatrix transit gateway. |
+| `transit_gw_name` | `string` | `""` | aviatrix only | Aviatrix transit gateway name to attach to. Required when `transit_type = "aviatrix"`. |
+| `tags` | `map(string)` | `{}` | no | Tags applied to created resources. |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `resource_group_name` | Resource group containing the spoke VNet. |
+| `vnet_id` | Azure resource ID of the spoke VNet. |
+| `vnet_name` | Name of the spoke VNet. |
+| `aviatrix_vpc_id` | Aviatrix `vpc_id` form: `vnet_name:resource_group:guid`. Required when referencing the spoke in other Aviatrix resources. |
+| `gateway_subnet_id` | Subnet ID of the Aviatrix gateway subnet. |
+| `ingress_subnet_id` | Subnet ID of the ingress subnet (internal NGINX LB). |
+| `ingress_subnet_name` | Name of the ingress subnet (used by Helm ingress-nginx annotations). |
+| `node_subnet_id` | Subnet ID for AKS node VMs. |
+| `pod_subnet_id` | Subnet ID for AKS pods (pod-subnet mode). |
+| `node_route_table_id` | Node route table ID (used for AKS identity Network Contributor role assignment). |
+| `pod_route_table_id` | Pod route table ID (used for AKS identity Network Contributor role assignment). |
+| `spoke_gateway_name` | Name of the Aviatrix spoke gateway. |
+| `spoke_gateway_public_ip` | Public IP of the spoke gateway. Pass to `authorized_ip_ranges` in the AKS cluster so node CSE bootstrap succeeds. |
+| `spoke_gateway_private_ip` | Private IP of the spoke gateway (sensitive). |
+| `spoke_gateway` | Full Aviatrix spoke gateway object from mc-spoke (sensitive; for advanced callers). |
+
+## Usage example: standalone (Single IP SNAT egress)
+
+```hcl
+module "spoke_vnet" {
+  source = "../../modules/azure-aks-spoke-vnet"
+
+  name         = "aks-single"
+  cluster_name = "aks-single"
+  vnet_cidr    = "10.30.0.0/23"
+  pod_cidr     = "100.64.0.0/16"
+
+  azure_region          = "eastus2"
+  aviatrix_azure_region = "East US 2"
+
+  aviatrix_azure_account_name = "Azure"
+
+  # Default: standalone — no transit attachment.
+  # transit_type    = "none"
+  # transit_gw_name = ""
+
+  tags = {
+    Environment = "demo"
+    Blueprint   = "azure-aks-singlecluster"
+  }
+}
+```
+
+## Usage example: attached to an Aviatrix transit
+
+```hcl
+module "spoke_vnet" {
+  source = "../../modules/azure-aks-spoke-vnet"
+
+  name         = "aks-single"
+  cluster_name = "aks-single"
+  vnet_cidr    = "10.30.0.0/23"
+
+  azure_region          = "eastus2"
+  aviatrix_azure_region = "East US 2"
+
+  aviatrix_azure_account_name = "Azure"
+
+  transit_type    = "aviatrix"
+  transit_gw_name = "avx-transit-eastus2"
+
+  tags = { Environment = "demo" }
+}
+```
+
+## Region name duality
+
+Azure requires two region name formats that differ between providers:
+
+| Format | Example | Used by |
+|---|---|---|
+| `azure_region` (azurerm) | `"eastus2"` | `azurerm_resource_group`, `azurerm_virtual_network`, etc. |
+| `aviatrix_azure_region` (Aviatrix) | `"East US 2"` | mc-spoke `region` argument, Aviatrix Controller API |
+
+Always supply both. A mismatch causes the spoke gateway to be deployed in a different region than the VNet.
+
+## Pod subnet delegation drift
+
+AKS automatically attaches a `Microsoft.ContainerService/managedClusters` delegation to the pod subnet when the cluster starts in pod-subnet mode. The `lifecycle { ignore_changes = [delegation] }` block on `azurerm_subnet.pod` prevents Terraform from removing this delegation on subsequent applies (Azure rejects the removal with `SubnetMissingRequiredDelegation` while AKS holds the service association link).
+
+When destroying, delete the AKS cluster before running `terraform destroy` on this module. If `terraform destroy` still fails on the pod subnet, use `-target` to destroy all other resources first:
+
+```bash
+terraform destroy -target=module.spoke -target=azurerm_subnet_route_table_association.pod
+# Then after AKS is fully gone:
+terraform destroy
+```

--- a/modules/azure-aks-spoke-vnet-82/main.tf
+++ b/modules/azure-aks-spoke-vnet-82/main.tf
@@ -1,0 +1,187 @@
+locals {
+  rg_name   = "${var.name}-rg"
+  vnet_name = "${var.name}-vnet"
+
+  # Subnet layout carved from the /23 vnet_cidr:
+  #   gateway: cidrsubnet(x,5,0) = first /28   (Aviatrix spoke gateway)
+  #   ingress: cidrsubnet(x,2,1) = second /25  (internal NGINX LB)
+  #   node:    cidrsubnet(x,1,1) = second /24  (AKS node pool)
+  gateway_subnet = cidrsubnet(var.vnet_cidr, 5, 0)
+  ingress_subnet = cidrsubnet(var.vnet_cidr, 2, 1)
+  node_subnet    = cidrsubnet(var.vnet_cidr, 1, 1)
+}
+
+resource "azurerm_resource_group" "this" {
+  name     = local.rg_name
+  location = var.azure_region
+  tags     = merge(var.tags, { Name = local.rg_name })
+}
+
+resource "azurerm_virtual_network" "this" {
+  name                = local.vnet_name
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  address_space       = [var.vnet_cidr, var.pod_cidr]
+  tags                = merge(var.tags, { Name = local.vnet_name, Cluster = var.cluster_name })
+}
+
+resource "azurerm_subnet" "gateway" {
+  name                 = "${var.name}-avx-gw"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = [local.gateway_subnet]
+}
+
+resource "azurerm_subnet" "ingress" {
+  name                 = "${var.name}-ingress"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = [local.ingress_subnet]
+}
+
+resource "azurerm_subnet" "node" {
+  name                 = "${var.name}-node"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = [local.node_subnet]
+}
+
+resource "azurerm_subnet" "pod" {
+  name                 = "${var.name}-pod"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = [var.pod_cidr]
+
+  # AKS attaches a Microsoft.ContainerService/managedClusters delegation in
+  # pod-subnet mode. Ignore it so later applies don't try to remove it (which
+  # Azure rejects with SubnetMissingRequiredDelegation while AKS holds the link).
+  lifecycle {
+    ignore_changes = [delegation]
+  }
+}
+
+# Route tables. The node and pod tables carry a blackhole 0.0.0.0/0 -> None
+# placeholder route; when single_ip_snat is enabled the Aviatrix controller
+# auto-selects route tables that already have a default route and rewrites it to
+# 0/0 -> spoke GW (works on 8.2 and 9.0 controllers; no private_route_table_config
+# needed). The gateway and ingress tables stay bare so the controller never
+# selects them (loop avoidance + symmetric ingress return). All tables ignore
+# route changes so controller-programmed routes survive terraform apply.
+resource "azurerm_route_table" "gateway" {
+  name                = "${var.name}-gateway-rt"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = var.tags
+  lifecycle {
+    ignore_changes = [route]
+  }
+}
+
+resource "azurerm_route_table" "ingress" {
+  name                = "${var.name}-ingress-rt"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = var.tags
+  lifecycle {
+    ignore_changes = [route]
+  }
+}
+
+resource "azurerm_route_table" "node" {
+  name                = "${var.name}-node-rt"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = var.tags
+
+  # Blackhole placeholder. The controller detects this default route and rewrites
+  # it to 0/0 -> spoke GW when single_ip_snat is enabled.
+  route {
+    name           = "default"
+    address_prefix = "0.0.0.0/0"
+    next_hop_type  = "None"
+  }
+
+  lifecycle {
+    ignore_changes = [route]
+  }
+}
+
+resource "azurerm_route_table" "pod" {
+  name                = "${var.name}-pod-rt"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = var.tags
+
+  # Blackhole placeholder. The controller detects this default route and rewrites
+  # it to 0/0 -> spoke GW when single_ip_snat is enabled.
+  route {
+    name           = "default"
+    address_prefix = "0.0.0.0/0"
+    next_hop_type  = "None"
+  }
+
+  lifecycle {
+    ignore_changes = [route]
+  }
+}
+
+resource "azurerm_subnet_route_table_association" "gateway" {
+  subnet_id      = azurerm_subnet.gateway.id
+  route_table_id = azurerm_route_table.gateway.id
+}
+
+resource "azurerm_subnet_route_table_association" "ingress" {
+  subnet_id      = azurerm_subnet.ingress.id
+  route_table_id = azurerm_route_table.ingress.id
+}
+
+resource "azurerm_subnet_route_table_association" "node" {
+  subnet_id      = azurerm_subnet.node.id
+  route_table_id = azurerm_route_table.node.id
+}
+
+resource "azurerm_subnet_route_table_association" "pod" {
+  subnet_id      = azurerm_subnet.pod.id
+  route_table_id = azurerm_route_table.pod.id
+}
+
+module "spoke" {
+  source  = "terraform-aviatrix-modules/mc-spoke/aviatrix"
+  version = "~> 8.2.0"
+
+  cloud            = "Azure"
+  name             = var.name
+  region           = var.aviatrix_azure_region
+  account          = var.aviatrix_azure_account_name
+  use_existing_vpc = true
+  vpc_id           = format("%s:%s:%s", azurerm_virtual_network.this.name, azurerm_resource_group.this.name, azurerm_virtual_network.this.guid)
+  gw_subnet        = azurerm_subnet.gateway.address_prefixes[0]
+  hagw_subnet      = azurerm_subnet.gateway.address_prefixes[0]
+  ha_gw            = false
+
+  # Single IP SNAT only. The controller auto-selects the node + pod route tables
+  # by their blackhole 0/0 -> None placeholder (no private_route_table_config,
+  # which is 9.0-only and forces mc-spoke 9.0.0 / provider >= 9.0).
+  single_ip_snat = true
+
+  attached   = var.transit_type == "aviatrix"
+  transit_gw = var.transit_type == "aviatrix" ? var.transit_gw_name : ""
+
+  tags = var.tags
+
+  depends_on = [
+    azurerm_subnet_route_table_association.node,
+    azurerm_subnet_route_table_association.pod,
+    azurerm_subnet_route_table_association.gateway,
+  ]
+}
+
+# Fail fast if attaching to a transit without naming it.
+resource "terraform_data" "validate_transit" {
+  lifecycle {
+    precondition {
+      condition     = var.transit_type != "aviatrix" || length(var.transit_gw_name) > 0
+      error_message = "transit_gw_name is required when transit_type = aviatrix."
+    }
+  }
+}

--- a/modules/azure-aks-spoke-vnet-82/outputs.tf
+++ b/modules/azure-aks-spoke-vnet-82/outputs.tf
@@ -1,0 +1,80 @@
+output "resource_group_name" {
+  description = "Resource group containing the spoke VNet."
+  value       = azurerm_resource_group.this.name
+}
+
+output "vnet_id" {
+  description = "Azure resource ID of the spoke VNet."
+  value       = azurerm_virtual_network.this.id
+}
+
+output "vnet_name" {
+  description = "Name of the spoke VNet."
+  value       = azurerm_virtual_network.this.name
+}
+
+output "aviatrix_vpc_id" {
+  description = "Aviatrix vpc_id form (vnet_name:rg:guid)."
+  value       = format("%s:%s:%s", azurerm_virtual_network.this.name, azurerm_resource_group.this.name, azurerm_virtual_network.this.guid)
+}
+
+output "gateway_subnet_id" {
+  description = "Subnet ID of the Aviatrix gateway subnet."
+  value       = azurerm_subnet.gateway.id
+}
+
+output "ingress_subnet_id" {
+  description = "Subnet ID of the ingress subnet (internal NGINX LB)."
+  value       = azurerm_subnet.ingress.id
+}
+
+output "ingress_subnet_name" {
+  description = "Name of the ingress subnet (used by Helm ingress-nginx annotations)."
+  value       = azurerm_subnet.ingress.name
+}
+
+output "node_subnet_id" {
+  description = "Subnet ID for AKS node VMs."
+  value       = azurerm_subnet.node.id
+}
+
+output "pod_subnet_id" {
+  description = "Subnet ID for AKS pods (pod-subnet mode)."
+  value       = azurerm_subnet.pod.id
+}
+
+output "node_route_table_id" {
+  description = "Node route table ID (Aviatrix programs 0/0 -> spoke GW here)."
+  value       = azurerm_route_table.node.id
+}
+
+output "pod_route_table_id" {
+  description = "Pod route table ID (Aviatrix programs 0/0 -> spoke GW here)."
+  value       = azurerm_route_table.pod.id
+}
+
+output "spoke_gateway_name" {
+  description = "Name of the Aviatrix spoke gateway."
+  # mc-spoke marks the whole spoke_gateway object sensitive; the gateway name is
+  # not a secret and is needed as a plain value by downstream layers / the README.
+  value = nonsensitive(module.spoke.spoke_gateway.gw_name)
+}
+
+output "spoke_gateway_public_ip" {
+  description = "Public IP of the spoke gateway (for AKS API authorized_ip_ranges)."
+  # Not a secret: consumed by the cluster layer as an AKS API authorized_ip_range
+  # (a plain CIDR list). Unwrap so sensitivity does not propagate downstream.
+  value = nonsensitive(module.spoke.spoke_gateway.public_ip)
+}
+
+output "spoke_gateway_private_ip" {
+  description = "Private IP of the spoke gateway."
+  value       = module.spoke.spoke_gateway.private_ip
+  sensitive   = true
+}
+
+output "spoke_gateway" {
+  description = "Full Aviatrix spoke gateway object."
+  value       = module.spoke.spoke_gateway
+  sensitive   = true
+}

--- a/modules/azure-aks-spoke-vnet-82/variables.tf
+++ b/modules/azure-aks-spoke-vnet-82/variables.tf
@@ -1,0 +1,69 @@
+variable "name" {
+  description = "Base name for the spoke VNet, resource group, and gateway."
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "AKS cluster name, used for subnet/resource tagging."
+  type        = string
+}
+
+variable "vnet_cidr" {
+  description = "Routable /23 CIDR for the VNet (gateway, ingress, node subnets carved from this)."
+  type        = string
+  default     = "10.30.0.0/23"
+
+  validation {
+    condition     = can(cidrhost(var.vnet_cidr, 0)) && tonumber(split("/", var.vnet_cidr)[1]) == 23
+    error_message = "vnet_cidr must be a valid IPv4 /23 CIDR block (the subnet layout assumes a /23)."
+  }
+}
+
+variable "pod_cidr" {
+  description = "Dedicated pod subnet CIDR (Azure CNI pod-subnet mode), added as a 2nd VNet address space."
+  type        = string
+  default     = "100.64.0.0/16"
+
+  validation {
+    condition     = can(cidrhost(var.pod_cidr, 0))
+    error_message = "pod_cidr must be a valid IPv4 CIDR block."
+  }
+}
+
+variable "azure_region" {
+  description = "Azure region in azurerm form (e.g. eastus2)."
+  type        = string
+}
+
+variable "aviatrix_azure_region" {
+  description = "Azure region in Aviatrix form (e.g. East US 2)."
+  type        = string
+}
+
+variable "aviatrix_azure_account_name" {
+  description = "Name of the Azure access account onboarded in the Aviatrix Controller."
+  type        = string
+}
+
+variable "transit_type" {
+  description = "How the spoke connects to the fabric. 'none' = standalone (Single IP SNAT egress only); 'aviatrix' = attach to an Aviatrix transit gateway."
+  type        = string
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "aviatrix"], var.transit_type)
+    error_message = "transit_type must be one of: none, aviatrix."
+  }
+}
+
+variable "transit_gw_name" {
+  description = "Aviatrix transit gateway name to attach to. Required when transit_type = aviatrix."
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Tags applied to created resources."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/azure-aks-spoke-vnet-82/versions.tf
+++ b/modules/azure-aks-spoke-vnet-82/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    aviatrix = {
+      source  = "AviatrixSystems/aviatrix"
+      version = "~> 8.2.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds Aviatrix **Controller 8.2** support for the `azure-aks-singlecluster` blueprint without changing the 9.0 default.

- New `modules/azure-aks-spoke-vnet-82`: the 8.2 variant of the spoke module. Single IP SNAT egress via a blackhole `0.0.0.0/0 → None` placeholder that the 8.2 controller auto-selects on the node+pod route tables (no `private_route_table_config`, which is 9.0-only and forces mc-spoke 9.0.0 / provider `>= 9.0.0`).
- `modules/azure-aks-cluster` provider pin loosened to `>= 8.2, < 10` (it only uses `aviatrix_kubernetes_cluster`, valid in both majors) so the 8.2 path needs no module edits.
- Blueprint README documents the 8.2 path as a 3-edit swap (provider `~> 8.2.0` in `network`/`cluster` versions.tf; spoke `source` → `-82`; `k8s_firewall_chart_version = "8.2.0"`), and why a single runtime toggle is impossible (the provider major is a static pin and must match the controller).

The default blueprint is byte-identical to before (Controller 9.0, `private_route_table_config`).

## Why two variants (not one toggle)
The route-table selection mechanism is welded to the provider/module version: `private_route_table_config` exists only in mc-spoke 9.0.0 (requires provider `>= 9.0.0`), and `required_providers` aggregate across all module blocks even at `count = 0` — so one init-able config cannot carry both. The provider major must match the controller major, which is a static, deploy-time choice.

## Test plan
- [x] `terraform validate` clean on the default 9.0 path (aviatrix v9.0.0 + mc-spoke 9.0.0)
- [x] `terraform validate` clean on the documented 8.2 swap (aviatrix v8.2.10 + mc-spoke 8.2.x)
- [x] **Live-deployed the 8.2 path on a real Controller 8.2.10**: controller programmed `0.0.0.0/0 → spoke GW` on node+pod route tables and left gateway/ingress bare, as designed
- [x] `terraform fmt -check -recursive` clean

> Behavioral note: the 8.2 blackhole auto-selection is **not** honored by a 9.0.x controller (verified live), which is exactly why the two pinned variants exist. Customers upgrading 8.2 → 9.0 should switch to the default 9.0 module and set `private_route_table_config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)