### PR TITLE
aws-eks: fix CRD onboarding RBAC + dcf-crd manifest drift (chart 9.0.0)

### DIFF
--- a/blueprints/aws-eks-singlecluster/k8s-apps/dcf-crd/firewallpolicy-infosec.yaml
+++ b/blueprints/aws-eks-singlecluster/k8s-apps/dcf-crd/firewallpolicy-infosec.yaml
@@ -29,8 +29,7 @@ spec:
           app: infosec
       action: permit
       protocol: tcp
-      ports:
-        - "443"
+      port: 443
       destinationSmartGroups:
         - name: public-internet
       webGroups:

--- a/blueprints/aws-eks-singlecluster/k8s-apps/dcf-crd/webgrouppolicy-dev.yaml
+++ b/blueprints/aws-eks-singlecluster/k8s-apps/dcf-crd/webgrouppolicy-dev.yaml
@@ -19,7 +19,7 @@
 #####################
 
 apiVersion: networking.aviatrix.com/v1alpha1
-kind: WebGroupPolicy
+kind: WebgroupPolicy
 metadata:
   name: dev-external-apis
   namespace: dev
@@ -28,13 +28,9 @@ spec:
     matchLabels:
       environment: development
 
-  action: permit
-  protocol: tcp
-  ports:
-    - "443"
   logging: true
 
-  domains:
+  allowedDomains:
     # Package registries
     - "pypi.org"
     - "*.pypi.org"

--- a/modules/aws-eks-cluster/main.tf
+++ b/modules/aws-eks-cluster/main.tf
@@ -230,9 +230,14 @@ resource "aviatrix_kubernetes_cluster" "this" {
 resource "aws_eks_access_entry" "aviatrix_controller" {
   count = var.enable_aviatrix_onboarding && var.aviatrix_controller_role_arn != "" ? 1 : 0
 
-  cluster_name      = module.eks.cluster_name
-  principal_arn     = var.aviatrix_controller_role_arn
-  kubernetes_groups = ["view-nodes"]
+  cluster_name  = module.eks.cluster_name
+  principal_arn = var.aviatrix_controller_role_arn
+  # "avx-controller" is the group the k8s-firewall Helm chart (installed in the
+  # nodes layer) binds its ClusterRole to; that ClusterRole is the only grant of
+  # networking.aviatrix.com/* (FirewallPolicy/WebgroupPolicy) read access. Without
+  # it the Controller can authenticate but gets "forbidden" listing the CRDs, so
+  # CRD-based policies never sync. "view-nodes" remains for the nodes grant.
+  kubernetes_groups = ["view-nodes", "avx-controller"]
   type              = "STANDARD"
 
   depends_on = [module.eks]


### PR DESCRIPTION
## Summary

The Distributed Cloud Firewall **Kubernetes CRD workflow was non-functional** on both `aws-eks-singlecluster` and `aws-eks-multicluster`. The Controller could authenticate to the EKS cluster but was **forbidden from reading** the `FirewallPolicy`/`WebgroupPolicy` CRDs, so CRD-based policies never synced into DCF rulesets.

Surfaced during a live deploy/QA of `aws-eks-singlecluster` against a 9.0.10 controller.

## Root cause (shared module — affects both aws-eks blueprints)

`modules/aws-eks-cluster/main.tf` granted the Controller IAM role only the `view-nodes` group + `AmazonEKSViewPolicy`. Neither covers the `networking.aviatrix.com` API group. The k8s-firewall Helm chart binds CRD-read (`networking.aviatrix.com/*`) **exclusively to the `avx-controller` group**, so the Controller was never authorized:

```
firewallpolicies.networking.aviatrix.com is forbidden:
User "...assumed-role/aviatrix-role-app/..." cannot list resource
"firewallpolicies" in API group "networking.aviatrix.com" at the cluster scope
```

## Fixes

| File | Change |
|---|---|
| `modules/aws-eks-cluster/main.tf` | Add `avx-controller` to the access entry's `kubernetes_groups` so the chart's ClusterRoleBinding applies to the Controller |
| `…/dcf-crd/firewallpolicy-infosec.yaml` | `spec.rules[].ports: ["443"]` → `port: 443` (9.0.0 uses integer `port`/`endPort`, not a `ports` array) |
| `…/dcf-crd/webgrouppolicy-dev.yaml` | 9.0.0 schema (`domains`→`allowedDomains`, drop `action`/`protocol`/`ports`) + kind casing `WebGroupPolicy`→`WebgroupPolicy` |

## Verification (live, controller 9.0.10)

- `kubectl auth can-i list firewallpolicies.networking.aviatrix.com --as-group=avx-controller` → **yes** (`view-nodes` → no)
- After applying, **both** CRD policies synced on the next Controller poll:
  - FirewallPolicy `infosec-egress` → ruleset `firewallpolicylist-gatus--infosec-egress` (`allow-virustotal`)
  - WebgroupPolicy `dev-external-apis` → `CreateWebGroupSuccess` / `CreateSmartGroupSuccess` / `CreatePolicySuccess`
- Gatus egress demo independently validated: egress allow-list PERMIT, GeoBlock-Iran BLOCKED.
- `terraform validate` passes for the `aws-eks-singlecluster` cluster layer with the module change.

## Notes

- The shared-module RBAC fix also repairs `aws-eks-multicluster`. (That blueprint has a separate, pre-existing `namespace_config` validate error unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)