### PR TITLE
fix(aws-eks): EBS CSI driver + default gp3 StorageClass (EKS 1.34 storage gap)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ tfplan
 *.tfstate
 *.tfstate.backup
 .terraform/
+
+# Git worktrees (local isolated workspaces)
+.worktrees/

--- a/blueprints/aws-eks-multicluster/README.md
+++ b/blueprints/aws-eks-multicluster/README.md
@@ -197,8 +197,8 @@ Layer 2: EKS Clusters (Control Plane Only)
 ├── clusters/backend/           # Control plane, IAM roles, security groups, VPC CNI addon
 
 Layer 3: EKS Node Groups + Kubernetes Resources
-├── nodes/frontend/             # k8s-firewall Helm, ENIConfig, nodes, CoreDNS, Helm charts (ALB Controller, ExternalDNS)
-├── nodes/backend/              # k8s-firewall Helm, ENIConfig, nodes, CoreDNS, Helm charts (ALB Controller, ExternalDNS)
+├── nodes/frontend/             # k8s-firewall Helm, ENIConfig, nodes, CoreDNS, EBS CSI + gp3 SC, Helm charts (ALB Controller, ExternalDNS)
+├── nodes/backend/              # k8s-firewall Helm, ENIConfig, nodes, CoreDNS, EBS CSI + gp3 SC, Helm charts (ALB Controller, ExternalDNS)
 ```
 
 Each layer reads the previous layer's state via `terraform_remote_state` data sources.
@@ -308,10 +308,11 @@ terraform apply
 - EKS managed node groups
 - Node IAM roles with SSM access
 - CoreDNS addon
+- EBS CSI driver addon + default `gp3` StorageClass (per cluster)
 - AWS Load Balancer Controller v1.10.1 (via Helm)
 - ExternalDNS v1.19.0 (via Helm)
 
-**Deployment order:** k8s-firewall Helm chart → ENIConfig → Node Groups → CoreDNS → Helm Charts (ALB Controller, ExternalDNS)
+**Deployment order:** k8s-firewall Helm chart → ENIConfig → Node Groups → CoreDNS → EBS CSI driver + gp3 StorageClass → Helm Charts (ALB Controller, ExternalDNS)
 
 **⚠️ IMPORTANT:** You cannot run kubectl commands until you configure kubectl in Step 5.
 

--- a/blueprints/aws-eks-multicluster/clusters/backend/outputs.tf
+++ b/blueprints/aws-eks-multicluster/clusters/backend/outputs.tf
@@ -74,6 +74,11 @@ output "external_dns_role_arn" {
   value       = module.backend_eks.external_dns_role_arn
 }
 
+output "ebs_csi_role_arn" {
+  description = "IAM role ARN for the EBS CSI driver (IRSA)"
+  value       = module.backend_eks.ebs_csi_role_arn
+}
+
 # Kubectl configuration
 output "configure_kubectl" {
   description = "Command to configure kubectl"

--- a/blueprints/aws-eks-multicluster/clusters/frontend/outputs.tf
+++ b/blueprints/aws-eks-multicluster/clusters/frontend/outputs.tf
@@ -74,6 +74,11 @@ output "external_dns_role_arn" {
   value       = module.frontend_eks.external_dns_role_arn
 }
 
+output "ebs_csi_role_arn" {
+  description = "IAM role ARN for the EBS CSI driver (IRSA)"
+  value       = module.frontend_eks.ebs_csi_role_arn
+}
+
 # Kubectl configuration
 output "configure_kubectl" {
   description = "Command to configure kubectl"

--- a/blueprints/aws-eks-multicluster/nodes/backend/main.tf
+++ b/blueprints/aws-eks-multicluster/nodes/backend/main.tf
@@ -160,3 +160,54 @@ resource "aws_eks_addon" "coredns" {
   # Ensure nodes are created before CoreDNS is deployed
   depends_on = [module.default_node_group]
 }
+
+#####################
+# EBS CSI Driver Addon + default StorageClass
+#####################
+
+# EKS 1.34 ships NO in-tree kubernetes.io/aws-ebs provisioner, so the
+# auto-created `gp2` StorageClass is non-functional and is not marked default.
+# Install the managed aws-ebs-csi-driver addon (provisioner ebs.csi.aws.com)
+# so PVC-backed workloads can provision block storage. IRSA role comes from the
+# cluster layer. Deployed here (Layer 3) because controller/node pods need nodes.
+resource "aws_eks_addon" "aws_ebs_csi_driver" {
+  cluster_name             = data.terraform_remote_state.cluster.outputs.cluster_name
+  addon_name               = "aws-ebs-csi-driver"
+  service_account_role_arn = data.terraform_remote_state.cluster.outputs.ebs_csi_role_arn
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+
+  preserve = true
+
+  tags = {
+    Environment = "demo"
+    Cluster     = "backend"
+    Terraform   = "true"
+  }
+
+  depends_on = [module.default_node_group]
+}
+
+# Default StorageClass backed by the EBS CSI driver (gp3).
+resource "kubernetes_storage_class_v1" "gp3" {
+  metadata {
+    name = "gp3"
+    annotations = {
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    }
+  }
+
+  storage_provisioner    = "ebs.csi.aws.com"
+  reclaim_policy         = "Delete"
+  volume_binding_mode    = "WaitForFirstConsumer"
+  allow_volume_expansion = true
+
+  parameters = {
+    type      = "gp3"
+    fsType    = "ext4"
+    encrypted = "true"
+  }
+
+  depends_on = [aws_eks_addon.aws_ebs_csi_driver]
+}

--- a/blueprints/aws-eks-multicluster/nodes/frontend/main.tf
+++ b/blueprints/aws-eks-multicluster/nodes/frontend/main.tf
@@ -160,3 +160,54 @@ resource "aws_eks_addon" "coredns" {
   # Ensure nodes are created before CoreDNS is deployed
   depends_on = [module.default_node_group]
 }
+
+#####################
+# EBS CSI Driver Addon + default StorageClass
+#####################
+
+# EKS 1.34 ships NO in-tree kubernetes.io/aws-ebs provisioner, so the
+# auto-created `gp2` StorageClass is non-functional and is not marked default.
+# Install the managed aws-ebs-csi-driver addon (provisioner ebs.csi.aws.com)
+# so PVC-backed workloads can provision block storage. IRSA role comes from the
+# cluster layer. Deployed here (Layer 3) because controller/node pods need nodes.
+resource "aws_eks_addon" "aws_ebs_csi_driver" {
+  cluster_name             = data.terraform_remote_state.cluster.outputs.cluster_name
+  addon_name               = "aws-ebs-csi-driver"
+  service_account_role_arn = data.terraform_remote_state.cluster.outputs.ebs_csi_role_arn
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+
+  preserve = true
+
+  tags = {
+    Environment = "demo"
+    Cluster     = "frontend"
+    Terraform   = "true"
+  }
+
+  depends_on = [module.default_node_group]
+}
+
+# Default StorageClass backed by the EBS CSI driver (gp3).
+resource "kubernetes_storage_class_v1" "gp3" {
+  metadata {
+    name = "gp3"
+    annotations = {
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    }
+  }
+
+  storage_provisioner    = "ebs.csi.aws.com"
+  reclaim_policy         = "Delete"
+  volume_binding_mode    = "WaitForFirstConsumer"
+  allow_volume_expansion = true
+
+  parameters = {
+    type      = "gp3"
+    fsType    = "ext4"
+    encrypted = "true"
+  }
+
+  depends_on = [aws_eks_addon.aws_ebs_csi_driver]
+}

--- a/blueprints/aws-eks-singlecluster/README.md
+++ b/blueprints/aws-eks-singlecluster/README.md
@@ -104,8 +104,8 @@ The blueprint is a **4-layer** deployment. Deploy in order: **network → cluste
 
 ```
 network/    Layer 1  Spoke VPC (module), Aviatrix spoke gateway, DCF SmartGroups/WebGroups/Ruleset
-cluster/    Layer 2  EKS control plane, OIDC/IRSA, VPC CNI addon, Controller onboarding
-nodes/      Layer 3  k8s-firewall Helm chart, ENIConfig, node group, CoreDNS, ALB Controller
+cluster/    Layer 2  EKS control plane, OIDC/IRSA (ALB, ExternalDNS, EBS CSI), VPC CNI addon, Controller onboarding
+nodes/      Layer 3  k8s-firewall Helm chart, ENIConfig, node group, CoreDNS, EBS CSI driver + default gp3 StorageClass, ALB Controller
 k8s-apps/   Layer 4  Gatus (kubectl apply); optional DCF CRD examples
 ```
 
@@ -146,7 +146,7 @@ cp terraform.tfvars.example terraform.tfvars
 terraform apply
 ```
 
-Creates: EKS control plane (K8s 1.34), OIDC provider, IRSA roles (ALB Controller, ExternalDNS), pod security group, and VPC CNI addon with custom networking. Onboards the cluster to the Aviatrix Controller.
+Creates: EKS control plane (K8s 1.34), OIDC provider, IRSA roles (ALB Controller, ExternalDNS, EBS CSI driver), pod security group, and VPC CNI addon with custom networking. Onboards the cluster to the Aviatrix Controller.
 
 ### Step 3: Nodes layer (~5-7 min)
 
@@ -156,7 +156,7 @@ terraform init
 terraform apply
 ```
 
-Creates (in order): k8s-firewall Helm chart (FirewallPolicy + WebGroupPolicy CRDs) → ENIConfig (one per AZ) → managed node group (2× t3.large SPOT) → CoreDNS addon → AWS Load Balancer Controller (Helm).
+Creates (in order): k8s-firewall Helm chart (FirewallPolicy + WebGroupPolicy CRDs) → ENIConfig (one per AZ) → managed node group (2× t3.large SPOT) → CoreDNS addon → EBS CSI driver addon + default `gp3` StorageClass → AWS Load Balancer Controller (Helm).
 
 ### Step 4: Configure kubectl + deploy k8s-apps (~1-2 min)
 

--- a/blueprints/aws-eks-singlecluster/cluster/outputs.tf
+++ b/blueprints/aws-eks-singlecluster/cluster/outputs.tf
@@ -74,6 +74,11 @@ output "external_dns_role_arn" {
   value       = module.eks.external_dns_role_arn
 }
 
+output "ebs_csi_role_arn" {
+  description = "IAM role ARN for the EBS CSI driver (IRSA)"
+  value       = module.eks.ebs_csi_role_arn
+}
+
 # Kubectl configuration
 output "configure_kubectl" {
   description = "Command to configure kubectl"

--- a/blueprints/aws-eks-singlecluster/nodes/main.tf
+++ b/blueprints/aws-eks-singlecluster/nodes/main.tf
@@ -139,3 +139,59 @@ resource "aws_eks_addon" "coredns" {
   # Ensure nodes are created before CoreDNS is deployed
   depends_on = [module.default_node_group]
 }
+
+#####################
+# EBS CSI Driver Addon + default StorageClass
+#####################
+
+# EKS 1.34 ships NO in-tree kubernetes.io/aws-ebs provisioner, so the
+# auto-created `gp2` StorageClass is non-functional and is not marked default.
+# Install the managed aws-ebs-csi-driver addon (provisioner ebs.csi.aws.com)
+# so PVC-backed workloads (databases, caches, etc.) can provision block storage.
+# IRSA role comes from the cluster layer. Deployed here (Layer 3) because the
+# controller/node pods need nodes to schedule on - same reason as CoreDNS.
+resource "aws_eks_addon" "aws_ebs_csi_driver" {
+  cluster_name             = data.terraform_remote_state.cluster.outputs.cluster_name
+  addon_name               = "aws-ebs-csi-driver"
+  service_account_role_arn = data.terraform_remote_state.cluster.outputs.ebs_csi_role_arn
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+
+  preserve = true
+
+  tags = {
+    Environment = "demo"
+    Terraform   = "true"
+  }
+
+  # Controller pods need a node to schedule on
+  depends_on = [module.default_node_group]
+}
+
+# Default StorageClass backed by the EBS CSI driver (gp3).
+# Marked default so PVCs without an explicit storageClassName bind here instead
+# of falling through to the dead in-tree `gp2` class. gp3 is cheaper and faster
+# than gp2 and supports volume expansion.
+resource "kubernetes_storage_class_v1" "gp3" {
+  metadata {
+    name = "gp3"
+    annotations = {
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    }
+  }
+
+  storage_provisioner    = "ebs.csi.aws.com"
+  reclaim_policy         = "Delete"
+  volume_binding_mode    = "WaitForFirstConsumer"
+  allow_volume_expansion = true
+
+  parameters = {
+    type      = "gp3"
+    fsType    = "ext4"
+    encrypted = "true"
+  }
+
+  # StorageClass is meaningless until the provisioner exists
+  depends_on = [aws_eks_addon.aws_ebs_csi_driver]
+}

--- a/blueprints/secure-enterprise-chat/README.md
+++ b/blueprints/secure-enterprise-chat/README.md
@@ -18,6 +18,8 @@ It is, deliberately, **really just a Helm chart**:
 
 ## Architecture
 
+![Architecture: LibreChat on an existing Aviatrix-protected cluster, with egress through the spoke gateway where DCF evaluates the per-pod FirewallPolicy CRD before traffic reaches Bedrock/Azure OpenAI/approved integrations](architecture.svg)
+
 ```
   Existing Aviatrix-protected cluster (built by a base k8s blueprint)
   ┌───────────────────────────────────────────────────────────────┐
@@ -72,28 +74,41 @@ pod. Nothing here is permitted to egress until it appears in that policy.
   defense-in-depth. Pass `--no-default-deny` to the generator to omit the
   trailing deny and rely on the fabric instead.)
 - A **default StorageClass** backed by a working CSI driver (the chart's
-  MongoDB/MeiliSearch want PVCs). On EKS 1.23+ the legacy in-tree `gp2`
-  (`kubernetes.io/aws-ebs`) does **not** provision — install the
-  `aws-ebs-csi-driver` addon and a default `gp3`/`gp2` CSI StorageClass, or set
-  `*.persistence.enabled=false` for an ephemeral lab.
-
-> **Validation status (live test on EKS + real controller):** verified
-> end-to-end. The generated `FirewallPolicy` reconciled on the controller
-> (`ruleset`/`attachmentPoint`/SmartGroups/WebGroup created), and egress
-> enforcement was **proven from the running pod**: allowlisted FQDNs
-> (`bedrock-runtime.us-east-1.amazonaws.com`, `sts.amazonaws.com`, `mcp.deepwiki.com`)
-> connected, while unlisted destinations (`example.org`, `api.openai.com`) were reset by the
-> trailing per-pod deny rule. **AWS Bedrock via IRSA was proven end-to-end**: with
-> no static keys, the pod assumed its IAM role through the web-identity token and
-> Claude 3.5 Haiku returned a real completion through the permitted
-> `bedrock-runtime.us-east-1` path. The deploy workarounds in Troubleshooting were
-> all exercised on that run.
+  MongoDB/MeiliSearch want PVCs). The repo's EKS blueprints
+  (`aws-eks-singlecluster`, `aws-eks-multicluster`) already provision this — their
+  nodes layer installs the `aws-ebs-csi-driver` addon and a default `gp3`
+  StorageClass — so clusters built from them satisfy this out of the box. You
+  only need to add one for an **externally-built or non-EKS cluster** that lacks a
+  default StorageClass (on EKS 1.23+ the legacy in-tree `gp2`,
+  `kubernetes.io/aws-ebs`, does **not** provision). For an ephemeral lab you can
+  instead set `*.persistence.enabled=false`.
 
 ### Required tools
 - `kubectl`, configured for the target cluster
 - `helm` >= 3.8 (OCI support) — for the raw-Helm path
 - `python3` + `pip` — for the egress-policy shim (`pip install -r egress-policy/requirements.txt`)
 - `terraform` >= 1.5 — only for the optional TF wrapper
+
+## Resources Created
+
+This blueprint **does not build infrastructure** — it layers a workload and a
+firewall policy onto a cluster you already own. There is **no incremental
+Aviatrix or cloud control-plane spend**; the only cost is the compute/storage the
+chart consumes on the existing cluster.
+
+| Resource | Where | Created by | Cost note |
+|---|---|---|---|
+| `librechat` Helm release (LibreChat API pod) | existing cluster | Helm / TF wrapper | Rides existing node capacity; ~no new spend |
+| `mongodb` (Deployment + PVC) | existing cluster | LibreChat chart dep | ~1 small PVC on the default StorageClass (e.g. `gp3` ~$0.08/GB-mo) |
+| `meilisearch` (StatefulSet + PVC) | existing cluster | LibreChat chart dep | ~1 small PVC on the default StorageClass |
+| `librechat-credentials-env` Secret | existing cluster | you (kubectl) | none |
+| `FirewallPolicy` CRD (+ reconciled DCF ruleset/attachmentPoint/SmartGroups/WebGroup) | Aviatrix Controller | egress generator + CRD controller | none (rules on the existing spoke) |
+| Ingress record / LB (if your ingress controller provisions one) | cloud | existing ingress controller | Standard ALB/LB hourly + LCU if exposed |
+| **Optional** IAM role for Bedrock via IRSA | AWS | you (`eksctl`/console) | IAM is free; Bedrock usage billed per token |
+
+**Estimated cost:** **~$0 incremental** for the lab itself (PVC storage is a few
+cents/day). Bedrock/Azure OpenAI token usage and any internet-facing
+load balancer are billed normally by the cloud provider.
 
 ## Deploy
 
@@ -315,6 +330,12 @@ kubectl -n librechat delete secret librechat-credentials-env
 kubectl delete namespace librechat
 ```
 
+If you created an IRSA role for Bedrock via `eksctl create iamserviceaccount`,
+it is **not** managed by this blueprint — delete it so it doesn't orphan:
+```bash
+eksctl delete iamserviceaccount --cluster <cluster> --namespace librechat --name librechat
+```
+
 The base cluster (and its DCF default-deny) is left intact — tear it down with
 its own blueprint when finished.
 
@@ -348,9 +369,12 @@ Aug 2025 Bitnami relocated most images out of `docker.io/bitnami`. Override to t
 legacy repo: `--set mongodb.image.repository=bitnamilegacy/mongodb` (or run your
 own MongoDB and point LibreChat at it).
 
-**Pods `Pending` on `unbound ... PersistentVolumeClaims`.** No default StorageClass
-that can provision (e.g. legacy `gp2` on EKS 1.34 has no in-tree provisioner).
-Install the EBS CSI driver + a default CSI StorageClass, or disable persistence:
+**Pods `Pending` on `unbound ... PersistentVolumeClaims`.** The cluster has no
+default StorageClass that can provision. Clusters built from this repo's EKS
+blueprints already ship a default `gp3` StorageClass (EBS CSI driver), so this
+should not occur there. On an externally-built or non-EKS cluster (e.g. legacy
+`gp2` on EKS 1.34 has no in-tree provisioner), install the EBS CSI driver + a
+default CSI StorageClass, or disable persistence:
 `--set mongodb.persistence.enabled=false --set meilisearch.persistence.enabled=false --set librechat.imageVolume.enabled=false`
 (MeiliSearch is a StatefulSet — its volumeClaimTemplate is immutable on upgrade,
 so delete the STS + PVC if you toggle this after first install).

--- a/blueprints/secure-enterprise-chat/architecture.svg
+++ b/blueprints/secure-enterprise-chat/architecture.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="560" viewBox="0 0 860 560" font-family="Segoe UI, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#444"/>
+    </marker>
+    <marker id="arrowR" markerWidth="10" markerHeight="10" refX="2" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M8,0 L0,3 L8,6 Z" fill="#444"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="860" height="560" fill="#ffffff"/>
+  <text x="430" y="30" text-anchor="middle" font-size="20" font-weight="700" fill="#1a1a2e">Secure Enterprise Chat — LibreChat on an Aviatrix-protected cluster</text>
+
+  <!-- Existing cluster boundary -->
+  <rect x="40" y="55" width="780" height="235" rx="12" fill="#f5f7fb" stroke="#9aa7c7" stroke-width="2" stroke-dasharray="6 4"/>
+  <text x="60" y="80" font-size="14" font-weight="700" fill="#3a4a7a">Existing Aviatrix-protected cluster (built by a base k8s blueprint)</text>
+  <text x="60" y="100" font-size="12" fill="#667">namespace: librechat</text>
+
+  <!-- LibreChat pod -->
+  <rect x="80" y="120" width="200" height="120" rx="10" fill="#e8f0ff" stroke="#3a6ea5" stroke-width="2"/>
+  <text x="180" y="150" text-anchor="middle" font-size="15" font-weight="700" fill="#1a3a6a">LibreChat</text>
+  <text x="180" y="172" text-anchor="middle" font-size="12" fill="#33506a">(API pod)</text>
+  <text x="180" y="210" text-anchor="middle" font-size="10.5" fill="#667">app.kubernetes.io/</text>
+  <text x="180" y="225" text-anchor="middle" font-size="10.5" fill="#667">name=librechat</text>
+
+  <!-- MongoDB -->
+  <rect x="360" y="120" width="190" height="60" rx="10" fill="#eafaf0" stroke="#2f8f5b" stroke-width="2"/>
+  <text x="455" y="156" text-anchor="middle" font-size="14" font-weight="700" fill="#1d5e3a">MongoDB</text>
+
+  <!-- MeiliSearch -->
+  <rect x="360" y="190" width="190" height="60" rx="10" fill="#eafaf0" stroke="#2f8f5b" stroke-width="2"/>
+  <text x="455" y="226" text-anchor="middle" font-size="14" font-weight="700" fill="#1d5e3a">MeiliSearch</text>
+
+  <!-- in-cluster link -->
+  <line x1="280" y1="165" x2="360" y2="150" stroke="#444" stroke-width="1.8" marker-end="url(#arrow)" marker-start="url(#arrowR)"/>
+  <line x1="280" y1="195" x2="360" y2="220" stroke="#444" stroke-width="1.8" marker-end="url(#arrow)" marker-start="url(#arrowR)"/>
+  <text x="320" y="140" text-anchor="middle" font-size="10" fill="#667">in-cluster</text>
+
+  <!-- FirewallPolicy CRD note -->
+  <rect x="600" y="120" width="200" height="130" rx="10" fill="#fff5e6" stroke="#cc8a1f" stroke-width="2"/>
+  <text x="700" y="148" text-anchor="middle" font-size="13" font-weight="700" fill="#8a5a0f">FirewallPolicy CRD</text>
+  <text x="700" y="172" text-anchor="middle" font-size="10.5" fill="#7a5">permit listed domains;</text>
+  <text x="700" y="188" text-anchor="middle" font-size="10.5" fill="#7a5">trailing per-pod deny</text>
+  <text x="700" y="212" text-anchor="middle" font-size="10" fill="#996">reconciled by the</text>
+  <text x="700" y="227" text-anchor="middle" font-size="10" fill="#996">Aviatrix CRD controller</text>
+
+  <!-- egress arrow down -->
+  <line x1="180" y1="240" x2="180" y2="330" stroke="#b33" stroke-width="2.4" marker-end="url(#arrow)"/>
+  <text x="195" y="285" font-size="11" fill="#b33">external egress (TCP 443)</text>
+
+  <!-- Aviatrix spoke gateway + DCF -->
+  <rect x="40" y="335" width="780" height="90" rx="12" fill="#fdeef0" stroke="#b33" stroke-width="2"/>
+  <text x="180" y="370" text-anchor="middle" font-size="15" font-weight="700" fill="#8a1f2a">Aviatrix spoke gateway</text>
+  <text x="430" y="370" text-anchor="middle" font-size="13" font-weight="600" fill="#8a1f2a">DCF evaluates the FirewallPolicy CRD</text>
+  <text x="430" y="392" text-anchor="middle" font-size="11.5" fill="#a44">permit listed domains, deny the rest</text>
+  <text x="430" y="410" text-anchor="middle" font-size="11" fill="#a44">(self-enforcing per-pod deny on tcp/443 → 0.0.0.0/0)</text>
+
+  <!-- egress arrow to backends -->
+  <line x1="180" y1="425" x2="180" y2="475" stroke="#b33" stroke-width="2.4" marker-end="url(#arrow)"/>
+
+  <!-- backends -->
+  <rect x="40" y="480" width="780" height="60" rx="12" fill="#eef0f5" stroke="#667" stroke-width="2"/>
+  <text x="430" y="516" text-anchor="middle" font-size="13" font-weight="600" fill="#334">Bedrock / Azure OpenAI / approved integrations (only allowlisted FQDNs)</text>
+</svg>

--- a/modules/aws-eks-cluster/main.tf
+++ b/modules/aws-eks-cluster/main.tf
@@ -62,6 +62,27 @@ module "external_dns_irsa_role" {
   tags = var.tags
 }
 
+# IAM role for service accounts - EBS CSI driver
+# Required so the aws-ebs-csi-driver addon (installed in the node-group layer)
+# can provision EBS volumes. EKS 1.34 ships no in-tree kubernetes.io/aws-ebs
+# provisioner, so without this addon + role there is no working block storage.
+module "ebs_csi_irsa_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.2"
+
+  name                  = "${var.cluster_name}-ebs-csi"
+  attach_ebs_csi_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
+    }
+  }
+
+  tags = var.tags
+}
+
 # Security group for cluster-level traffic (e.g., monitoring)
 resource "aws_security_group" "cluster_additional" {
   name        = "${var.cluster_name}-cluster-additional-sg"

--- a/modules/aws-eks-cluster/outputs.tf
+++ b/modules/aws-eks-cluster/outputs.tf
@@ -74,6 +74,11 @@ output "external_dns_role_arn" {
   value       = module.external_dns_irsa_role.arn
 }
 
+output "ebs_csi_role_arn" {
+  description = "IAM role ARN for the EBS CSI driver (IRSA), consumed by the aws-ebs-csi-driver addon"
+  value       = module.ebs_csi_irsa_role.arn
+}
+
 output "configure_kubectl" {
   description = "Command to configure kubectl"
   value       = "aws eks update-kubeconfig --region ${var.region} --name ${var.cluster_name}"


### PR DESCRIPTION
## Problem

The AWS EKS blueprints build **EKS 1.34** clusters that had **no working block storage**. The only StorageClass is the auto-created `gp2` using the legacy in-tree provisioner `kubernetes.io/aws-ebs`, which no longer exists in 1.34 (nothing provisions it), and it isn't marked default. Only `efs.csi.aws.com` was registered; the `aws-ebs-csi-driver` addon was never installed and had no IRSA role. Any PVC-backed workload (e.g. LibreChat's MongoDB/MeiliSearch) hangs `Pending`.

## Fix

- **`modules/aws-eks-cluster`** (shared): EBS CSI IRSA role (`kube-system:ebs-csi-controller-sa`, `attach_ebs_csi_policy`) + `ebs_csi_role_arn` output. Both EKS blueprints inherit it.
- **aws-eks-singlecluster** + **aws-eks-multicluster (frontend & backend)**: cluster layers re-export `ebs_csi_role_arn`; nodes layers add the `aws-ebs-csi-driver` managed addon (Layer 3, after nodes — same reason CoreDNS lives there) + a default `gp3` StorageClass (`ebs.csi.aws.com`, encrypted, expandable, `WaitForFirstConsumer`).
- READMEs updated (layer summaries + deployment order).

## Validation

`terraform fmt` + `validate` clean on all affected layers. **Applied live on `aws-eks-singlecluster`:**
- addon `ACTIVE` via the IRSA role; `ebs-csi-controller` (2×6/6) + `ebs-csi-node` DaemonSet (3/3) Running
- `gp3` is now the default StorageClass
- a test PVC (no explicit class) bound to a `gp3` PV, provisioned a real EBS volume (`vol-0f14aa…`), mounted and writable — then cleaned up

## Note: two riding-along commits

This branch also carries two local-only commits unrelated to the EBS fix (they existed nowhere else and would otherwise be lost):
- `08245af` docs(secure-enterprise-chat): README standards pass + architecture.svg
- `dbad414` chore: gitignore `.worktrees/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)